### PR TITLE
Bugfix/#2704 mobile nav scroll fix

### DIFF
--- a/src/app/main/component/layout/components/header/header.component.scss
+++ b/src/app/main/component/layout/components/header/header.component.scss
@@ -141,7 +141,7 @@ $white-color: #fff;
   background: $white-color;
   transition: transform 0.2s ease-in, top 0.2s linear 0.2s;
   box-shadow: 0 4px 5px -2px rgba(73, 74, 73, 0.2);
-  overflow: auto;
+  overflow-y: scroll;
 
   ul {
     display: flex;
@@ -151,6 +151,7 @@ $white-color: #fff;
     overflow: hidden;
     padding: 0;
     width: 100%;
+    height: 550px;
 
     li {
       height: 52px;

--- a/src/app/main/component/layout/components/header/header.component.scss
+++ b/src/app/main/component/layout/components/header/header.component.scss
@@ -141,7 +141,7 @@ $white-color: #fff;
   background: $white-color;
   transition: transform 0.2s ease-in, top 0.2s linear 0.2s;
   box-shadow: 0 4px 5px -2px rgba(73, 74, 73, 0.2);
-  overflow-y: scroll;
+  overflow-y: auto;
 
   ul {
     display: flex;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,10 +4,6 @@
 @import 'typography/typography';
 @import 'typography/typographyUbs';
 
-//html {
-//  overflow-y: auto !important;
-//}
-
 .hide {
   display: none;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,9 +4,9 @@
 @import 'typography/typography';
 @import 'typography/typographyUbs';
 
-html {
-  overflow-y: auto !important;
-}
+//html {
+//  overflow-y: auto !important;
+//}
 
 .hide {
   display: none;
@@ -19,6 +19,7 @@ a {
 body {
   margin: 0;
   font-family: var(--tertiary-font);
+  overflow-y: auto;
 }
 
 // Temporary fix for google autocomplit


### PR DESCRIPTION
The way problem solved is by transferring overflow: auto prop from html to body. Because of that the .modal-open class now has effect on the body's overflow so we can hide it while hamburger is open. Also, to get scroll prop working with hamb menu, we have to add fixed height to it. So now we do have scroll bar on after our screen resize.
![Screenshot_1](https://user-images.githubusercontent.com/61364785/122546323-8189c300-d037-11eb-992e-442185494f74.png)
