### PR TITLE
[Bugfix: UBS] Fix 'Next' button and remove empty orders for 3 step #2833

### DIFF
--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.html
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.html
@@ -234,13 +234,7 @@
         <div class="w-100 d-flex justify-content-end">
           <div>
             <button class="secondary-global-button btn btn-main" matStepperPrevious>{{ 'order-details.cancel' | translate }}</button>
-            <button
-              [disabled]="showTotal < 500"
-              type="submit"
-              (click)="submitStep()"
-              class="primary-global-button btn btn-main"
-              matStepperNext
-            >
+            <button [disabled]="showTotal < 500" type="submit" class="primary-global-button btn btn-main" matStepperNext>
               {{ 'order-details.next' | translate }}
             </button>
           </div>

--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -211,15 +211,6 @@ export class UBSOrderDetailsComponent implements OnInit, OnDestroy {
     this.calculateTotal();
   }
 
-  public submitStep() {
-    this.bags.forEach((bag) => {
-      const valueName = 'quantity' + String(bag.id);
-      if (this.orderDetailsForm.controls[valueName].value == null) {
-        this.orderDetailsForm.controls[valueName].setValue('0');
-      }
-    });
-  }
-
   calculatePoints(): void {
     if (this.certificateSum <= 0) {
       this.showTotal = this.total;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/43093994/120179030-c7125780-c212-11eb-844b-8539be7d1d26.png)

After:
![image](https://user-images.githubusercontent.com/43093994/120179080-d2fe1980-c212-11eb-9702-ec2892b132c0.png)
