### PR TITLE
Text translation for Profile privacy was fixed

### DIFF
--- a/src/app/component/user/components/profile/edit-profile/edit-profile.component.html
+++ b/src/app/component/user/components/profile/edit-profile/edit-profile.component.html
@@ -19,9 +19,9 @@
                 <input type="text"
                        formControlName = "city"
                        placeholder="{{userInfo.location}}"
-                       autocorrect="off" 
-                       autocapitalize="off" 
-                       spellcheck="off" 
+                       autocorrect="off"
+                       autocapitalize="off"
+                       spellcheck="off"
                        #search
                        pattern="^[a-zA-Zа-яА-Я][a-zA-Zа-яА-Я!\-\,’)( ]*$"
                        id="city">
@@ -40,7 +40,7 @@
             <app-social-networks></app-social-networks>
         </div>
         <div class="privacy-wrapper">
-            <p class="title">Profile privacy</p>
+            <p class="title">{{"user.edit-profile.privacy" | translate }}</p>
             <ul>
                 <li>
                     <label class="label-wrapper">{{"user.edit-profile.location" | translate }}


### PR DESCRIPTION
Text "Profile privacy" on edit-profile page displayed in English only. Bug #1347.

**Previous:**
![prev1](https://user-images.githubusercontent.com/58164899/96717649-79498d00-13af-11eb-9e9c-e25fa564b18f.jpg)
![prev2](https://user-images.githubusercontent.com/58164899/96717663-7e0e4100-13af-11eb-8e35-64b0daac4245.jpg)

**Result:**
![res1](https://user-images.githubusercontent.com/58164899/96717698-8d8d8a00-13af-11eb-959e-290d9b9554a1.jpg)
![res2](https://user-images.githubusercontent.com/58164899/96717704-8ebeb700-13af-11eb-98ce-66a47b943719.jpg)
