### PR TITLE
[Create news] User can published news with empty fields, after click on button 'Preview' #2653

### DIFF
--- a/src/app/component/eco-news/components/create-edit-news/create-edit-news.component.ts
+++ b/src/app/component/eco-news/components/create-edit-news/create-edit-news.component.ts
@@ -81,8 +81,8 @@ export class CreateEditNewsComponent extends FormBaseComponent implements OnInit
   public setInitialValues(): void {
     if (!this.createEcoNewsService.isBackToEditing) {
       this.initialValues = this.getFormValues();
-      this.isFormInvalid = !!!this.newsId;
     }
+    this.isFormInvalid = !!!this.newsId;
     this.onValueChanges();
   }
 


### PR DESCRIPTION
**Before**
Button 'Publish' is enabled. After click on 'Publish' button, opens new page(as on mock up). In result all buttons on page do not respond to clicks.

**After**
Button 'Publish' is disabled. User can`t published news.