### PR TITLE
Fixed incorrect resolutions breakpoints and containers size in the 'Eco news - list view' bug#828

### DIFF
--- a/src/app/component/eco-news/components/news-list/news-list-gallery-view/news-list-gallery-view.component.scss
+++ b/src/app/component/eco-news/components/news-list/news-list-gallery-view/news-list-gallery-view.component.scss
@@ -1,7 +1,7 @@
 $bp-smallest: 575px;
 $bp-phone: 767px;
-$bp-tablet: 991px;
-$bp-desktop: 1199px;
+$bp-tablet: 1023px;
+$bp-desktop: 1439px;
 
 p,
 div {
@@ -11,7 +11,7 @@ div {
 
 .list-gallery {
   width: 359px;
-  min-height: 500px;
+  min-height: 528px;
   box-shadow: 1px 1px 12px rgba(27, 51, 38, 0.15);
   background: #fff;
   border-radius: 4px;
@@ -127,11 +127,11 @@ div {
 @media screen and (max-width: $bp-desktop) {
   .list-gallery {
     width: 299px;
-    min-height: 500px;
+    min-height: 528px;
 
     .list-image {
       .list-image-content {
-        height: 172px;
+        height: 206px;
       }
     }
 
@@ -145,12 +145,12 @@ div {
 
 @media screen and (max-width: $bp-tablet) {
   .list-gallery {
-    width: 353px;
-    min-height: 500px;
+    width: 354px;
+    min-height: 528px;
 
     .list-image {
       .list-image-content {
-        height: 202px;
+        height: 206px;
       }
     }
 
@@ -165,11 +165,11 @@ div {
 @media screen and (max-width: $bp-phone) {
   .list-gallery {
     width: 258px;
-    height: 508px;
+    height: 528px;
 
     .list-image {
       .list-image-content {
-        height: 147px;
+        height: 206px;
       }
     }
 
@@ -199,11 +199,11 @@ div {
 @media screen and (max-width: $bp-smallest) {
   .list-gallery {
     width: 288px;
-    height: 508px;
+    height: 528px;
 
     .list-image {
       .list-image-content {
-        height: 166px;
+        height: 206px;
       }
     }
   }

--- a/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
+++ b/src/app/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
@@ -12,7 +12,7 @@ div {
 }
 
 .eco-news_list-view-wrp {
-  height: 185px;
+  height: 192px;
   -webkit-box-shadow: 1px 1px 12px rgba(27, 51, 38, 0.15);
   box-shadow: 1px 1px 12px rgba(27, 51, 38, 0.15);
   border-radius: 4px;
@@ -112,9 +112,9 @@ div {
 
 @media (min-width: 1024px) {
   .eco-news_list-view-wrp {
-    height: 171px;
-    -ms-grid-columns: 299px auto;
-    grid-template-columns: 299px auto;
+    height: 204px;
+    -ms-grid-columns: 359px auto;
+    grid-template-columns: 359px auto;
   }
 
   .eco-news_list-content-title {
@@ -125,15 +125,15 @@ div {
 
 @media (min-width: 1440px) {
   .eco-news_list-content {
-    height: 200px;
+    height: 204px;
     grid-template-rows: 20px 96px 20px;
     word-break: break-all;
   }
 
   .eco-news_list-view-wrp {
-    height: 200px;
-    -ms-grid-columns: 360px auto;
-    grid-template-columns: 360px auto;
+    height: 204px;
+    -ms-grid-columns: 359px auto;
+    grid-template-columns: 359px auto;
   }
 }
 


### PR DESCRIPTION
Bug story https://github.com/ita-social-projects/GreenCity/issues/828

New mockup https://www.figma.com/file/092AhCGadc1Hq8nAysxmYB/ITA-Greencity-%D0%A3%D0%91%D0%A1?node-id=12671%3A6429

Expected result:
1. News item's **container** size at 1200px is 1140x246px- **Done**. 
**Image size** is 359x314,71px. - **359x204 (by new mockup).**

2. News item's **container** size at 1199px-992px is 960x246px. - **960x204 (by new mockup).**
 **Image size** is 359x314,71px. - **359x204 (by new mockup).**

3-4. News item's **container** size at 991-768px is 740x246px. -**720x204(by new mockup).**
 **Image size** is 214x314,71px. - **204x204(by new mockup).**

5-6. News item's container size at 767-576px is scalable. Image is absent. - **Done**

7 . News are displayed in the Gallery view at 575px and less resolution. - **Done**