### PR TITLE
[Header] Old 'User Name' is shown when user signs for the second time after editing 'Name' field 

### DIFF
--- a/src/app/component/auth/components/sign-in/sign-in.component.spec.ts
+++ b/src/app/component/auth/components/sign-in/sign-in.component.spec.ts
@@ -16,6 +16,7 @@ import { GoogleSignInService } from '@global-service/auth/google-sign-in.service
 import { UserOwnSignIn } from '@global-models/user-own-sign-in';
 import { UserSuccessSignIn } from '@global-models/user-success-sign-in';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
+import { ProfileService } from '../../../user/components/profile/profile-service/profile.service';
 
 import { UserOwnSignInService } from '@auth-service/user-own-sign-in.service';
 import { GoogleBtnComponent } from '../google-btn/google-btn.component';
@@ -91,7 +92,8 @@ describe('SignIn component', () => {
         { provide: AuthServiceConfig, useFactory: provideConfig },
         { provide: MatDialogRef, useValue: matDialogMock },
         { provide: UserOwnSignInService, useValue: signInServiceMock },
-        { provide: Router, useValue: routerSpy }
+        { provide: Router, useValue: routerSpy },
+        { provide: ProfileService }
       ]
     });
   }));

--- a/src/app/component/auth/components/sign-in/sign-in.component.spec.ts
+++ b/src/app/component/auth/components/sign-in/sign-in.component.spec.ts
@@ -22,7 +22,6 @@ import { GoogleBtnComponent } from '../google-btn/google-btn.component';
 import { ErrorComponent } from '../error/error.component';
 import { SignInComponent } from './sign-in.component';
 import { provideConfig } from 'src/app/config/GoogleAuthConfig';
-import { ProfileService } from '@global-user/components/profile/profile-service/profile.service';
 
 describe('SignIn component', () => {
   let component: SignInComponent;
@@ -92,8 +91,7 @@ describe('SignIn component', () => {
         { provide: AuthServiceConfig, useFactory: provideConfig },
         { provide: MatDialogRef, useValue: matDialogMock },
         { provide: UserOwnSignInService, useValue: signInServiceMock },
-        { provide: Router, useValue: routerSpy },
-        { provide: ProfileService }
+        { provide: Router, useValue: routerSpy }
       ]
     });
   }));

--- a/src/app/component/auth/components/sign-in/sign-in.component.spec.ts
+++ b/src/app/component/auth/components/sign-in/sign-in.component.spec.ts
@@ -22,6 +22,7 @@ import { GoogleBtnComponent } from '../google-btn/google-btn.component';
 import { ErrorComponent } from '../error/error.component';
 import { SignInComponent } from './sign-in.component';
 import { provideConfig } from 'src/app/config/GoogleAuthConfig';
+import { ProfileService } from '@global-user/components/profile/profile-service/profile.service';
 
 describe('SignIn component', () => {
   let component: SignInComponent;
@@ -91,7 +92,8 @@ describe('SignIn component', () => {
         { provide: AuthServiceConfig, useFactory: provideConfig },
         { provide: MatDialogRef, useValue: matDialogMock },
         { provide: UserOwnSignInService, useValue: signInServiceMock },
-        { provide: Router, useValue: routerSpy }
+        { provide: Router, useValue: routerSpy },
+        { provide: ProfileService }
       ]
     });
   }));

--- a/src/app/component/auth/components/sign-in/sign-in.component.ts
+++ b/src/app/component/auth/components/sign-in/sign-in.component.ts
@@ -12,8 +12,7 @@ import { SignInIcons } from 'src/app/image-pathes/sign-in-icons';
 import { UserOwnSignIn } from '@global-models/user-own-sign-in';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { UserOwnAuthService } from '@global-service/auth/user-own-auth.service';
