### PR TITLE
[Accessibility] Removed screen reader focus from the icons

### DIFF
--- a/src/app/component/comments/components/comments-list/comments-list.component.html
+++ b/src/app/component/comments/components/comments-list/comments-list.component.html
@@ -24,7 +24,7 @@
         <span class="comment-dot last-dot"></span>
       </div>
       <div class="comment-likes">
-        <img [src]="likeImg" alt="like">
+        <img [src]="likeImg" alt="like" aria-hidden="true">
         <span class="like-amount">{{ comment.likes }}</span>
       </div>
     </div>

--- a/src/app/component/comments/components/delete-comment/delete-comment.component.html
+++ b/src/app/component/comments/components/delete-comment/delete-comment.component.html
@@ -3,6 +3,7 @@
             (click)="openPopup()">
       <img [src]="deleteIcon"
             class="btn-img"
+            aria-hidden="true"
             alt="edit icon">
       <span class="btn-text">
         {{"homepage.eco-news.comment.btn.delete" | translate}}

--- a/src/app/component/comments/components/edit-comment/edit-comment.component.html
+++ b/src/app/component/comments/components/edit-comment/edit-comment.component.html
@@ -3,6 +3,7 @@
             (click)=editComments()>
       <img [src]="editIcon"
             class="btn-img"
+            aria-hidden="true"
             alt="edit icon">
       <span class="btn-text">
         {{"homepage.eco-news.comment.btn.edit" | translate}}

--- a/src/app/component/comments/components/like-comment/like-comment.component.html
+++ b/src/app/component/comments/components/like-comment/like-comment.component.html
@@ -4,6 +4,7 @@
     <img [src]="commentsImages.like"
           class="btn-img"
           alt="like"
+          aria-hidden="true"
           #like>
     <span class="btn-text"
           *ngIf="!likeState && !error; else liked">

--- a/src/app/component/comments/components/reply-comment/reply-comment.component.html
+++ b/src/app/component/comments/components/reply-comment/reply-comment.component.html
@@ -2,6 +2,7 @@
   <button class="cta-btn reply">
     <img [src]="replyImages"
           class="btn-img"
+          aria-hidden="true"
           alt="reply">
     <span class="btn-text">
     {{"homepage.eco-news.comment.btn.reply" | translate}}

--- a/src/app/component/eco-news/components/eco-news-detail/eco-news-detail.component.html
+++ b/src/app/component/eco-news/components/eco-news-detail/eco-news-detail.component.html
@@ -8,6 +8,7 @@
         <div class="button-content">
           <div class="button-arrow">
             <img [src]="images.arrowLeft"
+                 aria-hidden="true"
                  alt="arrow"
                  class="button-arrow-img"
             >
@@ -41,6 +42,7 @@
       <div class="news-info-dot">
         <img [src]="images.ellipse"
              alt="dot"
+             aria-hidden="true"
         >
       </div>
       <div class="news-info-author">


### PR DESCRIPTION
Removed screen reader focus from the next icons
News page:
like
delete
edit
replay
arrow near 'Back to news' link
dot between 'Data' and 'Autor'