### PR TITLE
Bugfix/#2743-fix-search-field-spec-syms-support

### DIFF
--- a/src/app/main/service/search/search.service.ts
+++ b/src/app/main/service/search/search.service.ts
@@ -18,7 +18,8 @@ export class SearchService {
   public allElements: SearchDto;
 
   public getAllResults(searchQuery: string, lang: string): Observable<SearchModel> {
-    return this.http.get<SearchModel>(`${this.backEndLink}search?searchQuery=${searchQuery}&lang=${lang}`);
+    const processedSearchQuery = encodeURIComponent(searchQuery);
+    return this.http.get<SearchModel>(`${this.backEndLink}search?searchQuery=${processedSearchQuery}&lang=${lang}`);
   }
 
   public getAllResultsByCat(


### PR DESCRIPTION
CORS does not accept a few spec characters so we need to escape them with encodeURIComponent function