### PR TITLE
[FIX] Bug #1546 Wrong alignment 'Reply' button in Uk, Ru l10n

### DIFF
--- a/src/app/component/comments/components/delete-comment/delete-comment.component.scss
+++ b/src/app/component/comments/components/delete-comment/delete-comment.component.scss
@@ -6,7 +6,7 @@ $main-font: 'Open Sans', sans-serif;
   display: flex;
 
   .delete {
-    width: 74px;
+    width: fit-content;
     height: 40px;
     margin-right: 8px;
   }

--- a/src/app/component/comments/components/edit-comment/edit-comment.component.scss
+++ b/src/app/component/comments/components/edit-comment/edit-comment.component.scss
@@ -7,7 +7,7 @@ $main-font: 'Open Sans', sans-serif;
   margin-left: 50px;
 
   .edit {
-    width: 74px;
+    width: fit-content;
     height: 40px;
     margin-right: 8px;
   }

--- a/src/app/component/comments/components/like-comment/like-comment.component.scss
+++ b/src/app/component/comments/components/like-comment/like-comment.component.scss
@@ -7,7 +7,7 @@ $main-font: 'Open Sans', sans-serif;
   margin-left: 50px;
 
   .like {
-    width: 74px;
+    width: fit-content;
     height: 40px;
     margin-right: 8px;
   }

--- a/src/app/component/comments/components/reply-comment/reply-comment.component.scss
+++ b/src/app/component/comments/components/reply-comment/reply-comment.component.scss
@@ -7,7 +7,7 @@ $main-font: 'Open Sans', sans-serif;
   margin-left: 5px;
 
   .reply {
-    width: 85px;
+    width: fit-content;
     height: 40px;
   }
 

--- a/src/app/component/comments/components/view-replies/view-replies.component.scss
+++ b/src/app/component/comments/components/view-replies/view-replies.component.scss
@@ -19,6 +19,7 @@ $main-font: 'Open Sans', sans-serif;
     line-height: 24px;
     color: #878787;
     mix-blend-mode: normal;
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
Bug [1546](https://github.com/ita-social-projects/GreenCity/issues/1546)

**Previous result**
Wrong alignment 'Reply', 'Edit' and 'Delete' buttons in comment section in UK and RU languages
'View replies' text wraps to the next line in UK and RU languages
![prev](https://user-images.githubusercontent.com/59996447/96716796-30dd9f80-13ae-11eb-94c2-150e9af4ff33.PNG)
![prev_1](https://user-images.githubusercontent.com/59996447/96716802-333ff980-13ae-11eb-96c4-1148a109440d.PNG)

**Actual result**:
![result](https://user-images.githubusercontent.com/59996447/96716873-510d5e80-13ae-11eb-962d-f9488640a827.PNG)
![result_1](https://user-images.githubusercontent.com/59996447/96716878-536fb880-13ae-11eb-9486-fa41552a645b.PNG)