### PR TITLE
Bugfix/#2500  no validation message when the name ends with a dot or contain 3 dots in a row

### DIFF
--- a/src/app/component/auth/components/sign-up/sign-up.validator.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.validator.ts
@@ -18,7 +18,7 @@ export function ConfirmPasswordValidator(controlName: string, matchingControlNam
 
 export function ValidatorRegExp(controlName: string) {
   return (formGroup: FormGroup) => {
-    const regexpName = /(?:^[a-z0-9][a-z0-9\.]{5,29})+(?:[^\.]+\z)$/gi;
+    const regexpName = /^(?!\.)(?!.*\.$)(?!.*?\.\.)[a-zA-Z0-9_.]+$/gi;
     const regexpPass = /^(?=.*[a-z]+)(?=.*[A-Z]+)(?=.*\d+)(?=.*[~`!@#$%^&*()+=_\-{}|:;”’?/<>,.\]\[]+).{8,}$/;
     const regexp = controlName === 'firstName' ? regexpName : regexpPass;
     const control = formGroup.controls[controlName];

--- a/src/app/component/auth/components/sign-up/sign-up.validator.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.validator.ts
@@ -18,7 +18,7 @@ export function ConfirmPasswordValidator(controlName: string, matchingControlNam
 
 export function ValidatorRegExp(controlName: string) {
   return (formGroup: FormGroup) => {
-    const regexpName = /^(?!\.)(?!.*\.$)(?!.*?\.\.)[a-zA-Z0-9_.]+$/gi;
+    const regexpName = /^(?!\.)(?!.*\.$)(?!.*?\.\.)[a-zA-Z0-9_.]{5,29}$/gi;
     const regexpPass = /^(?=.*[a-z]+)(?=.*[A-Z]+)(?=.*\d+)(?=.*[~`!@#$%^&*()+=_\-{}|:;”’?/<>,.\]\[]+).{8,}$/;
     const regexp = controlName === 'firstName' ? regexpName : regexpPass;
     const control = formGroup.controls[controlName];

--- a/src/app/component/auth/components/sign-up/sign-up.validator.ts
+++ b/src/app/component/auth/components/sign-up/sign-up.validator.ts
@@ -18,7 +18,7 @@ export function ConfirmPasswordValidator(controlName: string, matchingControlNam
 
 export function ValidatorRegExp(controlName: string) {
   return (formGroup: FormGroup) => {
-    const regexpName = /^[a-z0-9][a-z0-9\.]{5,29}$/gi;
+    const regexpName = /(?:^[a-z0-9][a-z0-9\.]{5,29})+(?:[^\.]+\z)$/gi;
     const regexpPass = /^(?=.*[a-z]+)(?=.*[A-Z]+)(?=.*\d+)(?=.*[~`!@#$%^&*()+=_\-{}|:;”’?/<>,.\]\[]+).{8,}$/;
     const regexp = controlName === 'firstName' ? regexpName : regexpPass;
     const control = formGroup.controls[controlName];


### PR DESCRIPTION
Now, the message will appear if a user will input the dot at the end of the name or put consecutive dots

proof:
**case with a dot at the end**
![зображення](https://user-images.githubusercontent.com/46484914/113482002-4995c980-94a5-11eb-9e37-36bef163d62d.png)


**case with a consecutive dots**

![зображення](https://user-images.githubusercontent.com/46484914/113482024-629e7a80-94a5-11eb-941a-311241f297d4.png)


link to the bug: https://github.com/ita-social-projects/GreenCity/issues/2500