### PR TITLE
Bugfix/#1795 fix improper message on entering to short password

### DIFF
--- a/src/app/component/auth/components/sign-up/sign-up.validator.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.validator.ts
@@ -25,7 +25,7 @@ export function ValidatorRegExp(controlName: string) {
     if (control.value === '') {
       control.setErrors({ required: true });
     } else {
-      if (controlName === 'password' && control.value.length < 8 ) {
+      if (controlName === 'password' && control.value.length < 8) {
         control.setErrors({ minlength: true });
 
       } else if (!control.value.match(regexp)) {

--- a/src/app/component/auth/components/sign-up/sign-up.validator.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.validator.ts
@@ -27,10 +27,8 @@ export function ValidatorRegExp(controlName: string) {
     } else {
       if (controlName === 'password' && control.value.length < 8) {
         control.setErrors({ minlength: true });
-
       } else if (!control.value.match(regexp)) {
         control.setErrors({ symbolInvalid: true });
-
       } else {
         control.setErrors(null);
       }

--- a/src/app/component/auth/components/sign-up/sign-up.validator.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.validator.ts
@@ -25,8 +25,12 @@ export function ValidatorRegExp(controlName: string) {
     if (control.value === '') {
       control.setErrors({ required: true });
     } else {
-      if (!control.value.match(regexp)) {
+      if (controlName === 'password' && control.value.length < 9 ) {
+        control.setErrors({ minlength: true });
+
+      } else if (!control.value.match(regexp)) {
         control.setErrors({ symbolInvalid: true });
+
       } else {
         control.setErrors(null);
       }

--- a/src/app/component/auth/components/sign-up/sign-up.validator.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.validator.ts
@@ -25,7 +25,7 @@ export function ValidatorRegExp(controlName: string) {
     if (control.value === '') {
       control.setErrors({ required: true });
     } else {
-      if (controlName === 'password' && control.value.length < 9 ) {
+      if (controlName === 'password' && control.value.length < 8 ) {
         control.setErrors({ minlength: true });
 
       } else if (!control.value.match(regexp)) {


### PR DESCRIPTION
In registration forms wasn't  message about short password .

A message has appeared:
"Password has contain at least one character of Uppercase letter (A-Z), Lowercase letter (a-z), Digit (0-9), Special character (~`!@#$%^&*()+=_-{}[]|:;”’?/<>,.)"

A message appears: "Password must be at least 8 characters in length" (Expected result)

I added one else condition for shorter password as 8 characters. 