### PR TITLE
remove unnecessary outline in click moment from eco news items

### DIFF
--- a/src/app/component/eco-news/components/news-list/news-list.component.scss
+++ b/src/app/component/eco-news/components/news-list/news-list.component.scss
@@ -51,6 +51,10 @@
   margin-bottom: 40px;
 }
 
+li:focus {
+  outline: none;
+}
+
 a {
   text-decoration: none;
 }


### PR DESCRIPTION
remove unnecessary outline in click moment from eco news items

https://github.com/ita-social-projects/GreenCity/issues/1205