### PR TITLE
Implement homepage habit items statistics representation

### DIFF
--- a/src/app/component/general/homepage/homepage/homepage.component.html
+++ b/src/app/component/general/homepage/homepage/homepage.component.html
@@ -16,7 +16,7 @@
   </header>
   <section id="stats">
     <h2 class="section-caption">
-      {{ "homepage.stats.caption-before" | translate }} 45
+      {{ "homepage.stats.caption-before" | translate }} {{usersAmount}}
       {{ "homepage.stats.caption-after" | translate }}</h2>
     <app-stat-rows></app-stat-rows>
   </section>

--- a/src/app/component/general/homepage/homepage/homepage.component.ts
+++ b/src/app/component/general/homepage/homepage/homepage.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { LocalStorageService } from 'src/app/service/localstorage/local-storage.service';
+import {UserService} from "../../../../service/user/user.service";
 
 @Component({
   selector: 'app-homepage',
@@ -9,17 +10,25 @@ import { LocalStorageService } from 'src/app/service/localstorage/local-storage.
 })
 export class HomepageComponent implements OnInit {
 
+  usersAmount: number;
   readonly guyImage = 'assets/img/guy.png';
   readonly path2 = 'assets/img/path-2.svg';
   readonly path4 = 'assets/img/path-4_3.png';
   readonly path5 = 'assets/img/path-5.png';
 
-  constructor(private router: Router, private localStorageService: LocalStorageService) { }
+  constructor(
+    private router: Router,
+    private localStorageService: LocalStorageService,
+    private userService: UserService
+  ) { }
 
   userId: number;
 
   ngOnInit() {
     this.localStorageService.userIdBehaviourSubject.subscribe(userId => this.userId = userId);
+    this.userService.countActivatedUsers().subscribe(num => {
+      this.usersAmount = num;
+    });
   }
 
   startHabit() {

--- a/src/app/component/general/homepage/stat-rows/stat-rows.component.ts
+++ b/src/app/component/general/homepage/stat-rows/stat-rows.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import {UserService} from "../../../../service/user/user.service";
 
 @Component({
   selector: 'app-stat-rows',
@@ -7,28 +8,41 @@ import { Component, OnInit } from '@angular/core';
 })
 export class StatRowsComponent implements OnInit {
 
-  // TODO Create entity for habitStatItem
+  homePageHabitStats: Array<any>;
 
-  readonly homePageHabitStats = [
-    {
-      action: 'Не взяли',
-      caption: 'пакетів',
-      count: 85,
-      question: 'А скільки пакетів ти не взяв сьогодні?',
-      iconPath: 'assets/img/habit-pic-bag.png',
-      locationText: 'тут можна купити еко-сумочки і торбинки'
-    },
-    {
-      action: 'Не викинули',
-      caption: 'склянок',
-      count: 78,
-      question: 'А скільки склянок не викинув сьогодні ти?',
-      iconPath: 'assets/img/habit-pic-cup.png',
-      locationText: 'заклади, які роблять знижку на напій в своє горнятко'
-    }
-  ];
+  constructor(private userService: UserService) {
+  }
 
-  constructor() { }
-
-  ngOnInit() { }
+  ngOnInit() {
+    // TODO: homePageHabitStats should be populated entirely by server-side returned data
+    // instead of manual declaration of habit statistics.
+    this.userService.getTodayStatisticsForAllHabitItems().subscribe(habitDtoArray => {
+      function getStatisticForHabitItemName(habitItemName: string) {
+        let habitItemDto = habitDtoArray.find(it => it.habitItem === habitItemName);
+        if (habitItemDto === undefined) {
+          return 0;
+        } else {
+          return habitItemDto.notTakenItems;
+        }
+      }
+      this.homePageHabitStats = [
+        {
+          action: 'Не взяли',
+          caption: 'пакетів',
+          count: getStatisticForHabitItemName('bags'),
+          question: 'А скільки пакетів ти не взяв сьогодні ти?',
+          iconPath: 'assets/img/habit-pic-bag.png',
+          locationText: 'тут можна купити еко-сумочки і торбинки'
+        },
+        {
+          action: 'Не викинули',
+          caption: 'склянок',
+          count: getStatisticForHabitItemName('caps'),
+          question: 'А скільки склянок не викинув сьогодні ти?',
+          iconPath: 'assets/img/habit-pic-cup.png',
+          locationText: 'заклади, які роблять знижку на напій в своє горнятко'
+        }
+      ];
+    });
+  }
 }

--- a/src/app/model/goal/HabitItemsAmountStatisticDto.ts
+++ b/src/app/model/goal/HabitItemsAmountStatisticDto.ts
@@ -1,0 +1,4 @@
+export class HabitItemsAmountStatisticDto {
+  habitItem: string;
+  notTakenItems: number;
+}

--- a/src/app/service/user/user.service.ts
+++ b/src/app/service/user/user.service.ts
@@ -6,7 +6,7 @@ import {BehaviorSubject, Observable, of} from 'rxjs';
 import {UserRoleModel} from '../../model/user/user-role.model';
 import {UserStatusModel} from '../../model/user/user-status.model';
 import {UserPageableDtoModel} from '../../model/user/user-pageable-dto.model';
-import {mainLink, userLink} from '../../links';
+import {habitStatisticLink, mainLink, userLink} from '../../links';
 import {RolesModel} from '../../model/user/roles.model';
 import {UserFilterDtoModel} from '../../model/user/userFilterDto.model';
 import {UserUpdateModel} from '../../model/user/user-update.model';
@@ -17,6 +17,7 @@ import {CustomGoalSaveRequestDto} from '../../model/goal/CustomGoalSaveRequestDt
 import {UserCustomGoalDto} from '../../model/goal/UserCustomGoalDto';
 import {UserGoalDto} from '../../model/goal/UserGoalDto';
 import {OnLogout} from '../OnLogout';
+import {HabitItemsAmountStatisticDto} from "../../model/goal/HabitItemsAmountStatisticDto";
 
 @Injectable({
   providedIn: 'root'
@@ -230,5 +231,34 @@ export class UserService implements OnLogout {
     this.goalsSubject.next(Object.assign({}, this.dataStore).goals);
     this.availableCustomGoalsSubject.next(Object.assign({}, this.dataStore).availableCustomGoals);
     this.availablePredefinedGoalsSubject.next(Object.assign({}, this.dataStore).availablePredefinedGoals);
+  }
+
+  /**
+   * Returns amount of users with activated status.
+   * Can be used for representing total amount of users in the system.
+   *
+   * @returns Observable<number> that can be used for subscription to obtain amount of users.
+   */
+  countActivatedUsers(): Observable<number> {
+    return this.http.get(`${userLink}/activatedUsersAmount`) as Observable<number>;
+  }
+
+  /**
+   * Returns statistic for all not taken habit items in the system for today.
+   * Data is returned as an array of key-value-pairs mapped to HabitItemsAmountStatisticDto,
+   * where key is the name of habit item and value is not taken amount of these items.
+   * Language of habit items is defined by the `language` parameter.
+   * By default English language is set on the backend and should be used for technical purposes.
+   * When habit items have to be represented to users this parameter should be set according to user's localization.
+   *
+   * @param language - Optional parameter for name of habit item localization language(e.x. "en" or "uk").
+   * @returns Observable<Array<HabitItemsAmountStatisticDto>> that can be used for those key-value pairs acquisition.
+   */
+  getTodayStatisticsForAllHabitItems(language?: string): Observable<Array<HabitItemsAmountStatisticDto>> {
+    let endpointLink = `${habitStatisticLink}todayStatisticsForAllHabitItems`;
+    if (language != undefined) {
+      endpointLink += `?language=${language}`;
+    }
+    return this.http.get(endpointLink) as Observable<Array<HabitItemsAmountStatisticDto>>;
   }
 }


### PR DESCRIPTION
By now only habit item names and according amount of not taken items are queried from the server, but in the future releases this behavior should be changed for full server-side pollution of habit statistics, including all the fields in `homePageHabitStats` array, localized according to the user's localization.

Corresponding pull request for the server-side: https://github.com/ita-social-projects/GreenCity/pull/390