### PR TITLE
'Magnifier' image size fixed

### DIFF
--- a/src/app/component/layout/components/header/header.component.scss
+++ b/src/app/component/layout/components/header/header.component.scss
@@ -208,6 +208,10 @@ $screen-320: " screen and (max-width : 320px)";
     list-style-type: none;
     margin-right: 20px;
 
+    &:first-child img{
+      width: 16px;
+    }
+
     &:nth-of-type(4) {
       margin-right: 5px;
     }

--- a/src/app/component/layout/components/header/header.component.scss
+++ b/src/app/component/layout/components/header/header.component.scss
@@ -208,7 +208,7 @@ $screen-320: " screen and (max-width : 320px)";
     list-style-type: none;
     margin-right: 20px;
 
-    &:first-child img{
+    &:first-child img {
       width: 16px;
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29043985/93860977-813ae200-fcc8-11ea-8fc4-e30e484e85f8.png)

Image size changed to total picture size (16x16px) , not to circle size (11x11px) on mockup!

![image](https://user-images.githubusercontent.com/29043985/93861182-c8c16e00-fcc8-11ea-8103-df8ccedb64a5.png)

![image](https://user-images.githubusercontent.com/29043985/93861395-1b028f00-fcc9-11ea-8295-a99c0142097a.png)