### PR TITLE
[Bug] 'Duration' value is displayed on the habit in progress card / bug#2244

### DIFF
--- a/src/app/component/user/components/profile/profile-dashboard/one-habit/one-habit.component.html
+++ b/src/app/component/user/components/profile/profile-dashboard/one-habit/one-habit.component.html
@@ -1,9 +1,8 @@
 <div class="main">
   <div class="description">
     <div class="first-row">
-      <div class="calendar"
-           *ngIf="showCalendar"
-      ></div>
+      <div class="calendar">
+      </div>
       <p>{{ daysCounter }}</p>
       <div
         *ngIf="showPhoto"

--- a/src/app/component/user/components/profile/profile-dashboard/one-habit/one-habit.component.ts
+++ b/src/app/component/user/components/profile/profile-dashboard/one-habit/one-habit.component.ts
@@ -12,9 +12,8 @@ import { LocalStorageService } from '@global-service/localstorage/local-storage.
 export class OneHabitComponent implements OnInit {
   @Input() habit: HabitAssignInterface;
   currentDate: string;
-  showCalendar: boolean;
   showPhoto: boolean;
-  daysCounter: string;
+  daysCounter: number;
   habitMark: string;
   isRequest = false;
   backgroundImage = 'assets/img/man.svg';
@@ -23,24 +22,21 @@ export class OneHabitComponent implements OnInit {
 
   private descriptionType = {
     acquired: () => {
-      this.showCalendar = true;
-      this.daysCounter = this.habit.duration.toString();
+      this.daysCounter = this.habit.duration;
       this.showPhoto = false;
       this.habitMark = 'star';
     },
     done: () => {
-      this.showCalendar = false;
       this.daysCounter = this.habit.workingDays
-        ? `${this.habit.workingDays}/${this.habit.duration}`
-        : this.habit.duration.toString();
+        ? this.habit.workingDays
+        : this.habit.duration;
       this.showPhoto = false;
       this.habitMark = 'mark';
     },
     undone: () => {
-      this.showCalendar = true;
       this.daysCounter = this.habit.workingDays
-        ? `${this.habit.workingDays}/${this.habit.duration}`
-        : this.habit.duration.toString();
+        ? this.habit.workingDays
+        : this.habit.duration;
       this.showPhoto = true;
       this.habitMark = 'plus';
     }


### PR DESCRIPTION
Description:
"User story #988"

There were two disabled numeric values in the left high angle of the habit in progress card: 'days in progress/duration' but expected one numeric value in the left high angle of the habit in progress card: 'days in progress'.

It was fixed by changing one-habit component.

BEFORE:
![BEFORE](https://user-images.githubusercontent.com/70901435/108817294-5549c280-75c0-11eb-829f-54960824da92.png)

AFTER:
![AFTER](https://user-images.githubusercontent.com/70901435/108817316-61358480-75c0-11eb-800a-952d7d80857a.jpg)


