### PR TITLE
[FIX] Incorrect alignment and size of 'Eco news' link and Twitter icon on the footer

### DIFF
--- a/src/app/component/layout/components/footer/footer.component.scss
+++ b/src/app/component/layout/components/footer/footer.component.scss
@@ -29,7 +29,7 @@ $generalFont : 'Open Sans', sans-serif;
           .router-links {
             text-decoration: none;
             font-family: $generalFont;
-            font-size: 14.10px;
+            font-size: 14.1px;
             line-height: 16px;
             color: #494a49;
             margin-right: 32px;

--- a/src/app/component/layout/components/footer/footer.component.scss
+++ b/src/app/component/layout/components/footer/footer.component.scss
@@ -29,11 +29,10 @@ $generalFont : 'Open Sans', sans-serif;
           .router-links {
             text-decoration: none;
             font-family: $generalFont;
-            font-size: 14.07px;
+            font-size: 14.10px;
             line-height: 16px;
             color: #494a49;
             margin-right: 32px;
-            padding-top: 3px;
           }
         }
       }


### PR DESCRIPTION
[Bug #877](https://github.com/ita-social-projects/GreenCity/issues/877)

**Previous result:**

1. Size of link 'Eco news' on the footer is 60.7-22
2. Twitter icon on the footer is 16-14
3. Incorrect alignment "Follow us" and icons

![prev_0](https://user-images.githubusercontent.com/59996447/97740208-9c7be700-1ae9-11eb-9ca4-2b2b6808a499.PNG)
![prev_1](https://user-images.githubusercontent.com/59996447/97740214-9dad1400-1ae9-11eb-835c-f24ff3148a90.PNG)

**Actual result:**

1. Size of link 'Eco news' on the footer is 61-19
2. Twitter icon on the footer is 15-12.9
3. Alignment of "Follow us" and icons is correct (mockup is not updated)

![result](https://user-images.githubusercontent.com/59996447/97740227-a1409b00-1ae9-11eb-84c0-c19f82154c74.PNG)
![result_1](https://user-images.githubusercontent.com/59996447/97740233-a30a5e80-1ae9-11eb-806e-a085e14c91d2.PNG)
