### PR TITLE
closes [UI, Editing comment] 'Save' button is shown instead of 'Save …

### DIFF
--- a/src/app/component/comments/components/comments-list/comments-list.component.html
+++ b/src/app/component/comments/components/comments-list/comments-list.component.html
@@ -44,7 +44,7 @@
     </div>
   <div class="comments-elements">
     <div class="btn-wrapper"
-         *ngIf="isLoggedIn && (comment.author.id === +userId) && !comment.isEdit; else editComment">
+         *ngIf="isLoggedIn && checkCommentAuthor(comment.author.id) && !comment.isEdit; else editComment">
       <app-edit-comment (isEditing)="showElements(comment.id, 'isEdit')"></app-edit-comment>
       <app-delete-comment [element]="comment"
                           [dataType] = "dataType"
@@ -53,7 +53,7 @@
     </div>
     <ng-template #editComment>
       <div class="save-cancel-wrapper"
-           *ngIf="isLoggedIn && (comment.author.id === +userId)">
+           *ngIf="isLoggedIn && checkCommentAuthor(comment.author.id)">
         <div class="d-flex">
           <div class="main-wrapper">
             <button (click)="saveEditedComment(comment)"
@@ -80,7 +80,7 @@
         </div>
       </div>
     </ng-template>
-    <app-like-comment *ngIf="isLoggedIn && (comment.author.id !== +userId)"
+    <app-like-comment *ngIf="isLoggedIn && !checkCommentAuthor(comment.author.id)"
                       [comment]="comment"
                       (likesCounter)="changeCounter($event, comment.id, 'likes')">
     </app-like-comment>

--- a/src/app/component/comments/components/comments-list/comments-list.component.html
+++ b/src/app/component/comments/components/comments-list/comments-list.component.html
@@ -54,14 +54,14 @@
     <ng-template #editComment>
       <div class="save-cancel-wrapper"
            *ngIf="isLoggedIn && (comment.author.id === +userId)">
-        <div class="save-cancel-btn">
+        <div class="d-flex">
           <div class="main-wrapper">
             <button (click)="saveEditedComment(comment)"
                     [disabled]="!content.valid"
                     class="cta-btn save-edit">
               <img [src]="editIcon"
                    alt="edit icon">
-              <span class="btn-text">
+              <span class="d-none d-sm-block btn-text">
                 {{"homepage.eco-news.comment.btn.save" | translate}}
               </span>
             </button>
@@ -72,7 +72,7 @@
               <img [src]="cancelIcon"
                     class="btn-img"
                     alt="cancel icon">
-              <span class="btn-text">
+              <span class="d-none d-sm-block btn-text">
                 {{"homepage.eco-news.comment.btn.cancel" | translate}}
               </span>
             </button>
@@ -85,7 +85,7 @@
                       (likesCounter)="changeCounter($event, comment.id, 'likes')">
     </app-like-comment>
     <app-reply-comment (click)="showElements(comment.id, 'showRelyButton')"
-                      *ngIf="isLoggedIn && !comment.isEdit">
+                      *ngIf="isLoggedIn && !comment.isEdit && dataType === types.commentType">
     </app-reply-comment>
     <div class="btn-replies"
          *ngIf="dataType === types.commentType">

--- a/src/app/component/comments/components/comments-list/comments-list.component.html
+++ b/src/app/component/comments/components/comments-list/comments-list.component.html
@@ -38,10 +38,24 @@
                 [value]="comment.text"
                 [formControl]="content"
                 class="edit-text-input"
-                maxlength="8000"></textarea>
-      <div class="save-cancel-wrapper">
+                maxlength="8000">
+      </textarea>
+    </div>
+    </div>
+  <div class="comments-elements">
+    <div class="btn-wrapper"
+         *ngIf="isLoggedIn && (comment.author.id === +userId) && !comment.isEdit; else editComment">
+      <app-edit-comment (isEditing)="showElements(comment.id, 'isEdit')"></app-edit-comment>
+      <app-delete-comment [element]="comment"
+                          [dataType] = "dataType"
+                          (elementsList)="deleteComment()">
+      </app-delete-comment>
+    </div>
+    <ng-template #editComment>
+      <div class="save-cancel-wrapper"
+           *ngIf="isLoggedIn && (comment.author.id === +userId)">
         <div class="save-cancel-btn">
