### PR TITLE
[Dependencies]  updating the dependencies on demand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3275,6 +3275,14 @@
         "schema-utils": "^1.0.0",
         "serialize-javascript": "^1.7.0",
         "webpack-log": "^2.0.0"
+      },
+      "dependencies": {
+        "serialize-javascript": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+          "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
+          "dev": true
+        }
       }
     },
     "core-js": {
@@ -8953,7 +8961,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -9535,10 +9542,12 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
-      "dev": true
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "serve-index": {
       "version": "1.9.1",
@@ -10585,6 +10594,12 @@
         "worker-farm": "^1.7.0"
       },
       "dependencies": {
+        "serialize-javascript": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+          "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "ngx-swiper-wrapper": "^8.0.2",
     "node-forge": "^0.10.0",
     "rxjs": "~6.4.0",
+    "serialize-javascript": "^5.0.1",
     "socket.io": "^4.0.0",
     "sockjs-client": "^1.5.0",
     "ssri": "^8.0.1",


### PR DESCRIPTION
**This PR contains upgrades of the following dependencies:**

- ssri: 6.0.1-> 8.0.1
- y18n: 4.0.1 -> 5.0.5
- elliptic: 6.5.4 -> 6.5.4
- socket.io: 2.1.1 -> 4.0.0
- ini: 1.3.5 -> 2.0.0
- webpack-subresource-integrity: 1.5.1 -> 1.5.2
- node-forge: 0.10.0 -> 0.10.0
- yargs-parser: 13.1.2 -> 20.2.7
- tree-kill: 1.2.2 -> 1.2.2
- websocket-extensions: 0.1.4 -> 0.1.4
- minimist: 1.2.3 -> 1.2.5
- kind-of: 6.0.3 -> 6.0.3
- serialize-javascript: 3.1.0 -> 5.0.1