### PR TITLE
[Bugfix] Style, accessibility changes on Eco News page

### DIFF
--- a/src/app/component/eco-news/components/news-list/news-list-gallery-view/news-list-gallery-view.component.html
+++ b/src/app/component/eco-news/components/news-list/news-list-gallery-view/news-list-gallery-view.component.html
@@ -1,4 +1,4 @@
-<div class="list-gallery">
+<div class="list-gallery" role="link">
   <div class="list-image">
     <img class="list-image-content"
          [src]="checkNewsImage()"
@@ -13,9 +13,9 @@
     </div>
     <div class="added-data">
       <div class="title-list word-wrap">
-        <p>
+        <h3>
           {{ ecoNewsModel.title }}
-        </p>
+        </h3>
       </div>
       <div class="list-text word-wrap">
         <p>

--- a/src/app/component/eco-news/components/news-list/news-list-gallery-view/news-list-gallery-view.component.scss
+++ b/src/app/component/eco-news/components/news-list/news-list-gallery-view/news-list-gallery-view.component.scss
@@ -75,7 +75,6 @@ div {
         font-size: 14px;
         line-height: 21px;
         color: var(--secondary-dark-grey);
-        white-space: pre-wrap;
       }
     }
 

--- a/src/app/component/eco-news/components/news-list/news-list-gallery-view/news-list-gallery-view.component.scss
+++ b/src/app/component/eco-news/components/news-list/news-list-gallery-view/news-list-gallery-view.component.scss
@@ -59,12 +59,15 @@ div {
       .title-list {
         max-height: 52px;
         overflow: hidden;
-        font-family: var(--secondary-font);
-        font-style: normal;
-        font-weight: 500;
-        font-size: 21px;
-        line-height: 26px;
-        color: var(--secondary-dark-grey);
+
+        h3 {
+          font-family: var(--secondary-font);
+          font-style: normal;
+          font-weight: 500;
+          font-size: 21px;
+          line-height: 26px;
+          color: var(--secondary-dark-grey);
+        }
       }
 
       .list-text {
@@ -175,7 +178,7 @@ div {
       .added-data {
         height: 222px;
 
-        .title-list {
+        .title-list > h3 {
           font-size: 18px;
           line-height: 24px;
         }

--- a/src/app/component/eco-news/components/news-list/news-list.component.ts
+++ b/src/app/component/eco-news/components/news-list/news-list.component.ts
@@ -35,7 +35,7 @@ export class NewsListComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.onResize();
-    this.setDefaultNumberOfNews(6);
+    this.setDefaultNumberOfNews(12);
     this.setNullList();
     this.checkUserSingIn();
     this.userOwnAuthService.getDataFromLocalStorage();

--- a/src/app/component/eco-news/components/remaining-count/remaining-count.component.html
+++ b/src/app/component/eco-news/components/remaining-count/remaining-count.component.html
@@ -1,1 +1,1 @@
-<p> {{remainingCount}} {{remainingCount === 1 ? 'item' : 'items'}} found</p>
+<h2> {{remainingCount}} {{remainingCount === 1 ? 'item' : 'items'}} found</h2>

--- a/src/app/component/eco-news/components/remaining-count/remaining-count.component.scss
+++ b/src/app/component/eco-news/components/remaining-count/remaining-count.component.scss
@@ -1,4 +1,4 @@
-p {
+h2 {
   font-family: var(--primary-font);
   font-size: 16px;
   line-height: 24px;
@@ -7,7 +7,7 @@ p {
 }
 
 @media screen and (max-width: 575px) {
-  p {
+  h2 {
     font-size: 12px;
   }
 }


### PR DESCRIPTION
ita-social-projects/GreenCity#2137
Changed default number of news from 6 to 12
Previous:
![103314982-f424c900-4a2c-11eb-812c-2eb88a969aa5](https://user-images.githubusercontent.com/55454496/104464299-724fa680-55bb-11eb-87ef-5abdecda7fc9.png)
Result:
![image](https://user-images.githubusercontent.com/55454496/104481256-3c67ed80-55ce-11eb-9cfe-8d80ae62ea1a.png)

ita-social-projects/GreenCity#1886
Fixed incorrect text alignment in content item on the Eco News page
Previous:
Before the first word in the text there is a space
![image](https://user-images.githubusercontent.com/55454496/104480755-9320f780-55cd-11eb-9ab0-c527e93e6064.png)
Result:
![image](https://user-images.githubusercontent.com/55454496/104481072-ff036000-55cd-11eb-8060-06ccc447a4d1.png)

ita-social-projects/GreenCity#2152
Changed Eco News page structure for better accessibility