### PR TITLE
[COMMENTS] Styles, empty space between comments, bug#2057 

### DIFF
--- a/src/app/component/comments/components/comment-pagination/comment-pagination.component.scss
+++ b/src/app/component/comments/components/comment-pagination/comment-pagination.component.scss
@@ -2,8 +2,7 @@
   display: flex;
   justify-content: center;
   text-align: center;
-  height: 35px;
-  margin-top: 64px;
+  height: 15px;
 
   .custom-pagination {
     display: flex;

--- a/src/app/component/comments/components/comment-pagination/comment-pagination.component.scss
+++ b/src/app/component/comments/components/comment-pagination/comment-pagination.component.scss
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: center;
   text-align: center;
-  height: 15px;
+  height: 28px;
 
   .custom-pagination {
     display: flex;
@@ -15,7 +15,7 @@
     }
 
     .page-number.current {
-      height: 32px;
+      height: 28px;
       min-width: 32px;
       background: var(--primary-green) !important;
       border-radius: 4px;
@@ -23,10 +23,10 @@
 
     .page-number a {
       display: block;
-      height: 35px;
+      height: 28px;
       font-family: var(--primary-font);
-      font-size: 24px;
-      line-height: 35px;
+      font-size: 21px;
+      line-height: 28px;
       color: var(--primary-dark-grey);
       cursor: pointer;
     }


### PR DESCRIPTION
Fixed a lot of empty space between reply to comment and next comment (bug#2057).
Before:
![before](https://user-images.githubusercontent.com/70901435/104811929-8be52e00-5807-11eb-9acd-e4e19a83263b.jpg)
After:
![after](https://user-images.githubusercontent.com/70901435/104811956-a7e8cf80-5807-11eb-980a-50d26ac2d354.jpg)


