### PR TITLE
fixing bugs related to eco-news page

### DIFF
--- a/src/app/component/eco-news/components/filter-news/filter-news.component.html
+++ b/src/app/component/eco-news/components/filter-news/filter-news.component.html
@@ -2,17 +2,17 @@
   <span>Filter by</span>
   <ul class="ul-eco-buttons">
 
-    <a href="#/news" *ngFor="let filter of filters; index as i">
+    <a *ngFor="let filter of filters; index as i">
 
-      <li (click)="toggleFilter(filters[i].name)" 
+      <li (click)="toggleFilter(filters[i].name)"
           [ngClass]="{
                       'ul-eco-buttons-li': !filters[i].isActive,
                       'clicked-filter-button': filters[i].isActive
                     }">
         {{ filters[i].name }}
-        <div [ngClass]="{ 
+        <div [ngClass]="{
                           closeNone: !filters[i].isActive,
-                          close: filters[i].isActive 
+                          close: filters[i].isActive
                         }">
         </div>
       </li>

--- a/src/app/component/eco-news/components/filter-news/filter-news.component.scss
+++ b/src/app/component/eco-news/components/filter-news/filter-news.component.scss
@@ -46,7 +46,7 @@
     display: inline-block;
     padding: 8px 16px;
     border-radius: 25px;
-    margin-right: 8px;
+    margin:0 8px 8px 0;
     text-transform: capitalize;
 }
 

--- a/src/app/component/eco-news/components/news-list/news-list-gallery-view/news-list-gallery-view.component.html
+++ b/src/app/component/eco-news/components/news-list/news-list-gallery-view/news-list-gallery-view.component.html
@@ -10,12 +10,12 @@
       {{ tag }}
     </div>
   </div>
-  <div class="title-list">
+  <div class="title-list word-wrap">
     <p>
       {{ ecoNewsModel.title }}
     </p>
   </div>
-  <div class="list-text">
+  <div class="list-text word-wrap">
     <p>
       {{ newsText }}
     </p>

--- a/src/app/component/eco-news/components/news-list/news-list-gallery-view/news-list-gallery-view.component.scss
+++ b/src/app/component/eco-news/components/news-list/news-list-gallery-view/news-list-gallery-view.component.scss
@@ -84,6 +84,10 @@ div {
   }
 }
 
+.word-wrap {
+  word-break: break-word;
+}
+
 @media screen and (max-width: 992px) {
   .list-gallery-content {
     width: 353px;
@@ -97,6 +101,7 @@ div {
 
 @media screen and (max-width: 768px) {
   .list-gallery-content {
+    padding: 0;
     width: 258px;
   }
 
@@ -108,6 +113,7 @@ div {
 
 @media screen and (max-width: 576px) {
   .list-gallery-content {
+    padding: 0;
     width: 288px;
   }
 

--- a/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.html
+++ b/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.html
@@ -13,13 +13,13 @@
           {{ tag }}
         </div>
       </div>
-      <div class="title-list"
+      <div class="title-list word-wrap"
            #titleHeight>
         <p>
           {{ ecoNewsModel.title }}
         </p>
       </div>
-      <div class="list-text"
+      <div class="list-text word-wrap"
            #textHeight>
         <p>
           {{ textValidationOfMinCharacters() }}

--- a/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
+++ b/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
@@ -48,6 +48,11 @@ div {
         margin: 0 16px 0 0;
         text-transform: capitalize;
       }
+
+      .word-wrap {
+        word-break: break-word;
+      }
+
     }
 
     .title-list {

--- a/src/app/component/eco-news/components/remaining-count/remaining-count.component.scss
+++ b/src/app/component/eco-news/components/remaining-count/remaining-count.component.scss
@@ -3,4 +3,5 @@ p {
     font-size: 16px;
     line-height: 24px;
     color: #000000;
+    padding-bottom: 7px;
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -201,7 +201,7 @@
         "sign-in-with-google": "Sign in with Google",
         "bad-email-or-password": "Bad email or password",
         "forgot-password": "Forgot password?",
-        "havenot-account": "Have not an account yet?",
+        "havenot-account": "Don't have an account yet?",
         "or-signin": "or"
       },
       "sign-up": {


### PR DESCRIPTION
Bugs number:
#547 News display: issue with tags;
#550 News display: alinment;
#695 [Eco news] Filters can be open as a link;
#793 [Display news] Image is displayed beyond the field boundaries in tne Gallery view on 768-320px resolutions;
#713 [Display news] News title is displayed beyond the field boundaries after creation when it consists of one long word without spaces, horizontal scroll-bar appears;
#714 [Display news] News content is displayed beyond the field boundaries after creation when it consists of one long word without spaces, horizontal scroll-bar appears;
#495 BUG [UI] Grammar mistake in text 'Have not an account yet?' on 'Sign-in' page;