### PR TITLE
Bugfix/#1872 Fixed sign up, restore password and confirm restore password form validation

### DIFF
--- a/src/app/component/auth/components/confirm-restore-password/confirm-restore-password.component.html
+++ b/src/app/component/auth/components/confirm-restore-password/confirm-restore-password.component.html
@@ -36,6 +36,7 @@
                     required
                     minlength="8"
                     name="form-control password"
+                    (input)="setPasswordBackendErr()">
               >
               <span class="show-password">
                   <img [src]="authImages.hiddenEye"
@@ -49,6 +50,7 @@
             <div *ngIf="passwordField.invalid && passwordField.touched"
               class="error-message-show error-message">
             <app-error [formElement]="passwordField"
+                      [passwordFieldValue]="passwordFieldValue"
                       [controlName]="'password'"></app-error>
             </div>
             <label class="content-label under-error">
@@ -68,6 +70,7 @@
                     formControlName="confirmPassword"
                     name="form-control password-confirm"
                     required
+                    (input)="setPasswordBackendErr()">
               >
               <span class="show-password">
                   <img [src]="authImages.hiddenEye"
@@ -82,7 +85,8 @@
             (confirmPasswordField.dirty || confirmPasswordField.touched)"
               class="error-message-show error-message">
             <app-error [formElement]="confirmPasswordField"
-                      [controlName]="'password'"></app-error>
+                       [passwordConfirmFieldValue]="passwordConfirmFieldValue"
+                       [controlName]="'password'"></app-error>
             </div>
             <button 
                     [disabled]="confirmRestorePasswordForm.invalid || passwordField.value !== confirmPasswordField.value"

--- a/src/app/component/auth/components/confirm-restore-password/confirm-restore-password.component.ts
+++ b/src/app/component/auth/components/confirm-restore-password/confirm-restore-password.component.ts
@@ -91,7 +91,7 @@ export class ConfirmRestorePasswordComponent implements OnInit {
     }, 2000);
   }
 
