### PR TITLE
bugfix/#2712 Renaming UBS nav link

### DIFF
--- a/src/app/component/layout/components/header/header.component.html
+++ b/src/app/component/layout/components/header/header.component.html
@@ -39,7 +39,7 @@
               </a>
             </li>
             <li role="link">
-              <a [routerLink]="['/ubs']" routerLinkActive="active-link" routerLinkActiveOptions="{exact:true}"> UBS </a>
+              <a [routerLink]="['/ubs']" routerLinkActive="active-link" routerLinkActiveOptions="{exact:true}"> UBS courier</a>
             </li>
             <hr class="header_line container" [ngClass]="{ 'd-none': !toggleBurgerMenu }" />
             <div *ngIf="!isLoggedIn; then userLoggedInSmall; else userNotLoggerInSmall"></div>

--- a/src/app/component/layout/components/header/header.component.html
+++ b/src/app/component/layout/components/header/header.component.html
@@ -39,7 +39,9 @@
               </a>
             </li>
             <li role="link">
-              <a [routerLink]="['/ubs']" routerLinkActive="active-link" routerLinkActiveOptions="{exact:true}"> UBS courier</a>
+              <a [routerLink]="['/ubs']" routerLinkActive="active-link" routerLinkActiveOptions="{exact:true}">{{
+                'user.lower-nav-bar.ubs' | translate
+              }}</a>
             </li>
             <hr class="header_line container" [ngClass]="{ 'd-none': !toggleBurgerMenu }" />
             <div *ngIf="!isLoggedIn; then userLoggedInSmall; else userNotLoggerInSmall"></div>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -253,7 +253,6 @@
     "add-cafe": "Add a cafe",
     "admin": "Administrator",
     "my-habits": "My habits",
-    "ubs": "UBS courier",
     "profile": "Profile",
     "user-settings": "Settings",
     "sign-out": "Sign out",
@@ -562,7 +561,6 @@
       "tips": "Tips & Tricks",
       "map": "Places",
       "my-habits": "My habits",
