### PR TITLE
Date localisation in eco-news-detail component was fixed

### DIFF
--- a/src/app/component/comments/components/comments-list/comments-list.component.html
+++ b/src/app/component/comments/components/comments-list/comments-list.component.html
@@ -12,7 +12,7 @@
     <div class="comment-date-likes">
       <div class="comment-date">
         <span class="comment-dot"></span>
-        <span class="comment-date-month">{{ comment.modifiedDate | date: 'longDate'}}
+        <span class="comment-date-month">{{ comment.modifiedDate | dateLocalisation}}
           <span *ngIf="isCommentEdited(comment)"
                 class="edited">
             {{"homepage.eco-news.comment.btn.edited" | translate}}
@@ -76,7 +76,7 @@
                          *ngIf="isLoggedIn"></app-reply-comment>
       <app-view-replies [repliesCounter]="comment.replies"
                         (click)="showElements(comment.id, 'showAllRelies')"></app-view-replies>
-    </div> 
+    </div>
   </div>
    <app-comments-container *ngIf="dataType === 'comment'"
                            [comment]='comment'

--- a/src/app/component/eco-news/components/eco-news-detail/eco-news-detail.component.html
+++ b/src/app/component/eco-news/components/eco-news-detail/eco-news-detail.component.html
@@ -35,7 +35,7 @@
       </div>
     </div>
     <div class="news-info">
-      <div class="news-info-date">{{ newsItem.creationDate | date: 'mediumDate' }}</div>
+      <div class="news-info-date">{{ newsItem.creationDate | dateLocalisation }}</div>
       <div class="news-info-dot">
         <img [src]="images.ellipse"
              alt="dot"

--- a/src/app/component/eco-news/components/eco-news-detail/eco-news-detail.component.spec.ts
+++ b/src/app/component/eco-news/components/eco-news-detail/eco-news-detail.component.spec.ts
@@ -12,7 +12,7 @@ import { ActivatedRoute } from '@angular/router';
 import {TranslateLoader, TranslateModule} from '@ngx-translate/core';
 import {HttpClient} from '@angular/common/http';
 import {CUSTOM_ELEMENTS_SCHEMA, Pipe, PipeTransform} from '@angular/core';