-  private setPasswordBackendErr() {
+  public setPasswordBackendErr(): void {
     this.passwordErrorMessageBackEnd = null;
     if (this.confirmRestorePasswordForm) {
       this.passwordFieldValue = this.passwordField.value;

--- a/src/app/component/auth/components/confirm-restore-password/confirm-restore-password.component.ts
+++ b/src/app/component/auth/components/confirm-restore-password/confirm-restore-password.component.ts
@@ -26,6 +26,8 @@ export class ConfirmRestorePasswordComponent implements OnInit {
   public emailErrorMessageBackEnd: string;
   public passwordErrorMessageBackEnd: string;
   public loadingAnim: boolean;
+  public passwordFieldValue: string;
+  public passwordConfirmFieldValue: string;
   public form: any;
   public token: string;
 
@@ -51,8 +53,8 @@ export class ConfirmRestorePasswordComponent implements OnInit {
 
   public initFormReactive(): void {
     this.confirmRestorePasswordForm = this.formBuilder.group({
-      password: new FormControl('', [Validators.required, Validators.minLength(8)]),
-      confirmPassword: new FormControl('', [Validators.required, Validators.minLength(8)])
+      password: new FormControl('', []),
+      confirmPassword: new FormControl('', [])
     },
     {
       validator: [
@@ -91,6 +93,10 @@ export class ConfirmRestorePasswordComponent implements OnInit {
 
   private setPasswordBackendErr() {
     this.passwordErrorMessageBackEnd = null;
+    if(this.confirmRestorePasswordForm) {
+      this.passwordFieldValue = this.passwordField.value;
+      this.passwordConfirmFieldValue = this.confirmPasswordField.value;
+    }
   }
 
   public setPasswordVisibility(htmlInput: HTMLInputElement, htmlImage: HTMLImageElement): void {

--- a/src/app/component/auth/components/confirm-restore-password/confirm-restore-password.component.ts
+++ b/src/app/component/auth/components/confirm-restore-password/confirm-restore-password.component.ts
@@ -93,7 +93,7 @@ export class ConfirmRestorePasswordComponent implements OnInit {
 
   private setPasswordBackendErr() {
     this.passwordErrorMessageBackEnd = null;
-    if(this.confirmRestorePasswordForm) {
+    if (this.confirmRestorePasswordForm) {
       this.passwordFieldValue = this.passwordField.value;
       this.passwordConfirmFieldValue = this.confirmPasswordField.value;
     }

--- a/src/app/component/auth/components/error/error.component.spec.ts
+++ b/src/app/component/auth/components/error/error.component.spec.ts
@@ -23,7 +23,7 @@ describe('error component', () => {
     // @ts-ignore
     component.getType();
 
-    expect(component.errorMessage).toBe('user.auth.sign-in.email-is-required');
+    expect(component.errorMessage).toBe('user.auth.sign-in.password-is-required');
   });
 
   it('Error: get email message', () => {
@@ -33,7 +33,7 @@ describe('error component', () => {
 
   it('Error: get required message', () => {
     // @ts-ignore
-    expect(component.getErrorMsg[`required`]()).toBe('user.auth.sign-in.email-is-required');
+    expect(component.getErrorMsg[`required`]()).toBe('user.auth.sign-in.password-is-required');
   });
 
   it('Error: get passwordMismatch message', () => {

--- a/src/app/component/auth/components/error/error.component.ts
+++ b/src/app/component/auth/components/error/error.component.ts
@@ -16,13 +16,11 @@ export class ErrorComponent implements OnChanges {
 
   private getErrorMsg = {
     required: () => {
-      if(this.controlName === 'email') {
+      if (this.controlName === 'email') {
         return 'user.auth.sign-in.email-is-required';
-      }
-      else if(this.controlName === 'firstName'){
+      } else if (this.controlName === 'firstName') {
         return 'user.auth.sign-up.first-name-is-required';
-      }
-      else {
+      } else {
         return 'user.auth.sign-in.password-is-required';
       }
     },

--- a/src/app/component/auth/components/error/error.component.ts
+++ b/src/app/component/auth/components/error/error.component.ts
@@ -9,11 +9,23 @@ export class ErrorComponent implements OnChanges {
   @Input() public controlName: string;
   @Input() public formElement: FormControl;
   @Input() public emailFieldValue: string;
+  @Input() public nameFieldValue: string;
   @Input() public passwordFieldValue: string;
+  @Input() public passwordConfirmFieldValue: string;
   public errorMessage = '';
 
   private getErrorMsg = {
-    required: () => this.controlName === 'password' ? 'user.auth.sign-in.password-is-required' : 'user.auth.sign-in.email-is-required',
+    required: () => {
+      if(this.controlName === 'email') {
+        return 'user.auth.sign-in.email-is-required';
+      }
+      else if(this.controlName === 'firstName'){
+        return 'user.auth.sign-up.first-name-is-required';
+      }
+      else {
+        return 'user.auth.sign-in.password-is-required';
+      }
+    },
     email: () => this.emailFieldValue ? 'user.auth.sign-in.this-is-not-email' : 'user.auth.sign-in.email-is-required',
     passwordMismatch: () => 'user.auth.sign-up.password-match',
     minlength: () => 'user.auth.sign-in.password-must-be-at-least-8-characters-long',

--- a/src/app/component/auth/components/restore-password/restore-password.component.html
+++ b/src/app/component/auth/components/restore-password/restore-password.component.html
@@ -18,7 +18,8 @@
               'alert-email-validation':'successful-email-validation'">
               <div class="validation-email-error" *ngIf="emailField.invalid && emailField.touched">
                 <app-error [formElement]="emailField"
-                          [controlName]="'required'"></app-error>
+                           [emailFieldValue]="emailFieldValue"
+                           [controlName]="'email'"></app-error>
               </div>
     <div class="validation-email-error"
           *ngIf="emailErrorMessageBackEnd!=null">

--- a/src/app/component/auth/components/restore-password/restore-password.component.ts
+++ b/src/app/component/auth/components/restore-password/restore-password.component.ts
@@ -34,6 +34,7 @@ export class RestorePasswordComponent implements OnInit, OnDestroy {
   public loadingAnim: boolean;
   public currentLanguage: string;
   public userIdSubscription: Subscription;
+  public emailFieldValue: string;
   @Output() public pageName = new EventEmitter();
 
   constructor(
@@ -66,6 +67,9 @@ export class RestorePasswordComponent implements OnInit, OnDestroy {
     this.emailErrorMessageBackEnd = null;
     this.passwordErrorMessageBackEnd = null;
     this.backEndError = null;
+    if(this.restorePasswordForm) {
+      this.emailFieldValue = this.restorePasswordForm.get('email').value;
+    }
   }
 
   private checkIfUserId(): void {

--- a/src/app/component/auth/components/restore-password/restore-password.component.ts
+++ b/src/app/component/auth/components/restore-password/restore-password.component.ts
@@ -67,7 +67,7 @@ export class RestorePasswordComponent implements OnInit, OnDestroy {
     this.emailErrorMessageBackEnd = null;
     this.passwordErrorMessageBackEnd = null;
     this.backEndError = null;
-    if(this.restorePasswordForm) {
+    if (this.restorePasswordForm) {
       this.emailFieldValue = this.restorePasswordForm.get('email').value;
     }
   }

--- a/src/app/component/auth/components/sign-up/sign-up.component.html
+++ b/src/app/component/auth/components/sign-up/sign-up.component.html
@@ -24,6 +24,7 @@
     <div *ngIf="emailControl.invalid && emailControl.touched"
         class="error-message">
       <app-error [formElement]="emailControl" 
+                 [emailFieldValue]="emailFieldValue"
                  [controlName]="'email'"></app-error>
     </div>
     <div *ngIf="emailErrorMessageBackEnd" 
@@ -35,16 +36,18 @@
       {{ 'user.auth.sign-up.first-name' | translate }}
     </label>
     <input type="text"
-          placeholder="{{ 'user.auth.sign-up.first-name-is-required' | translate }}"
+          placeholder="{{ 'user.auth.sign-up.first-name' | translate }}"
           id="firstName"
           name="firstName"
           formControlName="firstName"
+          (input)="setEmailBackendErr()"
           [ngClass]="firstNameControl.invalid && firstNameControl.touched ||  backEndError 
                       ? 'main-data-input wrong-input'
                       : 'main-data-input'">
     <div *ngIf="firstNameControl.invalid && firstNameControl.touched"
         class="error-message">
       <app-error [formElement]="firstNameControl"
+                 [nameFieldValue]="nameFieldValue"
                  [controlName]="'firstName'"></app-error>
     </div>
     <div *ngIf="firstNameErrorMessageBackEnd" 
@@ -64,7 +67,8 @@
              #inputPassword
              formControlName="password"
              id="password"
-             name="form-control password">
+             name="form-control password"
+             (input)="setEmailBackendErr()">
       <img [src]="signUpImages.hiddenEye"
             alt="eye"
             class="show-password-img"
@@ -74,6 +78,7 @@
     <div *ngIf="passwordControl.invalid && passwordControl.touched"
         class="error-message">
       <app-error [formElement]="passwordControl"
+                 [passwordFieldValue]="passwordFieldValue"
                  [controlName]="'password'"></app-error>
     </div>
     <label class="content-label under-error"
@@ -91,7 +96,8 @@
              #repeatPassword
              formControlName="repeatPassword"
              id="repeatPassword"
-             name="form-control password-confirm">
+             name="form-control password-confirm"
+             (input)="setEmailBackendErr()">
       <img [src]="signUpImages.hiddenEye"
             alt="eye"
             class="show-password-img"
@@ -100,7 +106,8 @@
     </div>
     <div *ngIf="passwordControlConfirm.invalid && passwordControlConfirm.touched"
           class="error-message">
-      <app-error [formElement]="passwordControlConfirm" 
+      <app-error [formElement]="passwordControlConfirm"
+                 [passwordConfirmFieldValue]="passwordConfirmFieldValue"
                  [controlName]="'repeatPassword'"></app-error>
     </div>
     <div *ngIf="passwordErrorMessageBackEnd" 

--- a/src/app/component/auth/components/sign-up/sign-up.component.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.component.ts
@@ -37,7 +37,7 @@ export class SignUpComponent implements OnInit, OnDestroy {
   public passwordConfirmErrorMessageBackEnd: string;
   public backEndError: string;
   public emailFieldValue: string;
-  public nameFieldValue: string = '';
+  public nameFieldValue: string;
   public passwordFieldValue: string;
   public passwordConfirmFieldValue: string;
   public currentLanguage: string;
@@ -131,7 +131,7 @@ export class SignUpComponent implements OnInit, OnDestroy {
   private onFormInit(): void {
     this.signUpForm = this.formBuilder.group({
         email: ['', [ Validators.required, Validators.email ]],
-        firstName: [this.nameFieldValue, []],
+        firstName: ['', []],
         password: ['', []],
         repeatPassword: ['', []]
       },

--- a/src/app/component/auth/components/sign-up/sign-up.component.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.component.ts
@@ -36,6 +36,10 @@ export class SignUpComponent implements OnInit, OnDestroy {
   public firstNameErrorMessageBackEnd: string;
   public passwordConfirmErrorMessageBackEnd: string;
   public backEndError: string;
+  public emailFieldValue: string;
+  public nameFieldValue: string = '';
+  public passwordFieldValue: string;
+  public passwordConfirmFieldValue: string;
   public currentLanguage: string;
   private destroy: Subject<boolean> = new Subject<boolean>();
   private errorsType = {
@@ -101,6 +105,12 @@ export class SignUpComponent implements OnInit, OnDestroy {
 
   public setEmailBackendErr(): void {
     this.emailErrorMessageBackEnd = null;
+    if (this.signUpForm) {
+      this.emailFieldValue = this.emailControl.value;
+      this.nameFieldValue = this.firstNameControl.value;
+      this.passwordFieldValue = this.passwordControl.value;
+      this.passwordConfirmFieldValue = this.passwordControlConfirm.value;
+    }
   }
 
   public setPasswordVisibility(htmlInput: HTMLInputElement, htmlImage: HTMLImageElement): void {
@@ -121,9 +131,9 @@ export class SignUpComponent implements OnInit, OnDestroy {
   private onFormInit(): void {
     this.signUpForm = this.formBuilder.group({
         email: ['', [ Validators.required, Validators.email ]],
-        firstName: ['', [ Validators.required ]],
-        password: ['', [ Validators.required ]],
-        repeatPassword: ['', [ Validators.required ]]
+        firstName: [this.nameFieldValue, []],
+        password: ['', []],
+        repeatPassword: ['', []]
       },
       {
         validator: [

--- a/src/app/component/auth/components/sign-up/sign-up.validator.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.validator.ts
@@ -4,10 +4,15 @@ export function ConfirmPasswordValidator(controlName: string, matchingControlNam
   return (formGroup: FormGroup) => {
     const control = formGroup.controls[controlName];
     const matchingControl = formGroup.controls[matchingControlName];
-    if (control.value !== matchingControl.value && matchingControl.value !== '') {
-      matchingControl.setErrors({ passwordMismatch: true });
-    } else {
-      matchingControl.setErrors(null);
+    if(matchingControl.value === ''){
+      matchingControl.setErrors({ required: true });
+    }
+    else {
+      if (control.value !== matchingControl.value) {
+        matchingControl.setErrors({ passwordMismatch: true });
+      } else {
+        matchingControl.setErrors(null);
+      }
     }
   };
 }
@@ -18,10 +23,15 @@ export function ValidatorRegExp(controlName: string) {
     const regexpPass = /^(?=.*[a-z]+)(?=.*[A-Z]+)(?=.*\d+)(?=.*[~`!@#$%^&*()+=_\-{}|:;”’?/<>,.\]\[]+).{8,}$/;
     const regexp = controlName === 'firstName' ? regexpName : regexpPass;
     const control = formGroup.controls[controlName];
-    if (!control.value.match(regexp)) {
-      control.setErrors({ symbolInvalid: true });
-    } else {
-      control.setErrors(null);
+    if(control.value === '') {
+      control.setErrors({ required: true });
+    }
+    else {
+      if (!control.value.match(regexp)) {
+        control.setErrors({ symbolInvalid: true });
+      } else {
+        control.setErrors(null);
+      }
     }
   };
 }

--- a/src/app/component/auth/components/sign-up/sign-up.validator.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.validator.ts
@@ -4,10 +4,9 @@ export function ConfirmPasswordValidator(controlName: string, matchingControlNam
   return (formGroup: FormGroup) => {
     const control = formGroup.controls[controlName];
     const matchingControl = formGroup.controls[matchingControlName];
-    if(matchingControl.value === ''){
+    if (matchingControl.value === '') {
       matchingControl.setErrors({ required: true });
-    }
-    else {
+    } else {
       if (control.value !== matchingControl.value) {
         matchingControl.setErrors({ passwordMismatch: true });
       } else {
@@ -23,10 +22,9 @@ export function ValidatorRegExp(controlName: string) {
     const regexpPass = /^(?=.*[a-z]+)(?=.*[A-Z]+)(?=.*\d+)(?=.*[~`!@#$%^&*()+=_\-{}|:;”’?/<>,.\]\[]+).{8,}$/;
     const regexp = controlName === 'firstName' ? regexpName : regexpPass;
     const control = formGroup.controls[controlName];
-    if(control.value === '') {
+    if (control.value === '') {
       control.setErrors({ required: true });
-    }
-    else {
+    } else {
       if (!control.value.match(regexp)) {
         control.setErrors({ symbolInvalid: true });
       } else {


### PR DESCRIPTION
### **Fixed sign up, restore password and confirm restore password form validation**

_**Problem:**_ Validators were not working corectly. After clicking on fields incorrect message was displayed.

> Expected result
> For the 'Email' field displayes error-message 'Email is required'
> For User Name' field displayes error-message 'User Name is required'
> For the 'Password' field displayes error-message 'Password is required'
> For the 'Confirm Password' field displayes error-message 'Password is required'

**Before:**
![image](https://user-images.githubusercontent.com/39058788/101206759-3f3efc80-3678-11eb-9636-34225c9bc8ad.png)
![image](https://user-images.githubusercontent.com/39058788/101206863-6dbcd780-3678-11eb-9818-002d9b52c60d.png)

**After:**
![image](https://user-images.githubusercontent.com/39058788/101206803-554cbd00-3678-11eb-99a1-d2a3e4015832.png)
![image](https://user-images.githubusercontent.com/39058788/101206891-77ded600-3678-11eb-894c-2728c0403cdf.png)
