### PR TITLE
[Restoring password] Styles are incorrectly displayed when user restoring the password 

### DIFF
--- a/src/app/component/auth/components/confirm-restore-password/confirm-restore-password.component.html
+++ b/src/app/component/auth/components/confirm-restore-password/confirm-restore-password.component.html
@@ -37,7 +37,6 @@
                     minlength="8"
                     name="form-control password"
                     (input)="setPasswordBackendErr()">
-              >
               <span class="show-password">
                   <img [src]="authImages.hiddenEye"
                       alt="eye"
@@ -45,7 +44,7 @@
                       #inputPasswordImg
                       (click)="setPasswordVisibility(inputPassword, inputPasswordImg)"
                   >
-                </span>
+              </span>
             </div>
             <div *ngIf="passwordField.invalid && passwordField.touched"
               class="error-message-show error-message">
@@ -71,7 +70,6 @@
                     name="form-control password-confirm"
                     required
                     (input)="setPasswordBackendErr()">
-              >
               <span class="show-password">
                   <img [src]="authImages.hiddenEye"
                       alt="eye"


### PR DESCRIPTION
**Description:**
When a user wants to reset a password, the fields that need to be filled in are incorrectly displayed in the window where you need to enter a new password.
Before:
![before](https://user-images.githubusercontent.com/70901435/105598735-fca6c000-5d9c-11eb-8a76-93635fd415ea.jpg)
After:
![after](https://user-images.githubusercontent.com/70901435/105598863-06302800-5d9d-11eb-9011-125413211a07.jpg)
As we can see on the last picture, bug has been fixed.