### PR TITLE
[Edit profile] 'Save' button should be disabled by default if user doesn't change any info #2649

### DIFF
--- a/src/app/component/user/components/profile/edit-profile/edit-profile.component.html
+++ b/src/app/component/user/components/profile/edit-profile/edit-profile.component.html
@@ -1,9 +1,9 @@
 <div class="container">
     <h2>{{ "user.edit-profile.edit-profile" | translate }}</h2>
     <app-personal-photo></app-personal-photo>
-    <form #formEditProf 
-        [formGroup]="editProfileForm" 
-        (ngSubmit)="onSubmit()" 
+    <form #formEditProf
+        [formGroup]="editProfileForm"
+        (ngSubmit)="onSubmit()"
         (keydown.enter)="$event.preventDefault()">
         <div class="wrapper">
             <p>{{ "user.edit-profile.info" | translate }}</p>
@@ -73,7 +73,7 @@
         </div>
         <div class="buttons">
             <button type="button" (click)="cancel()">{{"user.edit-profile.btn.cancel" | translate }}</button>
-            <button type="submit" [disabled]="!editProfileForm.valid">{{"user.edit-profile.btn.save" | translate }}</button>
+            <button type="submit" [disabled]="!editProfileForm.valid || editProfileForm.pristine">{{"user.edit-profile.btn.save" | translate }}</button>
         </div>
     </form>
 </div>


### PR DESCRIPTION
# Problem:
## When a user goes to the edit profile page submit button should be disabled if no changes were applied.

# Actual result: 
![image](https://user-images.githubusercontent.com/43093994/115561429-39138a80-a2be-11eb-85ca-8912b126760e.png)

# Expected result:
## Save' button should be disabled while the user doesn't make any changes on the page

# Result:
### no changes
![image](https://user-images.githubusercontent.com/43093994/115561709-82fc7080-a2be-11eb-92e1-2ac9a7f13ef4.png)
### name changed
![image](https://user-images.githubusercontent.com/43093994/115561720-84c63400-a2be-11eb-8c1e-a9e66adb4c88.png)
