### PR TITLE
fixed bugs #867, #1014

### DIFF
--- a/src/app/component/comments/components/add-comment/add-comment.component.scss
+++ b/src/app/component/comments/components/add-comment/add-comment.component.scss
@@ -16,12 +16,10 @@
         height: 72px;
         overflow: hidden;
         resize: none;
+        padding: 10px 0 0 20px;
 
         &::placeholder {
             color:#878787;
-            position: relative;
-            top: 10px;
-            left: 10px;
         }
     }
 

--- a/src/app/component/comments/components/comment-body/comment-body.component.scss
+++ b/src/app/component/comments/components/comment-body/comment-body.component.scss
@@ -118,12 +118,10 @@ $main-font: 'Open Sans';
       height: 72px;
       overflow: hidden;
       resize: none;
+      padding: 10px 0 0 20px;
 
       &::placeholder {
         color:#878787;
-        position: relative;
-        top: 10px;
-        left: 10px;
       }
     }
   

--- a/src/app/component/layout/components/search-popup/search-not-found/search-not-found.component.scss
+++ b/src/app/component/layout/components/search-popup/search-not-found/search-not-found.component.scss
@@ -30,7 +30,7 @@
 
 .flex-container {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   width: 43rem;
   height: 340px;
   position: relative;
@@ -77,5 +77,18 @@
     box-shadow: 0px 0.25rem 2rem #e6ebea;
     border-radius: 0.25rem;
     cursor: pointer;
+  }
+}
+
+@media (max-width: 797px) {
+  .flex-container {
+    width: 300px;
+    margin-top: 30px;
+    flex-direction: column;
+    height: 650px;
+
+    .alternative-news, .alternative-tips {
+      padding: 2rem;
+    }
   }
 }


### PR DESCRIPTION
Bug #867 
Before: 
![image](https://user-images.githubusercontent.com/54152415/89542230-11e85c00-d808-11ea-8fb8-73a5a2cb8a43.png)
After
![image](https://user-images.githubusercontent.com/54152415/89542387-4a883580-d808-11ea-8234-baac2ab9f6b8.png)
When resolution is lower, blocks with news and tips moving to the left side
![image](https://user-images.githubusercontent.com/54152415/89542560-80c5b500-d808-11ea-8ca2-8513d4d6a34c.png)
Bug #1014
Before
![image](https://user-images.githubusercontent.com/54152415/89542773-cb473180-d808-11ea-831f-d1016796c66e.png)
After
![image](https://user-images.githubusercontent.com/54152415/89542693-abb00900-d808-11ea-8495-38d752a90fe8.png)
