### PR TITLE
[Create news] Wrong message appears after user clicks 'Publish' button (English localization) #2691

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -721,7 +721,7 @@
   },
   "post-news-loader": {
     "text-1": "Please wait while loading...",
-    "text-2": "Your news is loading to the website. Please wait until the page refreshes."
+    "text-2": "Your news is loading to website. Please wait until page refreshes."
   },
   "profile": {
     "calendar": {


### PR DESCRIPTION
**Before**
A message with the following text appears "Please wait while loading... Your news is loading to **the** website. Please wait until **the** page refreshes"

**After**
A message with the following text appears "Please wait while loading... Your news is loading to website. Please wait until page refresh."
<img width="427" alt="1" src="https://user-images.githubusercontent.com/82234978/116457830-8ff40380-a86c-11eb-8acf-2980bb29e3ba.PNG">
