### PR TITLE
Bugfix #2935 fix name of the order steps bar in UBS Courier tab

### DIFF
--- a/src/assets/i18n/ubs/en.json
+++ b/src/assets/i18n/ubs/en.json
@@ -65,7 +65,7 @@
     "ubs-courier": "UBS courier",
     "order-details": "Order details",
     "personal-data": "Personal data",
-    "payment": "Payment"
+    "payment": "Confirmation"
   },
   "personal-info": {
     "address-city": "city",

--- a/src/assets/i18n/ubs/ru.json
+++ b/src/assets/i18n/ubs/ru.json
@@ -65,7 +65,7 @@
     "ubs-courier": "УБС курьер",
     "order-details": "Детали заказа",
     "personal-data": "Личные данные",
-    "payment": "Оплата"
+    "payment": "Подтверждение"
   },
   "personal-info": {
     "address-city": "г.",

--- a/src/assets/i18n/ubs/ua.json
+++ b/src/assets/i18n/ubs/ua.json
@@ -65,7 +65,7 @@
     "ubs-courier": "УБС кур’єр",
     "order-details": "Деталі замовлення",
     "personal-data": "Особисті дані",
-    "payment": "Оплата"
+    "payment": "Підтвердження"
   },
   "personal-info": {
     "address-city": "м.",


### PR DESCRIPTION
[UBS Courier tab UI] Fixed name of the order steps bar.
Before:
![image](https://user-images.githubusercontent.com/39774581/124640609-522be080-de96-11eb-8b61-d48162862ec9.png)
After:
![image](https://user-images.githubusercontent.com/39774581/124647059-2280d680-de9e-11eb-944f-ee0480f1592b.png)

