### PR TITLE
[UBS Courier] Radio buttons in the 'Eco store' section are implemented not at one level with their labels #2836

### DIFF
--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.scss
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.scss
@@ -79,7 +79,6 @@
 .custom-control-label {
   color: var(--ubs-secondary-grey);
   padding-left: 0;
-  padding-top: 3px;
 }
 
 .custom-control-label::before {


### PR DESCRIPTION
fixed radio button style