### PR TITLE
[Display news: List view] Incorrect size and alignment of UI elements of news item on 'List view' page (1024 resolution Mozilla) #1879

### DIFF
--- a/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.html
+++ b/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.html
@@ -6,7 +6,7 @@
     />
   <div class="eco-news_list-content">
     <div class="filter-tag">
-      <p class="eco-news_list-tag" *ngFor="let tag of ecoNewsModel.tags">
+      <p class="eco-news_list-tag d-inline-block" *ngFor="let tag of ecoNewsModel.tags">
         {{ tag }}
       </p>
     </div>

--- a/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.html
+++ b/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.html
@@ -6,9 +6,9 @@
     />
   <div class="eco-news_list-content">
     <div class="filter-tag">
-      <span class="eco-news_list-tag" *ngFor="let tag of ecoNewsModel.tags">
+      <p class="eco-news_list-tag" *ngFor="let tag of ecoNewsModel.tags">
         {{ tag }}
-      </span>
+      </p>
     </div>
     <div> 
       <div class="eco-news_list-content-title"

--- a/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
+++ b/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
@@ -31,6 +31,7 @@ div {
   text-transform: uppercase;
   color: var(--primary-green);
   margin-right: 5px;
+  display: inline-block;
 }
 
 .eco-news_list-content {
@@ -98,6 +99,7 @@ div {
     width: 100%;
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
+    overflow: hidden;
   }
 
   .eco-news_list-view-wrp {
@@ -111,9 +113,9 @@ div {
 
 @media (min-width: 1024px) {
   .eco-news_list-view-wrp {
-    height: 167px;
-    -ms-grid-columns: 300px auto;
-    grid-template-columns: 300px auto;
+    height: 171px;
+    -ms-grid-columns: 299px auto;
+    grid-template-columns: 299px auto;
   }
 
   .eco-news_list-content-title {

--- a/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
+++ b/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
@@ -31,7 +31,6 @@ div {
   text-transform: uppercase;
   color: var(--primary-green);
   margin-right: 5px;
-  display: inline-block;
 }
 
 .eco-news_list-content {


### PR DESCRIPTION
Bug story https://github.com/ita-social-projects/GreenCity/issues/1879

There are 6 points in the bug story:

1. The size of the image is 299x171.
result 
![image](https://user-images.githubusercontent.com/24696596/109280053-2f702800-7823-11eb-8d19-64d7e04f5c6e.png)

2. The size of the 'News' label is 42x16.
result
![image](https://user-images.githubusercontent.com/24696596/109280290-7eb65880-7823-11eb-8b17-23bee0b24fa3.png)

Points 3,4,5,6 have done by the previous developer.

