### PR TITLE
Bugfix/#2734 Added dot at the end of the sentence after searching tex…

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -122,7 +122,7 @@
       "see-all-tips": "See all Tips & Tricks"
     },
     "search-not-found": {
-      "not-found-text": "We couldn't find results for '{{searchQuery}}' Please change the search.",
+      "not-found-text": "We couldn't find results for '{{searchQuery}}'. Please change the search.",
       "choose-alternative": "Maybe you can find some interesting stuff here:",
       "alternative-header-news": "News",
       "alternative-description-news": "Find the latest news, events and initiatives here. Find news and create ones.",


### PR DESCRIPTION
Before: The dot is missed at the end of the sentence after searching text which couldn't be found.
image
![image](https://user-images.githubusercontent.com/39774581/122419989-00c5bb00-cf94-11eb-9a19-a79b096863eb.png)
After:
![image](https://user-images.githubusercontent.com/39774581/122420025-07543280-cf94-11eb-88a5-da68f750a9e3.png)
