### PR TITLE
fixed alignment in sign in btn, marrgin and position in sign in window

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ jobs:
       - ng test --watch=false --browsers ChromeHeadless
       name: test app
     -
-      before_script: npm cache clean --force
       script:
       - ng build --prod --base-href /GreenCityClient/ --aot=false --build-optimizer=false
       name: build app

--- a/src/app/component/auth/components/restore-password/restore-password.component.scss
+++ b/src/app/component/auth/components/restore-password/restore-password.component.scss
@@ -27,14 +27,13 @@ $inputHeight : 48px;
   .right-side {
     width: 50%;
     max-width: 480px;
-    display: flex;
     flex-direction: column;
     justify-content: center;
 
     .close-modal-window {
       display: flex;
       justify-content: flex-end;
-      margin: 26px 26px 22px 12px;
+      margin: 26px 26px 22px 22px;
     }
 
     .cross-btn {
@@ -62,7 +61,7 @@ $inputHeight : 48px;
     }
 
     .sign-in-form {
-      margin: 10px 56px 0 56px;
+      margin: 0 56px;
       display: flex;
       flex-direction: column;
 
@@ -89,6 +88,7 @@ $inputHeight : 48px;
         font-size: 16px;
         line-height: 24px;
         color: #878787;
+        margin-bottom: 0;
       }
 
       input[type=email]:focus {
@@ -146,7 +146,8 @@ $inputHeight : 48px;
     }
 
     .mentioned-password {
-      margin: 200px 121px 40px 56px;
+      min-width: 320px;
+      margin: 200px 107px 40px 48px;
       font-family: $generalFont;
       font-size: 16px;
       line-height: 16px;

--- a/src/app/component/layout/components/footer/footer.component.scss
+++ b/src/app/component/layout/components/footer/footer.component.scss
@@ -3,9 +3,7 @@
 $generalFont : 'Open Sans', sans-serif;
 
 .main-background-image {
-  background-image: url("~/assets/img/icon/footer/background-image-footer.svg");
-  background-repeat: no-repeat;
-  background-position: center;
+  background: url("~/assets/img/icon/footer/background-image-footer.svg") no-repeat center;
   height: 286px;
   width: 100%;
 

--- a/src/app/component/layout/components/header/header.component.scss
+++ b/src/app/component/layout/components/header/header.component.scss
@@ -275,7 +275,7 @@ $screen-320: " screen and (max-width : 320px)";
     a {
       display: block;
       min-width: 40px;
-      word-break: break-all;
+
     }
   }
 
@@ -295,6 +295,7 @@ $screen-320: " screen and (max-width : 320px)";
       cursor: pointer;
       width: auto;
       min-width: 86px;
+      margin-left: 25px;
       padding: 0 4px 0;
       height: 32px;
       display: flex;

--- a/src/app/component/layout/components/header/header.component.scss
+++ b/src/app/component/layout/components/header/header.component.scss
@@ -275,7 +275,6 @@ $screen-320: " screen and (max-width : 320px)";
     a {
       display: block;
       min-width: 40px;
-
     }
   }
 


### PR DESCRIPTION
Actual result: 

[1207](https://github.com/ita-social-projects/GreenCity/issues/1207) - There is a margin between:
- 'Email' input field and error message (0px)
- in div.mentioned-password (200px 107px 40px 56px;)

<img width="554" alt="Screen Shot 2020-08-28 at 13 57 16" src="https://user-images.githubusercontent.com/55846203/91555135-1bfa0800-e939-11ea-9988-83405641523c.png">


[1208](https://github.com/ita-social-projects/GreenCity/issues/1208) - Button 'x' stay at an independent position

<img width="549" alt="Screen Shot 2020-08-28 at 13 56 56" src="https://user-images.githubusercontent.com/55846203/91555212-3fbd4e00-e939-11ea-8752-a3f79c88568c.png">


[1213](https://github.com/ita-social-projects/GreenCity/issues/1213) - Увійти' label has propper alignment 

<img width="586" alt="Screen Shot 2020-08-27 at 22 57 45" src="https://user-images.githubusercontent.com/55846203/91555285-64b1c100-e939-11ea-958e-e48977320ea5.png">