-          <div class="save-btn">
+          <div class="main-wrapper">
             <button (click)="saveEditedComment(comment)"
                     [disabled]="!content.valid"
                     class="cta-btn save-edit">
@@ -52,7 +66,7 @@
               </span>
             </button>
           </div>
-          <div class="cancel-btn">
+          <div class="main-wrapper">
             <button (click)="cancelEditedComment(comment)"
                     class="cta-btn cancel-edit">
               <img [src]="cancelIcon"
@@ -65,28 +79,24 @@
           </div>
         </div>
       </div>
-    </div>
-    </div>
-  <div class="comments-elements">
-    <div class="btn-wrapper" *ngIf="isLoggedIn && (comment.author.id === +userId) && !comment.isEdit">
-      <app-edit-comment (isEditing)="showElements(comment.id, 'isEdit')"></app-edit-comment>
-      <app-delete-comment [element]="comment"
-                          [dataType] = "dataType"
-                          (elementsList)="deleteComment()"></app-delete-comment>
-    </div>
+    </ng-template>
     <app-like-comment *ngIf="isLoggedIn && (comment.author.id !== +userId)"
                       [comment]="comment"
-                      (likesCounter)="changeCounter($event, comment.id, 'likes')"></app-like-comment>
-    <div class="btn-replies" *ngIf="dataType === types.commentType"
-         [ngClass]="isLoggedIn ? 'btn-replies-registered' : 'btn-replies-unregistered'">
-      <app-reply-comment (click)="showElements(comment.id, 'showRelyButton')"
-                         *ngIf="isLoggedIn"></app-reply-comment>
+                      (likesCounter)="changeCounter($event, comment.id, 'likes')">
+    </app-like-comment>
+    <app-reply-comment (click)="showElements(comment.id, 'showRelyButton')"
+                      *ngIf="isLoggedIn && !comment.isEdit">
+    </app-reply-comment>
+    <div class="btn-replies"
+         *ngIf="dataType === types.commentType">
       <app-view-replies [repliesCounter]="comment.replies"
-                        (click)="showElements(comment.id, 'showAllRelies')"></app-view-replies>
+                        (click)="showElements(comment.id, 'showAllRelies')">
+      </app-view-replies>
     </div>
   </div>
-   <app-comments-container *ngIf="dataType === types.commentType"
-                           [comment]='comment'
-                           (repliesCounter)="changeCounter($event, comment.id, 'replies')"
-                           dataType="reply"></app-comments-container>
+  <app-comments-container *ngIf="dataType === types.commentType"
+                          [comment]='comment'
+                          (repliesCounter)="changeCounter($event, comment.id, 'replies')"
+                          dataType="reply">
+  </app-comments-container>
 </div>

--- a/src/app/component/comments/components/comments-list/comments-list.component.scss
+++ b/src/app/component/comments/components/comments-list/comments-list.component.scss
@@ -118,10 +118,6 @@
   }
 }
 
-.save-cancel-btn {
-  display: flex;
-}
-
 .btn-replies {
   display: flex;
   justify-content: flex-end;
@@ -160,17 +156,17 @@
   border: none;
   background-color: #fff;
   outline: none;
+}
 
