### PR TITLE
[Bug Fix]: [#878] Page doesn't scroll up to it's top if user scrolls the page down and clicks on link of this page in the Header

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -36,7 +36,7 @@ export const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes, { preloadingStrategy: PreloadAllModules })],
+  imports: [RouterModule.forRoot(routes, { onSameUrlNavigation: 'reload', preloadingStrategy: PreloadAllModules })],
   exports: [RouterModule],
 })
 export class AppRoutingModule {}


### PR DESCRIPTION
Changed onSameUrlNavigation extra option in forRoot() method from 'ignore' to 'reload'