-import {DateLocalisationPipe} from '../../../../pipe/date-localisation-pipe/date-localisation.pipe';
+import {DateLocalisationPipe} from '@pipe/date-localisation-pipe/date-localisation.pipe';
 
 @Pipe({ name: 'translate' })
 class TranslatePipeMock implements PipeTransform {

--- a/src/app/component/eco-news/components/eco-news-detail/eco-news-detail.component.spec.ts
+++ b/src/app/component/eco-news/components/eco-news-detail/eco-news-detail.component.spec.ts
@@ -12,6 +12,7 @@ import { ActivatedRoute } from '@angular/router';
 import {TranslateLoader, TranslateModule} from '@ngx-translate/core';
 import {HttpClient} from '@angular/common/http';
 import {CUSTOM_ELEMENTS_SCHEMA, Pipe, PipeTransform} from '@angular/core';
+import {DateLocalisationPipe} from '../../../../pipe/date-localisation-pipe/date-localisation.pipe';
 
 @Pipe({ name: 'translate' })
 class TranslatePipeMock implements PipeTransform {
@@ -46,7 +47,8 @@ describe('EcoNewsDetailComponent', () => {
         EcoNewsDetailComponent,
         EcoNewsWidgetComponent,
         NewsListGalleryViewComponent,
-        TranslatePipeMock
+        TranslatePipeMock,
+        DateLocalisationPipe
       ],
       schemas: [
         CUSTOM_ELEMENTS_SCHEMA

--- a/src/app/component/eco-news/eco-news.module.ts
+++ b/src/app/component/eco-news/eco-news.module.ts
@@ -29,7 +29,6 @@ import { CommentsModule } from '../comments/comments.module';
 import { NoNewsComponent } from './components/no-news/no-news.component';
 import { MatSnackBarComponent } from './../errors/mat-snack-bar/mat-snack-bar.component';
 import { EcoNewsComponent } from './eco-news.component';
-import { DateLocalisationPipe } from '@pipe/date-localisation-pipe/date-localisation.pipe';
 
 registerLocaleData(usLocale, 'en');
 registerLocaleData(ruLocale, 'ru');
@@ -50,8 +49,7 @@ registerLocaleData(ukLocale, 'uk');
     NewsPreviewPageComponent,
     PostNewsLoaderComponent,
     NoNewsComponent,
-    MatSnackBarComponent,
-    DateLocalisationPipe
+    MatSnackBarComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/component/eco-news/eco-news.module.ts
+++ b/src/app/component/eco-news/eco-news.module.ts
@@ -5,6 +5,10 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { ImageCropperModule } from 'ngx-image-cropper';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+import { registerLocaleData } from '@angular/common';
+import usLocale from '@angular/common/locales/en-US-POSIX';
+import ruLocale from '@angular/common/locales/ru';
+import ukLocale from '@angular/common/locales/uk';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { EcoNewsRoutingModule } from './eco-news-routing.module';
 import { SharedModule } from '../shared/shared.module';
@@ -25,7 +29,11 @@ import { CommentsModule } from '../comments/comments.module';
 import { NoNewsComponent } from './components/no-news/no-news.component';
 import { MatSnackBarComponent } from './../errors/mat-snack-bar/mat-snack-bar.component';
 import { EcoNewsComponent } from './eco-news.component';
+import { DateLocalisationPipe } from '../../pipe/date-localisation-pipe/date-localisation.pipe';
 
+registerLocaleData(usLocale, 'en');
+registerLocaleData(ruLocale, 'ru');
+registerLocaleData(ukLocale, 'uk');
 
 @NgModule({
   declarations: [
@@ -42,7 +50,8 @@ import { EcoNewsComponent } from './eco-news.component';
     NewsPreviewPageComponent,
     PostNewsLoaderComponent,
     NoNewsComponent,
-    MatSnackBarComponent
+    MatSnackBarComponent,
+    DateLocalisationPipe
   ],
   imports: [
     CommonModule,

--- a/src/app/component/eco-news/eco-news.module.ts
+++ b/src/app/component/eco-news/eco-news.module.ts
@@ -29,7 +29,7 @@ import { CommentsModule } from '../comments/comments.module';
 import { NoNewsComponent } from './components/no-news/no-news.component';
 import { MatSnackBarComponent } from './../errors/mat-snack-bar/mat-snack-bar.component';
 import { EcoNewsComponent } from './eco-news.component';
-import { DateLocalisationPipe } from '../../pipe/date-localisation-pipe/date-localisation.pipe';
+import { DateLocalisationPipe } from '@pipe/date-localisation-pipe/date-localisation.pipe';
 
 registerLocaleData(usLocale, 'en');
 registerLocaleData(ruLocale, 'ru');

--- a/src/app/component/shared/shared.module.ts
+++ b/src/app/component/shared/shared.module.ts
@@ -18,6 +18,8 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { DragAndDropDirective } from '../eco-news/directives/drag-and-drop.directive';
 import { DragAndDropComponent } from './components/drag-and-drop/drag-and-drop.component';
 import { ImageCropperModule } from 'ngx-image-cropper';
+import {MatSnackBarComponent} from '@global-errors/mat-snack-bar/mat-snack-bar.component';
+import { DateLocalisationPipe } from '@pipe/date-localisation-pipe/date-localisation.pipe';
 
 @NgModule({
   declarations: [
@@ -26,6 +28,7 @@ import { ImageCropperModule } from 'ngx-image-cropper';
     DragAndDropDirective,
     DragAndDropComponent,
     EditPhotoPopUpComponent,
+    DateLocalisationPipe
   ],
   imports: [
     ImageCropperModule,
@@ -61,6 +64,7 @@ import { ImageCropperModule } from 'ngx-image-cropper';
     MatProgressSpinnerModule,
     DragAndDropDirective,
     DragAndDropComponent,
+    DateLocalisationPipe
   ],
   providers: [],
 })

--- a/src/app/pipe/date-localisation-pipe/date-localisation.pipe.spec.ts
+++ b/src/app/pipe/date-localisation-pipe/date-localisation.pipe.spec.ts
@@ -1,0 +1,10 @@
+import { DateLocalisationPipe } from './date-localisation.pipe';
+import { LocalStorageService } from '../../service/localstorage/local-storage.service';
+
+describe('DateLocalisationPipe', () => {
+  it('create an instance of pipe', () => {
+    const localStorageService = new LocalStorageService();
+    const pipe = new DateLocalisationPipe(localStorageService);
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipe/date-localisation-pipe/date-localisation.pipe.ts
+++ b/src/app/pipe/date-localisation-pipe/date-localisation.pipe.ts
@@ -1,0 +1,23 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { formatDate } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { LocalStorageService } from '../../service/localstorage/local-storage.service';
+
+@Pipe({
+  name: 'dateLocalisation',
+  pure: false
+})
+export class DateLocalisationPipe implements PipeTransform {
+
+  private langChangeSubscription: Subscription;
+  private locale: string = this.localStorageService.getCurrentLanguage();
+
+  constructor(private localStorageService: LocalStorageService) {
+    this.langChangeSubscription = this.localStorageService.languageSubject
+      .subscribe(lang => this.locale = lang);
+  }
+
+  transform(date: string | Date): string {
+    return formatDate(date, 'mediumDate', `${this.locale}`, null);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,8 @@
       "@global-images/*": ["src/assets/img/*"],
       "@eco-news-images/*": ["src/assets/img/icon/econews/*"],
       "@footer-images/*": ["src/assets/img/icon/footer/*"],
-      "@environment/*": ["src/environments/*"]
+      "@environment/*": ["src/environments/*"],
+      "@pipe/*": ["src/app/pipe/*"]
     }
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
Date localisation on the eco-news-detail page and comments was not changed depending on language that was choosen by a user. Date displayed in English only.
Bug #1479.
Bug #1554.

**Previous:**
![prev](https://user-images.githubusercontent.com/58164899/96509246-67a79e80-1264-11eb-8a27-87420418be19.jpg)

![prev](https://user-images.githubusercontent.com/58164899/96911077-045a7e00-14a9-11eb-8e2e-26639bd53d95.png)


**Result:**
![ru](https://user-images.githubusercontent.com/58164899/96509310-7d1cc880-1264-11eb-84ff-4b230d48bc64.jpg)

![uk](https://user-images.githubusercontent.com/58164899/96509330-83ab4000-1264-11eb-82b3-5658b8e0bb49.jpg)

![res1](https://user-images.githubusercontent.com/58164899/96911146-1d632f00-14a9-11eb-8ae8-a82f29c29f03.png)

![res2](https://user-images.githubusercontent.com/58164899/96911147-1dfbc580-14a9-11eb-8d99-5dddc690899b.png)

![res3](https://user-images.githubusercontent.com/58164899/96911148-1dfbc580-14a9-11eb-86b5-60406e1b2cda.png)
