### PR TITLE
[Forgot password] The 'or sign in with' text is shown insted of the 'or' text #2685

### DIFF
--- a/src/app/main/component/auth/components/restore-password/restore-password.component.html
+++ b/src/app/main/component/auth/components/restore-password/restore-password.component.html
@@ -27,7 +27,7 @@
       <span *ngIf="loadingAnim" class="spinner-border spinner-border-sm" role="status" aria-hidden="true"> </span>
       {{ 'user.auth.forgot-password.send-btn' | translate }}
     </button>
-    <span class="or-use-google">{{ 'user.auth.forgot-password.or-signin' | translate }}</span>
+    <span class="or-use-google">{{ 'user.auth.sign-up.or' | translate }}</span>
     <app-google-btn
       (click)="signInWithGoogle()"
       class="google-sing-in-button"


### PR DESCRIPTION
**Before**
The 'or sign in with' text is shown between two buttons
![bug1](https://user-images.githubusercontent.com/79053863/116275342-374d3980-a78c-11eb-9653-99212483d487.png)

**After**
The 'or' text is shown between two buttons
![bug1](https://user-images.githubusercontent.com/79053863/116275518-6499e780-a78c-11eb-8239-65e46208b2f9.png)