### PR TITLE
[FIX] Bug #1343 Wrong alignment between '+' icon and text on 'Linked social networks' (screen responsive 320)

### DIFF
--- a/src/app/component/user/components/profile/edit-profile/social-networks/social-networks.component.html
+++ b/src/app/component/user/components/profile/edit-profile/social-networks/social-networks.component.html
@@ -1,30 +1,34 @@
 <ul>
     <li *ngFor="let socialNetwork of socialNetworks">
         <div class="link">
-            <a href="{{socialNetwork.link}}">
-                <img src="{{socialNetwork.icon}}" 
+            <a href="{{socialNetwork.link}}" class="link-button">
+                <img src="{{socialNetwork.icon}}"
+                     class="link-button-img" 
                      alt="">
             </a>
-            <a href="{{socialNetwork.link}}">{{socialNetwork.link}}</a>
+            <a href="{{socialNetwork.link}}" class="link-text">{{socialNetwork.link}}</a>
         </div>
         <div class="edit-icons">
-            <button>
+            <button class="edit-button">
                 <img src="{{icons.edit}}" 
-                     alt="edit icon">
+                     class="edit-button-img"
+                     alt="edit-icon">
             </button>
-            <button>
+            <button class="delete-button">
                 <img src="{{icons.delete}}" 
-                     alt="delete icon">
+                     class="delete-button-img"
+                     alt="delete-icon">
             </button>
         </div>
     </li>
     <li>
         <div class="link">
-            <button>
-                <img src="{{icons.add}}" 
+            <button class="add-button">
+                <img src="{{icons.add}}"
+                     class="add-button-img"
                      alt="add-icon">
             </button>
-            <a>{{"user.edit-profile.add-link" | translate }}</a>
+            <a class="add-text">{{"user.edit-profile.add-link" | translate }}</a>
         </div>
     </li>
 </ul>

--- a/src/app/component/user/components/profile/edit-profile/social-networks/social-networks.component.scss
+++ b/src/app/component/user/components/profile/edit-profile/social-networks/social-networks.component.scss
@@ -9,30 +9,32 @@ ul {
     margin-bottom: 24px;
 
     .link {
-      img {
+      .link-button-img {
         height: 24px;
         width: 24px;
       }
 
-      a {
+      .link-text {
         color: #494a49;
         font-family: opensans, sans-serif;
         font-size: 16px;
         line-height: 24px;
-        margin-right: 16px;
+        margin-left: 16px;
       }
     }
 
     .edit-icons {
       justify-self: end;
 
-      button {
+      .edit-button,
+      .delete-button {
         border: none;
         background-color: transparent;
         outline: none;
         padding: 0;
 
-        img {
+        .edit-button-img,
+        .delete-button-img {
           padding-left: 18px;
         }
       }
@@ -47,19 +49,23 @@ ul {
       display: flex;
       align-items: center;
 
-      button {
+      .add-button {
         border: transparent;
         background-color: transparent;
         padding: 0;
 
-        img {
+        &:focus {
+          outline: none;
+        }
+
+        .add-button-img {
           height: 26px;
           width: 26px;
           margin-right: 14px;
         }
       }
 
-      a {
+      .add-text {
         color: #056b33;
       }
     }
@@ -69,25 +75,19 @@ ul {
 @media screen and (max-width: 320px) {
   ul {
     li {
-      .link {
-        img {
-          margin-right: 12px;
-        }
+      .link-button-img {
+        margin-right: 12px;
+      }
 
-        a {
-          font-size: 14px;
-          margin-right: 0;
-        }
+      .link-text {
+        font-size: 14px;
+        margin-right: 0;
       }
     }
 
     li:last-child {
-      .link {
-        button {
-          img {
-            margin-right: 10px;
-          }
-        }
+      .add-button-img {
+        margin-right: 10px;
       }
     }
   }

--- a/src/app/component/user/components/profile/edit-profile/social-networks/social-networks.component.scss
+++ b/src/app/component/user/components/profile/edit-profile/social-networks/social-networks.component.scss
@@ -44,6 +44,9 @@ ul {
     margin-bottom: 0;
 
     .link {
+      display: flex;
+      align-items: center;
+
       button {
         border: transparent;
         background-color: transparent;
@@ -52,7 +55,7 @@ ul {
         img {
           height: 26px;
           width: 26px;
-          margin-right: 16px;
+          margin-right: 14px;
         }
       }
 
@@ -74,6 +77,16 @@ ul {
         a {
           font-size: 14px;
           margin-right: 0;
+        }
+      }
+    }
+
+    li:last-child {
+      .link {
+        button {
+          img {
+            margin-right: 10px;
+          }
         }
       }
     }


### PR DESCRIPTION
[Bug #1343](https://github.com/ita-social-projects/GreenCity/issues/1343)

**Previous result:**
Alignment of text 'Add social network' and image is different from other items in 'Linked social networks' list. 
Screen width: 320px.
![prev](https://user-images.githubusercontent.com/59996447/97709349-db4a7680-1ac2-11eb-88e4-553d3924e8ee.PNG)

**Actual result:**
Alignment of text 'Add social network' and image is the same as in other items from list. Text 'Add social network' aligned vertically. 
**Screen width: 320px.**
![result](https://user-images.githubusercontent.com/59996447/97709724-76dbe700-1ac3-11eb-98fe-f8ef2bf62728.PNG)
**Screen width: 1024px.**
![result_1](https://user-images.githubusercontent.com/59996447/97709726-78a5aa80-1ac3-11eb-943a-eefa5be0ef1f.PNG)