-  .btn-text {
-    display: inline-block;
-    margin-left: 5px;
-    font-family: var(--primary-font);
-    font-size: 16px;
-    line-height: 24px;
-    color: var(--secondary-grey);
-    mix-blend-mode: normal;
-    white-space: nowrap;
-  }
+.btn-text {
+  display: inline-block;
+  margin-left: 5px;
+  font-family: var(--primary-font);
+  font-size: 16px;
+  line-height: 24px;
+  color: var(--secondary-grey);
+  mix-blend-mode: normal;
+  white-space: nowrap;
 }
 
 .comment-likes {
@@ -188,12 +184,8 @@
 }
 
 @media screen and (max-width: 992px) {
-  .main-wrapper {
-    .cta-btn {
-      .btn-text {
-        font-size: 12px;
-      }
-    }
+  .btn-text {
+    font-size: 12px;
   }
 }
 
@@ -230,12 +222,6 @@
 
   .main-wrapper:last-child {
     margin-left: 0;
-  }
-
-  .cta-btn {
-    .btn-text {
-      display: none;
-    }
   }
 }
 

--- a/src/app/component/comments/components/comments-list/comments-list.component.scss
+++ b/src/app/component/comments/components/comments-list/comments-list.component.scss
@@ -83,73 +83,6 @@
     word-wrap: break-word;
   }
 
-  .comment-edit-text {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    margin-bottom: 10px;
-
-    .save-cancel-btn {
-      display: flex;
-
-      .replies-btn {
-        display: flex;
-        justify-content: flex-end;
-        width: 520px;
-      }
-    }
-
-    .save-edit {
-      width: fit-content;
-      height: 40px;
-      margin-right: 25px;
-      cursor: pointer;
-    }
-
-    .cancel-edit {
-      width: 74px;
-      height: 40px;
-      margin-right: 8px;
-      cursor: pointer;
-
-      .btn-img {
-        min-width: 12px;
-        max-height: 12px;
-      }
-    }
-
-    .edit-text-input {
-      width: 100%;
-      height: 72px;
-      overflow: hidden;
-      resize: none;
-      padding: 10px 0 0 20px;
-
-      &::placeholder {
-        color: var(--secondary-grey);
-      }
-    }
-
-    .cta-btn {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      text-align: center;
-      border: none;
-      background-color: #fff;
-
-      .btn-text {
-        display: inline-block;
-        margin-left: 5px;
-        font-family: var(--primary-font);
-        font-size: 16px;
-        line-height: 24px;
-        color: var(--secondary-grey);
-        mix-blend-mode: normal;
-      }
-    }
-  }
-
   .edit-text-button {
     width: 157px;
     height: 48px;
@@ -159,22 +92,84 @@
 .comments-elements {
   display: flex;
   padding-left: 55px;
+  justify-content: space-between;
 
   .btn-wrapper {
     display: flex;
   }
+}
 
-  .btn-replies {
+.comment-edit-text {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin-bottom: 10px;
+
+  .edit-text-input {
     width: 100%;
-    display: flex;
+    height: 72px;
+    overflow: hidden;
+    resize: none;
+    padding: 10px 0 0 20px;
 
-    &-registered {
-      justify-content: space-between;
+    &::placeholder {
+      color: var(--secondary-grey);
     }
+  }
+}
 
-    &-unregistered {
-      justify-content: flex-end;
-    }
+.save-cancel-btn {
+  display: flex;
+}
+
+.btn-replies {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.save-edit {
+  width: fit-content;
+  height: 40px;
+  margin-right: 25px;
+  cursor: pointer;
+}
+
+.save-edit:disabled {
+  pointer-events: none;
+}
+
+.cancel-edit {
+  height: 40px;
+  margin-right: 8px;
+  cursor: pointer;
+
+  .btn-img {
+    min-width: 12px;
+    max-height: 12px;
+  }
+}
+
+.cta-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  border: none;
+  background-color: #fff;
+  outline: none;
+
+  .btn-text {
+    display: inline-block;
+    margin-left: 5px;
+    font-family: var(--primary-font);
+    font-size: 16px;
+    line-height: 24px;
+    color: var(--secondary-grey);
+    mix-blend-mode: normal;
+    white-space: nowrap;
   }
 }
 
@@ -189,6 +184,16 @@
 
   .commnet-dot {
     display: none;
+  }
+}
+
+@media screen and (max-width: 992px) {
+  .main-wrapper {
+    .cta-btn {
+      .btn-text {
+        font-size: 12px;
+      }
+    }
   }
 }
 
@@ -212,6 +217,24 @@
 
     .comment-date-likes {
       justify-content: left;
+    }
+  }
+
+  .main-wrapper {
+    margin-left: 35px;
+
+    .edit {
+      width: 20px;
+    }
+  }
+
+  .main-wrapper:last-child {
+    margin-left: 0;
+  }
+
+  .cta-btn {
+    .btn-text {
+      display: none;
     }
   }
 }