-import { takeUntil, take } from 'rxjs/operators';
-import { ProfileService } from '@global-user/components/profile/profile-service/profile.service';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-sign-in',
@@ -47,7 +46,6 @@ export class SignInComponent implements OnInit, OnDestroy {
     private googleService: GoogleSignInService,
     private localStorageService: LocalStorageService,
     private userOwnAuthService: UserOwnAuthService,
-    private profileService: ProfileService
   ) { }
 
   ngOnInit() {
@@ -119,15 +117,8 @@ export class SignInComponent implements OnInit, OnDestroy {
     this.userOwnSignInService.saveUserToLocalStorage(data);
     this.userOwnAuthService.getDataFromLocalStorage();
     this.router.navigate(['profile', data.userId])
-      .then(() => {
+      .then(success => {
         this.localStorageService.setFirstSignIn();
-        this.profileService.getUserInfo()
-        .pipe(
-          take(1)
-        )
-        .subscribe(item => {
-          this.localStorageService.setFirstName(item.firstName);
-        });
       })
       .catch(fail => console.log('redirect has failed ' + fail));
   }

--- a/src/app/component/auth/components/sign-in/sign-in.component.ts
+++ b/src/app/component/auth/components/sign-in/sign-in.component.ts
@@ -12,7 +12,8 @@ import { SignInIcons } from 'src/app/image-pathes/sign-in-icons';
 import { UserOwnSignIn } from '@global-models/user-own-sign-in';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { UserOwnAuthService } from '@global-service/auth/user-own-auth.service';
-import { takeUntil } from 'rxjs/operators';
+import { takeUntil, take } from 'rxjs/operators';
+import { ProfileService } from '@global-user/components/profile/profile-service/profile.service';
 
 @Component({
   selector: 'app-sign-in',
@@ -46,6 +47,7 @@ export class SignInComponent implements OnInit, OnDestroy {
     private googleService: GoogleSignInService,
     private localStorageService: LocalStorageService,
     private userOwnAuthService: UserOwnAuthService,
+    private profileService: ProfileService
   ) { }
 
   ngOnInit() {
@@ -117,8 +119,15 @@ export class SignInComponent implements OnInit, OnDestroy {
     this.userOwnSignInService.saveUserToLocalStorage(data);
     this.userOwnAuthService.getDataFromLocalStorage();
     this.router.navigate(['profile', data.userId])
-      .then(success => {
+      .then(() => {
         this.localStorageService.setFirstSignIn();
+        this.profileService.getUserInfo()
+        .pipe(
+          take(1)
+        )
+        .subscribe(item => {
+          this.localStorageService.setFirstName(item.firstName);
+        });
       })
       .catch(fail => console.log('redirect has failed ' + fail));
   }

--- a/src/app/component/auth/components/sign-in/sign-in.component.ts
+++ b/src/app/component/auth/components/sign-in/sign-in.component.ts
@@ -12,7 +12,8 @@ import { SignInIcons } from 'src/app/image-pathes/sign-in-icons';
 import { UserOwnSignIn } from '@global-models/user-own-sign-in';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { UserOwnAuthService } from '@global-service/auth/user-own-auth.service';
-import { takeUntil } from 'rxjs/operators';
+import { takeUntil, take } from 'rxjs/operators';
+import { ProfileService } from '../../../user/components/profile/profile-service/profile.service';
 
 @Component({
   selector: 'app-sign-in',
@@ -46,6 +47,7 @@ export class SignInComponent implements OnInit, OnDestroy {
     private googleService: GoogleSignInService,
     private localStorageService: LocalStorageService,
     private userOwnAuthService: UserOwnAuthService,
+    private profileService: ProfileService
   ) { }
 
   ngOnInit() {
@@ -117,8 +119,15 @@ export class SignInComponent implements OnInit, OnDestroy {
     this.userOwnSignInService.saveUserToLocalStorage(data);
     this.userOwnAuthService.getDataFromLocalStorage();
     this.router.navigate(['profile', data.userId])
-      .then(success => {
+      .then(() => {
         this.localStorageService.setFirstSignIn();
+        this.profileService.getUserInfo()
+        .pipe(
+          take(1)
+        )
+        .subscribe(item => {
+          this.localStorageService.setFirstName(item.firstName);
+        });
       })
       .catch(fail => console.log('redirect has failed ' + fail));
   }

--- a/src/app/component/home/components/homepage/homepage.component.spec.ts
+++ b/src/app/component/home/components/homepage/homepage.component.spec.ts
@@ -22,7 +22,6 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AuthModule } from 'src/app/component/auth/auth.module';
 import { EcoNewsModule } from 'src/app/component/eco-news/eco-news.module';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
-import {APP_BASE_HREF} from '@angular/common';
 
 class MatDialogMock {
   open() {
@@ -93,7 +92,6 @@ describe('HomepageComponent', () => {
         { provide: UserService, useValue: userServiceMock },
         { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: MatDialog, useClass: MatDialogMock },
-        { provide: APP_BASE_HREF, useValue : '/' }
       ]
     })
     .compileComponents();

--- a/src/app/component/home/components/homepage/homepage.component.spec.ts
+++ b/src/app/component/home/components/homepage/homepage.component.spec.ts
@@ -22,6 +22,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AuthModule } from 'src/app/component/auth/auth.module';
 import { EcoNewsModule } from 'src/app/component/eco-news/eco-news.module';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
+import {APP_BASE_HREF} from '@angular/common';
 
 class MatDialogMock {
   open() {
@@ -92,6 +93,7 @@ describe('HomepageComponent', () => {
         { provide: UserService, useValue: userServiceMock },
         { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: MatDialog, useClass: MatDialogMock },
+        { provide: APP_BASE_HREF, useValue : '/' }
       ]
     })
     .compileComponents();


### PR DESCRIPTION
**Description:** The Name is changed after profile editing in 'Header'. After sign out-sign the 'User Name' in 'Header' is changed to the name with which account was created for the first time. 

**Before:**

![](https://user-images.githubusercontent.com/73852063/103318751-153ee700-4a38-11eb-8602-323a65bb6f6d.png)

**After:**
![Зняток екрану як 2021-01-25 22-18-28(1)](https://user-images.githubusercontent.com/50026335/105761797-3a057c00-5f5c-11eb-8ea0-43edb01eb0f5.png)

The Name is changed after profile editing in 'Header'. After sign out-sign the 'User Name' in 'Header' corresponds to the 'Name' in Profile.