### PR TITLE
Bugfix/#2394 fix the lato font i used instead of open sans

### DIFF
--- a/src/app/component/user/components/profile/profile-cards/profile-cards.component.scss
+++ b/src/app/component/user/components/profile/profile-cards/profile-cards.component.scss
@@ -19,8 +19,8 @@
 
     .card-description {
       font-size: 11px;
-      line-height: 15px;
-      font-family: var(--primary-font);
+      line-height: 16px;
+      font-family: var(--quaternary-font);
       align-items: center;
     }
 

--- a/src/typography/_fonts.scss
+++ b/src/typography/_fonts.scss
@@ -1,9 +1,11 @@
 @import url('https://fonts.googleapis.com/css?family=Lato&display=swap');
 @import url('https://fonts.googleapis.com/css?family=Montserrat&display=swap');
 @import url('https://fonts.googleapis.com/css?family=Roboto&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Open+Sans&display=swap');
 
 :root {
   --primary-font: 'Lato', sans-serif;
   --secondary-font: 'Montserrat', sans-serif;
   --tertiary-font: 'Roboto', sans-serif;
+  --quaternary-font: 'Open+Sans', sans-serif;
 }


### PR DESCRIPTION
The Lato font is used in the description of the fact instead of Open Sans (fact of the day in the profile page).

The wrong result was Lato font and line-height - 15. 
I didn't change font-size. At the new mockup we have 11px for that.

For this i set Open+Sans font globally.

var( --quaternary-font) is 'Open+Sans'.