--- a/src/app/component/comments/components/comments-list/comments-list.component.ts
+++ b/src/app/component/comments/components/comments-list/comments-list.component.ts
@@ -63,4 +63,8 @@ export class CommentsListComponent {
       return item;
     });
   }
+
+  public checkCommentAuthor(commentAuthorId: number) {
+    return commentAuthorId === +this.userId;
+  }
 }

--- a/src/app/component/comments/components/comments-list/comments-list.component.ts
+++ b/src/app/component/comments/components/comments-list/comments-list.component.ts
@@ -65,6 +65,6 @@ export class CommentsListComponent {
   }
 
   public checkCommentAuthor(commentAuthorId: number) {
-    return commentAuthorId === +this.userId;
+    return commentAuthorId === Number(this.userId);
   }
 }

--- a/src/app/component/comments/components/delete-comment/delete-comment.component.html
+++ b/src/app/component/comments/components/delete-comment/delete-comment.component.html
@@ -1,11 +1,11 @@
-<div class="main-wrapper">
+<div class="d-flex">
     <button class="cta-btn delete"
             (click)="openPopup()">
       <img [src]="deleteIcon"
             class="btn-img"
             aria-hidden="true"
             alt="edit icon">
-      <span class="btn-text">
+      <span class="d-none d-sm-block btn-text">
         {{"homepage.eco-news.comment.btn.delete" | translate}}
       </span>
     </button>

--- a/src/app/component/comments/components/delete-comment/delete-comment.component.scss
+++ b/src/app/component/comments/components/delete-comment/delete-comment.component.scss
@@ -31,6 +31,16 @@
   }
 }
 
