### PR TITLE
[Edit Profile] Mistakes in the titles - 'Edit Profile', 'Add Social Network', 'Profile Privacy' #2638

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -508,7 +508,7 @@
       "my-habits": "My habits"
     },
     "edit-profile": {
-      "edit-profile": "Edit profile",
+      "edit-profile": "Edit Profile",
       "edit-button": "Edit Picture",
       "info": "Personal info",
       "name": "Name",
@@ -518,8 +518,8 @@
       "title": "Credo",
       "title-warning": "Should contain maximum 170 symbols",
       "links": "Linked social networks",
-      "add-link": "Add Social Network",
-      "privacy": "Profile Privacy",
+      "add-link": "add social network",
+      "privacy": "profile privacy",
       "location": "Show my location",
       "eco-place": "Show my eco places",
       "shoping-list": "Show my shopping list",


### PR DESCRIPTION
Before
Pay attention to capitalization
1. Scroll down to the 'Add social network' button, title is in uppercase (see the attachment 1)
2. Scroll down to the 'Profile privacy' checkbox, the word in 'Profile privacy' title is in uppercase (see the attachment 1)

After
1. Three words in 'Add social network' button must be in lowercase (see the attachment 2)
2. Two words in 'Profile privacy' checkbox must be in lowercase (see the attachment 2)
 
![Screenshot_4](https://user-images.githubusercontent.com/82227122/116242242-66ed4900-a76e-11eb-9c9f-8bec9d122ade.png)

![Screenshot_5](https://user-images.githubusercontent.com/82227122/116242258-6a80d000-a76e-11eb-98e7-4d45cb6718fc.png)