### PR TITLE
[BugFix] Redundant scrollbar after clicking on 'Sign in' button; Invalid number of content items are displayed

### DIFF
--- a/src/app/component/eco-news/components/news-list/news-list.component.ts
+++ b/src/app/component/eco-news/components/news-list/news-list.component.ts
@@ -34,7 +34,7 @@ export class NewsListComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.onResize();
-    this.setDefaultNumberOfNews(12);
+    this.setDefaultNumberOfNews(6);
     this.setNullList();
     this.checkUserSingIn();
     this.userOwnAuthService.getDataFromLocalStorage();

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,6 +5,10 @@
 $color-greenCity-green: #13aa57;
 $color-greenCity-dark-green: #056b33;
 
+html {
+  overflow-y: auto !important;
+}
+
 .hide {
   display: none;
 }


### PR DESCRIPTION
[#1875](https://github.com/ita-social-projects/GreenCity/issues/1875)
**Previous result**
Scrollbar is shown on the right side of the page
![image](https://user-images.githubusercontent.com/59996447/101170516-41d52e00-3647-11eb-9003-85111f4de65f.png)

**Actual result**
Scrollbar is not shown on the right side of the page
![image](https://user-images.githubusercontent.com/59996447/101170462-29651380-3647-11eb-8d07-6f474b1cfd28.png)


[#1854](https://github.com/ita-social-projects/GreenCity/issues/1854)
Previous result
The first twelve content items are displayed by default

Actual result
The first six content items are displayed by default