+@media screen and (max-width: 992px) {
+  .main-wrapper {
+    .cta-btn {
+      .btn-text {
+        font-size: 12px;
+      }
+    }
+  }
+}
+
 @media screen and (max-width: 575px) {
   .delete {
     margin-right: 15px;

--- a/src/app/component/comments/components/delete-comment/delete-comment.component.scss
+++ b/src/app/component/comments/components/delete-comment/delete-comment.component.scss
@@ -1,6 +1,3 @@
-.main-wrapper {
-  display: flex;
-
   .delete {
     width: fit-content;
     height: 40px;
@@ -14,51 +11,36 @@
     border: none;
     background-color: #fff;
     outline: none;
-
-    .btn-img {
-      min-width: 12px;
-      max-height: 14px;
-    }
-
-    .btn-text {
-      margin-left: 5px;
-      font-family: var(--primary-font);
-      font-size: 16px;
-      line-height: 24px;
-      color: var(--secondary-grey);
-      mix-blend-mode: normal;
-    }
   }
-}
 
-@media screen and (max-width: 992px) {
-  .main-wrapper {
-    .cta-btn {
-      .btn-text {
-        font-size: 12px;
-      }
-    }
-  }
-}
-
-@media screen and (max-width: 575px) {
-  .delete {
-    margin-right: 15px;
+  .btn-img {
+    min-width: 12px;
+    max-height: 14px;
   }
 
   .btn-text {
-    display: none;
+    margin-left: 5px;
+    font-family: var(--primary-font);
+    font-size: 16px;
+    line-height: 24px;
+    color: var(--secondary-grey);
+    mix-blend-mode: normal;
   }
-}
 
-@media screen and (max-width: 380px) {
-  .main-wrapper {
-    .cta-btn {
-      width: 24px;
-
-      .btn-text {
-        display: none;
-      }
+  @media screen and (max-width: 992px) {
+    .btn-text {
+      font-size: 12px;
     }
   }
-}
+
+  @media screen and (max-width: 575px) {
+    .delete {
+      margin-right: 15px;
+    }
+  }
+
+  @media screen and (max-width: 380px) {
+    .cta-btn {
+      width: 24px;
+    }
+  }

--- a/src/app/component/comments/components/delete-comment/delete-comment.component.scss
+++ b/src/app/component/comments/components/delete-comment/delete-comment.component.scss
@@ -1,46 +1,46 @@
-  .delete {
-    width: fit-content;
-    height: 40px;
-  }
+.delete {
+  width: fit-content;
+  height: 40px;
+}
 
-  .cta-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    border: none;
-    background-color: #fff;
-    outline: none;
-  }
+.cta-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  border: none;
+  background-color: #fff;
+  outline: none;
+}
 
-  .btn-img {
-    min-width: 12px;
-    max-height: 14px;
-  }
+.btn-img {
+  min-width: 12px;
+  max-height: 14px;
+}
 
+.btn-text {
+  margin-left: 5px;
+  font-family: var(--primary-font);
+  font-size: 16px;
+  line-height: 24px;
+  color: var(--secondary-grey);
+  mix-blend-mode: normal;
+}
+
+@media screen and (max-width: 992px) {
   .btn-text {
-    margin-left: 5px;
-    font-family: var(--primary-font);
-    font-size: 16px;
-    line-height: 24px;
-    color: var(--secondary-grey);
-    mix-blend-mode: normal;
+    font-size: 12px;
   }
+}
 
-  @media screen and (max-width: 992px) {
-    .btn-text {
-      font-size: 12px;
-    }
+@media screen and (max-width: 575px) {
+  .delete {
+    margin-right: 15px;
   }
+}
 
-  @media screen and (max-width: 575px) {
-    .delete {
-      margin-right: 15px;
-    }
+@media screen and (max-width: 380px) {
+  .cta-btn {
+    width: 24px;
   }
-
-  @media screen and (max-width: 380px) {
-    .cta-btn {
-      width: 24px;
-    }
-  }
+}

--- a/src/app/component/comments/components/edit-comment/edit-comment.component.html
+++ b/src/app/component/comments/components/edit-comment/edit-comment.component.html
@@ -1,11 +1,11 @@
-<div class="main-wrapper">
+<div class="d-flex main-wrapper">
     <button class="cta-btn edit"
             (click)=editComments()>
       <img [src]="editIcon"
             class="btn-img"
             aria-hidden="true"
             alt="edit icon">
-      <span class="btn-text">
+      <span class="d-none d-sm-block btn-text">
         {{"homepage.eco-news.comment.btn.edit" | translate}}
       </span> 
     </button>

--- a/src/app/component/comments/components/edit-comment/edit-comment.component.scss
+++ b/src/app/component/comments/components/edit-comment/edit-comment.component.scss
@@ -1,43 +1,35 @@
-.main-wrapper {
+.edit {
+  width: fit-content;
+  height: 40px;
+}
+
+.cta-btn {
   display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  border: none;
+  background-color: #fff;
+  outline: none;
+}
 
-  .edit {
-    width: fit-content;
-    height: 40px;
-  }
+.btn-img {
+  min-width: 16px;
+  max-height: 16px;
+}
 
-  .cta-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    border: none;
-    background-color: #fff;
-    outline: none;
-
-    .btn-img {
-      min-width: 16px;
-      max-height: 16px;
-    }
-
-    .btn-text {
-      margin-left: 5px;
-      font-family: var(--primary-font);
-      font-size: 16px;
-      line-height: 24px;
-      color: var(--secondary-grey);
-      mix-blend-mode: normal;
-    }
-  }
+.btn-text {
+  margin-left: 5px;
+  font-family: var(--primary-font);
+  font-size: 16px;
+  line-height: 24px;
+  color: var(--secondary-grey);
+  mix-blend-mode: normal;
 }
 
 @media screen and (max-width: 992px) {
-  .main-wrapper {
-    .cta-btn {
-      .btn-text {
-        font-size: 12px;
-      }
-    }
+  .btn-text {
+    font-size: 12px;
   }
 }
 
@@ -45,25 +37,15 @@
   .main-wrapper {
     margin-left: 35px;
     margin-right: 15px;
-
-    .edit {
-      width: 20px;
-    }
   }
 
-  .btn-text {
-    display: none;
+  .edit {
+    width: 20px;
   }
 }
 
 @media screen and (max-width: 380px) {
-  .main-wrapper {
-    .cta-btn {
-      width: 24px;
-
-      .btn-text {
-        display: none;
-      }
-    }
+  .cta-btn {
+    width: 24px;
   }
 }

--- a/src/app/component/comments/components/edit-comment/edit-comment.component.scss
+++ b/src/app/component/comments/components/edit-comment/edit-comment.component.scss
@@ -31,6 +31,16 @@
   }
 }
 
+@media screen and (max-width: 992px) {
+  .main-wrapper {
+    .cta-btn {
+      .btn-text {
+        font-size: 12px;
+      }
+    }
+  }
+}
+
 @media screen and (max-width: 575px) {
   .main-wrapper {
     margin-left: 35px;

--- a/src/app/component/comments/components/like-comment/like-comment.component.html
+++ b/src/app/component/comments/components/like-comment/like-comment.component.html
@@ -1,4 +1,4 @@
-<div class="main-wrapper">
+<div class="d-flex main-wrapper">
   <button class="cta-btn like"
           (click)="pressLike()">
     <img [src]="commentsImages.like"
@@ -6,12 +6,12 @@
           alt="like"
           aria-hidden="true"
           #like>
-    <span class="btn-text"
+    <span class="d-none d-sm-block btn-text"
           *ngIf="!likeState && !error; else liked">
       {{"homepage.eco-news.comment.btn.like" | translate}}
     </span>
     <ng-template #liked>
-      <span class="btn-text">
+      <span class="d-none d-sm-block btn-text">
         {{"homepage.eco-news.comment.btn.liked" | translate}}
       </span>
     </ng-template>

--- a/src/app/component/comments/components/like-comment/like-comment.component.scss
+++ b/src/app/component/comments/components/like-comment/like-comment.component.scss
@@ -40,6 +40,16 @@
   }
 }
 
+@media screen and (max-width: 992px) {
+  .main-wrapper {
+    .cta-btn {
+      .btn-text {
+        font-size: 12px;
+      }
+    }
+  }
+}
+
 @media screen and (max-width: 575px) {
   .main-wrapper {
     padding-left: 30px;

--- a/src/app/component/comments/components/like-comment/like-comment.component.scss
+++ b/src/app/component/comments/components/like-comment/like-comment.component.scss
@@ -1,52 +1,44 @@
-.main-wrapper {
+.like {
+  width: fit-content;
+  height: 40px;
+  margin-right: 8px;
+}
+
+.visible {
+  visibility: visible;
+}
+
+.hidden {
+  visibility: hidden;
+}
+
+.cta-btn {
   display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  border: none;
+  background-color: #fff;
+  outline: none;
+}
 
-  .like {
-    width: fit-content;
-    height: 40px;
-    margin-right: 8px;
-  }
+.btn-img {
+  min-width: 16px;
+  max-height: 16px;
+}
 
-  .visible {
-    visibility: visible;
-  }
-
-  .hidden {
-    visibility: hidden;
-  }
-
-  .cta-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    border: none;
-    background-color: #fff;
-    outline: none;
-
-    .btn-img {
-      min-width: 16px;
-      max-height: 16px;
-    }
-
-    .btn-text {
-      margin-left: 5px;
-      font-family: var(--primary-font);
-      font-size: 16px;
-      line-height: 24px;
-      color: var(--secondary-grey);
-      mix-blend-mode: normal;
-    }
-  }
+.btn-text {
+  margin-left: 5px;
+  font-family: var(--primary-font);
+  font-size: 16px;
+  line-height: 24px;
+  color: var(--secondary-grey);
+  mix-blend-mode: normal;
 }
 
 @media screen and (max-width: 992px) {
-  .main-wrapper {
-    .cta-btn {
-      .btn-text {
-        font-size: 12px;
-      }
-    }
+  .btn-text {
+    font-size: 12px;
   }
 }
 
@@ -54,16 +46,10 @@
   .main-wrapper {
     padding-left: 30px;
   }
-
-  .btn-text {
-    display: none;
-  }
 }
 
 @media screen and (max-width: 380px) {
-  .main-wrapper {
-    .cta-btn {
-      width: 24px;
-    }
+  .cta-btn {
+    width: 24px;
   }
 }

--- a/src/app/component/comments/components/reply-comment/reply-comment.component.html
+++ b/src/app/component/comments/components/reply-comment/reply-comment.component.html
@@ -1,10 +1,10 @@
-<div class="main-wrapper">
+<div class="d-flex main-wrapper">
   <button class="cta-btn reply">
     <img [src]="replyImages"
           class="btn-img"
           aria-hidden="true"
           alt="reply">
-    <span class="btn-text">
+    <span class="d-none d-sm-block btn-text">
     {{"homepage.eco-news.comment.btn.reply" | translate}}
     </span>
   </button>

--- a/src/app/component/comments/components/reply-comment/reply-comment.component.scss
+++ b/src/app/component/comments/components/reply-comment/reply-comment.component.scss
@@ -1,68 +1,50 @@
-.main-wrapper {
+.reply {
+  width: fit-content;
+  height: 40px;
+}
+
+.cta-btn {
   display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  border: none;
+  background-color: #fff;
+  outline: none;
+}
 
-  .reply {
-    width: fit-content;
-    height: 40px;
-  }
+.btn-img {
+  min-width: 16px;
+  max-height: 16px;
+}
 
-  .cta-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    border: none;
-    background-color: #fff;
-    outline: none;
-
-    .btn-img {
-      min-width: 16px;
-      max-height: 16px;
-    }
-
-    .btn-text {
-      margin-left: 5px;
-      font-family: var(--primary-font);
-      font-size: 16px;
-      line-height: 24px;
-      color: var(--secondary-grey);
-      mix-blend-mode: normal;
-    }
-  }
+.btn-text {
+  margin-left: 5px;
+  font-family: var(--primary-font);
+  font-size: 16px;
+  line-height: 24px;
+  color: var(--secondary-grey);
+  mix-blend-mode: normal;
 }
 
 @media screen and (max-width: 992px) {
-  .main-wrapper {
-    .cta-btn {
-      .btn-text {
-        font-size: 12px;
-      }
-    }
+  .btn-text {
+    font-size: 12px;
   }
 }
 
 @media screen and (max-width: 575px) {
   .main-wrapper {
     margin-left: 5px;
+  }
 
-    .btn-text {
-      display: none;
-    }
-
-    .reply {
-      width: 15px;
-    }
+  .reply {
+    width: 15px;
   }
 }
 
 @media screen and (max-width: 380px) {
-  .main-wrapper {
-    .cta-btn {
-      width: 24px;
-
-      .btn-text {
-        display: none;
-      }
-    }
+  .cta-btn {
+    width: 24px;
   }
 }

--- a/src/app/component/comments/components/reply-comment/reply-comment.component.scss
+++ b/src/app/component/comments/components/reply-comment/reply-comment.component.scss
@@ -31,6 +31,16 @@
   }
 }
 
+@media screen and (max-width: 992px) {
+  .main-wrapper {
+    .cta-btn {
+      .btn-text {
+        font-size: 12px;
+      }
+    }
+  }
+}
+
 @media screen and (max-width: 575px) {
   .main-wrapper {
     margin-left: 5px;

--- a/src/app/component/comments/components/view-replies/view-replies.component.html
+++ b/src/app/component/comments/components/view-replies/view-replies.component.html
@@ -1,7 +1,7 @@
 <button *ngIf="repliesCounter >= 1"
         class="cta-btn view">
   <span class="btn-text">
-    {{ "homepage.eco-news.comment.view" | translate }} {{ repliesCounter }}
+    <span class="hide-text">{{ "homepage.eco-news.comment.view" | translate }} </span>{{ repliesCounter }}
     <ng-container [ngSwitch]="repliesCounter">
       <span *ngSwitchCase="1">{{ "homepage.eco-news.comment.replies.one-reply" | translate }}</span>
       <span

--- a/src/app/component/comments/components/view-replies/view-replies.component.html
+++ b/src/app/component/comments/components/view-replies/view-replies.component.html
@@ -1,7 +1,7 @@
 <button *ngIf="repliesCounter >= 1"
         class="cta-btn view">
   <span class="btn-text">
-    <span class="hide-text">{{ "homepage.eco-news.comment.view" | translate }} </span>{{ repliesCounter }}
+    <span class="d-none d-sm-inline">{{ "homepage.eco-news.comment.view" | translate }} </span>{{ repliesCounter }}
     <ng-container [ngSwitch]="repliesCounter">
       <span *ngSwitchCase="1">{{ "homepage.eco-news.comment.replies.one-reply" | translate }}</span>
       <span

--- a/src/app/component/comments/components/view-replies/view-replies.component.scss
+++ b/src/app/component/comments/components/view-replies/view-replies.component.scss
@@ -20,6 +20,23 @@
 }
 
 .view {
-  width: 140px;
   height: 40px;
+}
+
+@media screen and (max-width: 992px) {
+  .cta-btn {
+    .btn-text {
+      font-size: 12px;
+    }
+  }
+}
+
+@media screen and (max-width: 575px) {
+  .cta-btn {
+    .btn-text {
+      .hide-text {
+        display: none;
+      }
+    }
+  }
 }

--- a/src/app/component/comments/components/view-replies/view-replies.component.scss
+++ b/src/app/component/comments/components/view-replies/view-replies.component.scss
@@ -30,13 +30,3 @@
     }
   }
 }
-
-@media screen and (max-width: 575px) {
-  .cta-btn {
-    .btn-text {
-      .hide-text {
-        display: none;
-      }
-    }
-  }
-}


### PR DESCRIPTION
Bug history https://github.com/ita-social-projects/GreenCity/issues/2018

1. **Buttons "Reply" and "View 1 reply" fall down** - when the user press "Edit" his previous comment. All display resolutions.
in app:
![image](https://user-images.githubusercontent.com/24696596/108830040-95657100-75d1-11eb-872e-678baae41660.png)

but in design:
![image](https://user-images.githubusercontent.com/24696596/108830612-453ade80-75d2-11eb-850c-0f3070b38267.png)

result: 
![image](https://user-images.githubusercontent.com/24696596/108834087-669dc980-75d6-11eb-98c3-daf172c00f12.png)


2. **Overlap buttons.** - in "UK" and "RU" languages, from 992 to 576 resolution.
in app:
![image](https://user-images.githubusercontent.com/24696596/108833422-78cb3800-75d5-11eb-880d-479d40a54db9.png)

missing mockup

result: **changed buttons font-size from 16px to 12px.**
![image](https://user-images.githubusercontent.com/24696596/108834560-ff344980-75d6-11eb-84f8-d97c1f5bb1f1.png)

