### PR TITLE
bugfix#1013 and 1053

### DIFF
--- a/src/app/component/comments/components/add-comment/add-comment.component.html
+++ b/src/app/component/comments/components/add-comment/add-comment.component.html
@@ -12,7 +12,8 @@
        alt="avatar">
   <textarea placeholder="{{ dataSet.placeholder }}"
             formControlName="content"
-            type="text"></textarea>
+            type="text"
+            maxlength="8000"></textarea>
   <button class="primary-global-button"
           [disabled]="!addCommentForm.valid">
     {{ dataSet.btnText }}

--- a/src/app/component/eco-news/components/eco-news-detail/eco-news-widget/eco-news-widget.component.scss
+++ b/src/app/component/eco-news/components/eco-news-detail/eco-news-widget/eco-news-widget.component.scss
@@ -7,7 +7,7 @@ $bp-largest: 1440px;
 .gallery-view-active {
   display: inline-flex;
   flex-flow: row wrap;
-  justify-content: space-evenly;
+  justify-content: space-around;
   align-content: center;
   width: 100%;
 }


### PR DESCRIPTION
It's not possible to set more then 8000 character to 'Add a comment' field.
There is a space between recomendation news in IE11
before:
![1053(2)](https://user-images.githubusercontent.com/45083515/89538587-71903880-d803-11ea-8f79-55f34af11e68.jpg)

after:
![1053](https://user-images.githubusercontent.com/45083515/89538602-77861980-d803-11ea-9d0e-b29972a61b1e.jpg)

