### PR TITLE
[FIX] Bug #1344 Fixed margins in User Profile

### DIFF
--- a/src/app/component/user/components/profile/edit-profile/edit-profile.component.scss
+++ b/src/app/component/user/components/profile/edit-profile/edit-profile.component.scss
@@ -194,8 +194,12 @@ h2 {
 
     li {
       list-style: none;
-      margin-top: 28px;
+      margin-bottom: 24px;
 
+      &:last-child {
+        margin-bottom: 0;
+      }
+    
       .label-wrapper {
         color: #494a49;
         cursor: pointer;

--- a/src/app/component/user/components/profile/edit-profile/edit-profile.component.scss
+++ b/src/app/component/user/components/profile/edit-profile/edit-profile.component.scss
@@ -199,7 +199,7 @@ h2 {
       &:last-child {
         margin-bottom: 0;
       }
-    
+
       .label-wrapper {
         color: #494a49;
         cursor: pointer;


### PR DESCRIPTION
Margin between header and checkboxes in **'Profile privacy'** section is vissualy the same as margin between header and checkboxes in **'Linked social networks'** section
[1344](https://github.com/ita-social-projects/GreenCity/issues/1344)

Previous:
![prev](https://user-images.githubusercontent.com/59996447/96506548-7db36000-1260-11eb-9178-d610ca0f6aab.PNG)

Result:
![result](https://user-images.githubusercontent.com/59996447/96506579-8c9a1280-1260-11eb-8e09-62fc0f7e93c5.PNG)