### PR TITLE
[Edit Profile] User is not able to close the 'Cancel' editing pop-up by clicking on 'Cross' option in the top right corner of the notification. #2672

### DIFF
--- a/src/app/component/shared/components/warning-pop-up/warning-pop-up.component.html
+++ b/src/app/component/shared/components/warning-pop-up/warning-pop-up.component.html
@@ -1,4 +1,7 @@
 <div class="main-container">
+  <button class="close" (click)="userReply(false)">
+    <img src="{{ closeButton }}" alt="close">
+  </button>
   <div class="warning-text">
     <div class="warning-title" *ngIf="popupTitle">
       {{ popupTitle | translate }}

--- a/src/app/component/shared/components/warning-pop-up/warning-pop-up.component.scss
+++ b/src/app/component/shared/components/warning-pop-up/warning-pop-up.component.scss
@@ -1,4 +1,5 @@
 .main-container {
+  position: relative;
   max-width: 568px;
   height: 256px;
   padding: 56px;
@@ -6,6 +7,15 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+
+  .close {
+    position: absolute;
+    top: 26px;
+    right: 26px;
+    border: none;
+    background-color: transparent;
+    outline: none;
+  }
 }
 
 .warning-text {

--- a/src/app/component/shared/components/warning-pop-up/warning-pop-up.component.ts
+++ b/src/app/component/shared/components/warning-pop-up/warning-pop-up.component.ts
@@ -14,6 +14,7 @@ export class WarningPopUpComponent implements OnInit, OnDestroy {
   public popupSubtitle: string;
   public popupConfirm: string;
   public popupCancel: string;
+  public closeButton = './assets/img/profile/icons/cancel.svg';
   private destroyed$: ReplaySubject<any> = new ReplaySubject<any>(1);
 
   constructor(private matDialogRef: MatDialogRef<WarningPopUpComponent>,


### PR DESCRIPTION
**Before**
The 'Cancel' editing profile pop-up of a mockup and application is missing the 'Cross' in the top right corner.
![image](https://user-images.githubusercontent.com/66681131/116206274-4c53a980-a747-11eb-9f9e-43635a8fa1f1.png)

**After**
![image](https://user-images.githubusercontent.com/66681131/116206108-24644600-a747-11eb-9933-6e256976ea2a.png)
