### PR TITLE
[FIX] The horizontal scroll bar does not disappear after reducing the the size of the web page

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -113,6 +113,7 @@ body {
   border-radius: 4px;
   box-sizing: border-box;
   overflow: auto;
+  overflow-x: hidden;
   outline: 0;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
[Bug#1833](https://github.com/ita-social-projects/GreenCity/issues/1833)

**Environment:** OS: Windows 10 Pro
**Browser:** Firefox, Version: 82.0.3

**Previous result:**
![prev](https://user-images.githubusercontent.com/59996447/99312403-ad0cbb00-2866-11eb-967c-2195342f7268.png)

**Actual result:**
![result](https://user-images.githubusercontent.com/59996447/99312325-89497500-2866-11eb-8f4a-d61f49131ac3.PNG)
