### PR TITLE
Fixed incorrect size and alignment of news item on 'List view' page (768 resolution) #1883  Open

### DIFF
--- a/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
+++ b/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
@@ -102,11 +102,11 @@ div {
   }
 
   .eco-news_list-view-wrp {
-    height: 190px;
+    height: 204px;
     display: -ms-grid;
     display: grid;
-    -ms-grid-columns: 190px auto;
-    grid-template-columns: 190px auto;
+    -ms-grid-columns: 204px auto;
+    grid-template-columns: 204px auto;
   }
 }
 


### PR DESCRIPTION
Bug story https://github.com/ita-social-projects/GreenCity/issues/1883
New mockup https://www.figma.com/file/yFVSRLVAA1umR2nSj6B7ba/ITA-Greencity-%D0%A3%D0%91%D0%A1?node-id=12671%3A6429

Expected result:
1. The size of the image is 334x191. - 
  Result: 204x204 by new mockup.
![image](https://user-images.githubusercontent.com/24696596/109803678-04724380-7c2a-11eb-80a6-aaa14a76bf2f.png)

2. The size of the 'News' label is 42x16. - Fixed in task https://github.com/ita-social-projects/GreenCity/issues/1879.
3. The height of the 'Date' label is 21. - 20 height of this block (browser automatically calculated).
4. The height of the 'Author' label is 21. - 20 height of this block (browser automatically calculated).
5. The size of the 'Title' label is 501x78. -  Changed dynamically. Depending on the amount of text. MAX height is really 72.
6. Correct alignment of the news item. - Can't see the bug. Maybe fixed in previous tasks