### PR TITLE
bugfix/#2659 Fixing the padding and title sizes of Source section of Eco news

### DIFF
--- a/src/app/component/eco-news/components/eco-news-detail/eco-news-detail.component.scss
+++ b/src/app/component/eco-news/components/eco-news-detail/eco-news-detail.component.scss
@@ -141,7 +141,7 @@ $bp-largest: 1440px;
 }
 
 .news-text {
-  margin-left: 74px;
+  margin-left: 3rem;
   color: #000;
   text-align: left;
   width: 100%;
@@ -161,7 +161,7 @@ $bp-largest: 1440px;
 
 .source-title {
   font-family: var(--primary-font);
-  font-size: 24px;
+  font-size: 1.2rem;
   line-height: 40px;
   color: var(--primary-dark-grey);
   mix-blend-mode: normal;

--- a/src/app/component/eco-news/components/eco-news-detail/eco-news-detail.component.scss
+++ b/src/app/component/eco-news/components/eco-news-detail/eco-news-detail.component.scss
@@ -173,7 +173,6 @@ $bp-largest: 1440px;
   max-width: 631px;
   font-size: 18px;
   line-height: 32px;
-  color: #000;
   margin-top: 6px;
 }
 


### PR DESCRIPTION
**the result:**

![2](https://user-images.githubusercontent.com/46484914/115594667-acc58f80-a2de-11eb-8f35-314fd507680d.png)


link to the original task: https://github.com/ita-social-projects/GreenCity/issues/2659