### PR TITLE
[FIX] Bug #1636 pagination of replies works after refreshing the page

### DIFF
--- a/src/app/component/comments/components/comments-container/comments-container.component.ts
+++ b/src/app/component/comments/components/comments-container/comments-container.component.ts
@@ -67,6 +67,7 @@ export class CommentsContainerComponent implements OnInit, OnDestroy {
   public updateElementsList(): void {
     this.addCommentByPagination();
     this.getCommentsTotalElements();
+    this.getActiveComments();
   }
 
   public getCommentsTotalElements(): void {


### PR DESCRIPTION
[Bug #1636](https://github.com/ita-social-projects/GreenCity/issues/1636)

**Previous result:**
The application doesn't update pagination of replies after adding or deleting comments in replies and shows only last 10 replies. The same behaviour have comments in comments section of news. Only after refeshing the page updates pagination.
![prev_1](https://user-images.githubusercontent.com/59996447/97459122-18d4c580-1944-11eb-8a6f-38c6e70d66a9.PNG)
(without refreshing of page)
![prev_2](https://user-images.githubusercontent.com/59996447/97459169-25f1b480-1944-11eb-9aeb-e4b3652fd642.PNG)


**Actual result:**
Pagination is updated automatically after adding or deleting comments in comments section or replies to comments. Refreshing of page is not longer needed to update pagination.
![result_1](https://user-images.githubusercontent.com/59996447/97459178-29853b80-1944-11eb-90a2-320210230ca2.PNG)
(without refreshing of page)
![result_2](https://user-images.githubusercontent.com/59996447/97459209-330ea380-1944-11eb-9ca6-c905d5281966.PNG)
