### PR TITLE
bugfix/#2903-fix-end-certificate-date-display-ubs

### DIFF
--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -363,16 +363,20 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
   certificateMatch(cert): void {
     if (cert.certificateStatus === CertificateStatus.ACTIVE || cert.certificateStatus === CertificateStatus.NEW) {
       this.certificateSum += cert.certificatePoints;
-      this.certDate = cert.certificateDate;
+      this.certDate = this.certificateDateTreat(cert.certificateDate);
       this.certStatus = cert.certificateStatus;
       this.displayCert = true;
       this.addCert = true;
     }
 
     if (cert.certificateStatus === CertificateStatus.USED || cert.certificateStatus === CertificateStatus.EXPIRED) {
-      this.certDate = cert.certificateDate;
+      this.certDate = this.certificateDateTreat(cert.certificateDate);
       this.certStatus = cert.certificateStatus;
     }
+  }
+
+  private certificateDateTreat(date: string) {
+    return date.split('-').reverse().join('-');
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
fix current date format from 'YYYY-MM-DD' to 'DD-MM-YYYY'
![image](https://user-images.githubusercontent.com/61364785/127366769-7283f8e5-b498-45ff-ade9-55a4d123930c.png)
