### PR TITLE
[Edit Profile] Mistakes in the titles - 'Edit Profile', 'Add Social Network', 'Profile Privacy' #2638

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -508,7 +508,7 @@
       "my-habits": "My habits"
     },
     "edit-profile": {
-      "edit-profile": "Edit profile",
+      "edit-profile": "Edit Profile",
       "info": "Personal info",
       "name": "Name",
       "name-warning": "Should contain maximum 30 symbols",
@@ -517,8 +517,8 @@
       "title": "Credo",
       "title-warning": "Should contain maximum 170 symbols",
       "links": "Linked social networks",
-      "add-link": "Add social network",
-      "privacy": "Profile privacy",
+      "add-link": "Add Social Network",
+      "privacy": "Profile Privacy",
       "location": "Show my location",
       "eco-place": "Show my eco places",
       "shoping-list": "Show my shopping list",


### PR DESCRIPTION
**Before:**
  1. One word in 'Edit Profile' title is in lowercase
  2. Scroll down to the 'Add Social Network' button, title is in lowercase
  3. Scroll down to the 'Profile Privacy' checkbox, the word in 'Profile Privacy' title is in lowercase

**After:**
  1. Two words in 'Edit Profile' title must be in uppercase according to the mock-up
  2. Three words in 'Add Social Network' button must be in uppercase
  3. Two words in 'Profile Privacy' checkbox must be in uppercase