-      "ubs": "UBS courier",
       "follow-us": "Follow us"
     },
     "user-goals": {
@@ -733,7 +731,6 @@
     },
     "dashboard": {
       "my-habits": "My habits",
-      "ubs": "UBS courier",
       "my-news": "My news",
       "my-articles": "My articles",
       "my-tips-and-tricks": "My tips and tricks",
@@ -761,7 +758,6 @@
     "written-articles": "written articles",
     "published-news": "published news",
     "my-habits": "My Habits",
-    "ubs": "UBS courier",
     "my-news": "My news",
     "my-articles": "My articles",
     "friends": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -253,6 +253,7 @@
     "add-cafe": "Add a cafe",
     "admin": "Administrator",
     "my-habits": "My habits",
+    "ubs": "UBS courier",
     "profile": "Profile",
     "user-settings": "Settings",
     "sign-out": "Sign out",
@@ -505,6 +506,7 @@
       "eco-events": "Eco news",
       "tips": "Tips & Tricks",
       "map": "Places",
+      "ubs": "UBS courier",
       "my-habits": "My habits"
     },
     "edit-profile": {
@@ -560,6 +562,7 @@
       "tips": "Tips & Tricks",
       "map": "Places",
       "my-habits": "My habits",
+      "ubs": "UBS courier",
       "follow-us": "Follow us"
     },
     "user-goals": {
@@ -730,6 +733,7 @@
     },
     "dashboard": {
       "my-habits": "My habits",
+      "ubs": "UBS courier",
       "my-news": "My news",
       "my-articles": "My articles",
       "my-tips-and-tricks": "My tips and tricks",
@@ -757,6 +761,7 @@
     "written-articles": "written articles",
     "published-news": "published news",
     "my-habits": "My Habits",
+    "ubs": "UBS courier",
     "my-news": "My news",
     "my-articles": "My articles",
     "friends": {

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -258,7 +258,6 @@
     "add-cafe": "Добавить кафе",
     "admin": "Администратор",
     "my-habits": "Мои привычки",
-    "ubs": "UBS курьер",
     "profile": "Мой кабинет",
     "user-settings": "Настройки",
     "sign-out": "Выйти",
@@ -566,7 +565,6 @@
       "eco-events": "Эко новости",
       "tips": "Советы",
       "map": "Места",
-      "ubs": "UBS курьер",
       "my-habits": "Мои привычки",
       "follow-us": "Присоединяйтесь к нам"
     },
@@ -740,7 +738,6 @@
     "dashboard": {
       "my-habits": "Мои привычки",
       "my-news": "Мои новости",
-      "ubs": "UBS курьер",
       "my-tips-and-tricks": "Мои статьи",
       "habits-inprogress": "В процессе",
       "add-new-habit": "Добавить новую привычку",
@@ -762,7 +759,6 @@
     "no-eco-places": "У вас нет Эко Мест.",
     "online": "онлайн",
     "my-habits": "Мои привычки",
-    "ubs": "UBS курьер",
     "my-news": "Мои новости",
     "my-articles": "Мои статьи",
     "friends": {

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -258,6 +258,7 @@
     "add-cafe": "Добавить кафе",
     "admin": "Администратор",
     "my-habits": "Мои привычки",
+    "ubs": "UBS курьер",
     "profile": "Мой кабинет",
     "user-settings": "Настройки",
     "sign-out": "Выйти",
@@ -510,6 +511,7 @@
       "eco-events": "Эко новости",
       "tips": "Эко советы",
       "map": "Карта",
+      "ubs": "UBS курьер",
       "my-habits": "Мой кабинет"
     },
     "edit-profile": {
@@ -564,6 +566,7 @@
       "eco-events": "Эко новости",
       "tips": "Советы",
       "map": "Места",
+      "ubs": "UBS курьер",
       "my-habits": "Мои привычки",
       "follow-us": "Присоединяйтесь к нам"
     },
@@ -737,6 +740,7 @@
     "dashboard": {
       "my-habits": "Мои привычки",
       "my-news": "Мои новости",
+      "ubs": "UBS курьер",
       "my-tips-and-tricks": "Мои статьи",
       "habits-inprogress": "В процессе",
       "add-new-habit": "Добавить новую привычку",
@@ -758,6 +762,7 @@
     "no-eco-places": "У вас нет Эко Мест.",
     "online": "онлайн",
     "my-habits": "Мои привычки",
+    "ubs": "UBS курьер",
     "my-news": "Мои новости",
     "my-articles": "Мои статьи",
     "friends": {

--- a/src/assets/i18n/ua.json
+++ b/src/assets/i18n/ua.json
@@ -258,7 +258,6 @@
     "add-cafe": "Додати кафе",
     "admin": "Адміністратор",
     "my-habits": "Мої звички",
-    "ubs": "UBS кур'єр",
     "profile": "Мій кабінет",
     "user-settings": "Налаштування",
     "sign-out": "Вийти",
@@ -567,7 +566,6 @@
       "tips": "Поради",
       "map": "Місця",
       "my-habits": "Мої звички",
-      "ubs": "UBS кур'єр",
       "follow-us": "Приєднуйтесь до нас"
     },
     "user-goals": {
@@ -751,7 +749,6 @@
     },
     "dashboard": {
       "my-habits": "Мої звички",
-      "ubs": "UBS кур'єр",
       "my-news": "Мої новини",
       "my-tips-and-tricks": "Мої статті",
       "habits-inprogress": "У процесі",
@@ -774,7 +771,6 @@
     "no-eco-places": "У вас немає Еко Місць.",
     "online": "онлайн",
     "my-habits": "Мої звички",
-    "ubs": "UBS кур'єр",
     "my-news": "Мої новини",
     "my-articles": "Мої статті",
     "friends": {

--- a/src/assets/i18n/ua.json
+++ b/src/assets/i18n/ua.json
@@ -258,6 +258,7 @@
     "add-cafe": "Додати кафе",
     "admin": "Адміністратор",
     "my-habits": "Мої звички",
+    "ubs": "UBS кур'єр",
     "profile": "Мій кабінет",
     "user-settings": "Налаштування",
     "sign-out": "Вийти",
@@ -510,6 +511,7 @@
       "eco-events": "Еко новини",
       "tips": "Поради",
       "map": "Карта",
+      "ubs": "UBS кур'єр",
       "my-habits": "Мій кабінет"
     },
     "edit-profile": {
@@ -565,6 +567,7 @@
       "tips": "Поради",
       "map": "Місця",
       "my-habits": "Мої звички",
+      "ubs": "UBS кур'єр",
       "follow-us": "Приєднуйтесь до нас"
     },
     "user-goals": {
@@ -748,6 +751,7 @@
     },
     "dashboard": {
       "my-habits": "Мої звички",
+      "ubs": "UBS кур'єр",
       "my-news": "Мої новини",
       "my-tips-and-tricks": "Мої статті",
       "habits-inprogress": "У процесі",
@@ -770,6 +774,7 @@
     "no-eco-places": "У вас немає Еко Місць.",
     "online": "онлайн",
     "my-habits": "Мої звички",
+    "ubs": "UBS кур'єр",
     "my-news": "Мої новини",
     "my-articles": "Мої статті",
     "friends": {


### PR DESCRIPTION
Navigation-link has been renamed: UBS -> UBS courier
![зображення](https://user-images.githubusercontent.com/46484914/116777798-02383400-aa77-11eb-81d6-d684ce9b7b7a.png)

original task: https://github.com/ita-social-projects/GreenCity/issues/2712
