### PR TITLE
Fix confirmation message overlaps on home page

### DIFF
--- a/src/app/component/auth/components/sign-up/sign-up.component.spec.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.component.spec.ts
@@ -135,15 +135,6 @@ describe('SignUpComponent', () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    it('should call openSignUpPopup', () => {
-      // @ts-ignore
-      spyOn(component.dialog, 'open');
-      // @ts-ignore
-      component.openSignUpPopup();
-      // @ts-ignore
-      expect(component.dialog).toBeDefined();
-    });
-
     it('should emit "sign-in" after calling openSignInWindow', () => {
       component.openSignInWindow();
       // @ts-ignore
@@ -313,28 +304,6 @@ describe('SignUpComponent', () => {
         component.signUpWithGoogleSuccess(mockUserSuccessSignIn);
         fixture.ngZone.run(() => {
           expect(routerSpy.navigate).toHaveBeenCalledWith(['/profile', mockUserSuccessSignIn.userId]);
-        });
-        fixture.destroy();
-        flush();
-      }));
-
-      it('onSubmitSuccess should call openSignUpPopup', fakeAsync(() => {
-        const mockSuccessSignUp = {
-          email: 'test@gmail.com',
-          ownRegistrations: true,
-          userId: '23',
-          username: 'UserName'
-        };
-        // @ts-ignore
-        spyOn(component, 'openSignUpPopup');
-        // @ts-ignore
-        component.onSubmitSuccess(mockSuccessSignUp);
-        fixture.detectChanges();
-        fixture.ngZone.run(() => {
-          fixture.whenStable().then(() => {
-            // @ts-ignore
-            expect(component.openSignUpPopup).toHaveBeenCalled();
-          });
         });
         fixture.destroy();
         flush();

--- a/src/app/component/auth/components/sign-up/sign-up.component.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.component.ts
@@ -161,19 +161,9 @@ export class SignUpComponent implements OnInit, OnDestroy {
 
   private onSubmitSuccess(data: SuccessSignUpDto): void {
     this.loadingAnim = false;
-    // this.openSignUpPopup();
     this.closeSignUpWindow();
     this.snackBar.openSnackBar('signUp');
   }
-
-  // private openSignUpPopup(): void {
-  //   this.dialog.open(SubmitEmailComponent, {
-  //     hasBackdrop: true,
-  //     closeOnNavigation: true,
-  //     disableClose: false,
-  //     panelClass: 'custom-dialog-container',
-  //   });
-  // }
 
   private closeSignUpWindow(): void {
     this.matDialogRef.close();

--- a/src/app/component/auth/components/sign-up/sign-up.component.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.component.ts
@@ -161,19 +161,19 @@ export class SignUpComponent implements OnInit, OnDestroy {
 
   private onSubmitSuccess(data: SuccessSignUpDto): void {
     this.loadingAnim = false;
-    this.openSignUpPopup();
+    // this.openSignUpPopup();
     this.closeSignUpWindow();
     this.snackBar.openSnackBar('signUp');
   }
 
-  private openSignUpPopup(): void {
-    this.dialog.open(SubmitEmailComponent, {
-      hasBackdrop: true,
-      closeOnNavigation: true,
-      disableClose: false,
-      panelClass: 'custom-dialog-container',
-    });
-  }
+  // private openSignUpPopup(): void {
+  //   this.dialog.open(SubmitEmailComponent, {
+  //     hasBackdrop: true,
+  //     closeOnNavigation: true,
+  //     disableClose: false,
+  //     panelClass: 'custom-dialog-container',
+  //   });
+  // }
 
   private closeSignUpWindow(): void {
     this.matDialogRef.close();


### PR DESCRIPTION
After the user is successfully registered additional 'Confirmation' message overlaps on page.

I removed message as superfluous.
For this remove one function and fixed tests.