### PR TITLE
[Eco News] The text inside of the button 'Create news' is movable #2695

### DIFF
--- a/src/app/component/eco-news/components/news-list/news-list.component.scss
+++ b/src/app/component/eco-news/components/news-list/news-list.component.scss
@@ -64,6 +64,8 @@ a {
 }
 
 #create-button {
+  border-radius: 5px;
+  line-height: 16px;
   width: 183px;
   min-height: 40px;
   padding: 8px 40px;


### PR DESCRIPTION
**Before**
The text inside of the button 'Create news' is movable
Border-radius of 'Create news' button is 3 px

**After**
The text inside of the button shouldn't be movable
Border-radius of 'Create news button' should be 5 px