### PR TITLE
Invalid display of the login page has been fixed bugfix#1831

### DIFF
--- a/src/app/component/auth/components/auth-modal/auth-modal.component.scss
+++ b/src/app/component/auth/components/auth-modal/auth-modal.component.scss
@@ -10,9 +10,10 @@
 
 .wrapper {
   display: flex;
-  justify-content: space-between;
-  width: 100%;
-  max-width: 960px;
+  justify-content: center;
+  align-items: center;
+  min-width: 100vw;
+  min-height: 100vh;
   background-color: white;
   border-radius: 4px;
 


### PR DESCRIPTION
**Previous result:**
The 'sign in' emerged window does not overlap the home page and has white background, [bug#1831](https://github.com/ita-social-projects/GreenCity/issues/1831)

![auth-modal-unfixed](https://user-images.githubusercontent.com/58164899/99187057-16080c00-275d-11eb-8674-2f775f62423e.png)

**Actual result:**

![auth-modal-fixed](https://user-images.githubusercontent.com/58164899/99187431-405ac900-275f-11eb-942d-66483a47da9a.png)

