### PR TITLE
[Accessibility] Eco-news page (focus for 'filter by' and unnecessary regions) / bugs#2330, #2331

### DIFF
--- a/src/app/component/layout/components/header/header.component.html
+++ b/src/app/component/layout/components/header/header.component.html
@@ -7,29 +7,29 @@
       </a>
       <div class="header_navigation-menu" aria-label="Header Navigation Menu">
         <nav [ngClass]="toggleBurgerMenu ? 'header_navigation-menu-left-col' : 'header_navigation-menu-left'">
-          <ul role="navigation">
-            <li role="navigation to news">
+          <ul>
+            <li role="eco-news">
               <a [routerLink]="['/news']" routerLinkActive="active-link" routerLinkActiveOptions="{exact:true}">
                 {{ 'user.lower-nav-bar.eco-events' | translate }}
               </a>
             </li>
-            <li role="navigation to tips and tricks">
+            <li role="tips and tricks">
               <a [routerLink]="['/tips']" routerLinkActive="active-link" routerLinkActiveOptions="{exact:true}">
                 {{ 'user.lower-nav-bar.tips' | translate }}
               </a>
             </li>
-            <li role="navigation to map">
+            <li role="map">
               <a [routerLink]="['/map']" routerLinkActive="active-link" routerLinkActiveOptions="{exact:true}"
                 routerLinkActive="active-link" routerLinkActiveOptions="{exact:true}">
                 {{ 'user.lower-nav-bar.map' | translate }}
               </a>
             </li>
-            <li role="navigation to about us">
+            <li role="about us">
               <a [routerLink]="['/about']" routerLinkActive="active-link" routerLinkActiveOptions="{exact:true}">
                 {{ 'user.lower-nav-bar.about-us' | translate }}
               </a>
             </li>
-            <li role="navigation to profile">
+            <li role="profile">
               <a [routerLink]="['/profile', getUserId()]" routerLinkActive="active-link"
                 routerLinkActiveOptions="{exact:true}">
                 {{ 'user.lower-nav-bar.my-habits' | translate }}

--- a/src/app/component/shared/components/tag-filter/tag-filter.component.html
+++ b/src/app/component/shared/components/tag-filter/tag-filter.component.html
@@ -1,11 +1,12 @@
 <div class="wrapper">
-  <span>{{ header | translate }}</span>
-  <ul class="ul-eco-buttons">
+  <span tabindex="0">{{ header | translate }}</span>
+  <ul class="ul-eco-buttons" aria-label="filter by items">
     <a *ngFor="let filter of filters">
       <li (click)="toggleFilter(filter.name)"
           class="custom-chip global-tag"
-          [ngClass]="{'global-tag-clicked': filter.isActive }">
-          {{ filter.name | translate }}
+          [ngClass]="{'global-tag-clicked': filter.isActive }"
+          tabindex="0"
+        >{{ filter.name | translate }}
         <div [ngClass]="{'global-tag-close-icon': filter.isActive }"></div>
       </li>
     </a>


### PR DESCRIPTION
**Description:**

Bug#2330
**BEFORE:**
‘Filter by’ list doesn't have a name and isn't focusable when using tab navigation.
**AFTER:**
‘Filter by’ list is focusable and SR will read the name of the list  when user using tab navigation.
![f1](https://user-images.githubusercontent.com/70901435/109858301-50da7500-7c64-11eb-9de7-ec3035979329.png)
![f2](https://user-images.githubusercontent.com/70901435/109858311-533ccf00-7c64-11eb-8cec-ba6f75a37f29.png)

Bug#2331
**BEFORE:**
The content on the ‘Eco news’ page is not organized by region landmarks correctly (in navigation are present unnecessary element of regions).
**AFTER:**
The ‘Eco news’ page consist of 3 region landmarks: ‘Navigation’ region landmark (from the list of 5 links below the ‘GreenCity’ graphic link on the top of the page to header ‘Eco news’; ‘Main’ region landmark: from header ‘Eco news’ to ‘Content information’ region landmark (footer); ‘Content information’ region land mark (from Graphic ‘GreenCity Logo’ in footer to the end of the page).
![f3](https://user-images.githubusercontent.com/70901435/109858901-0efdfe80-7c65-11eb-9ee8-3c576525641a.png)

