### PR TITLE
bugfix/fix-issue-of-display-the-bonuses-in-ubs-curier

### DIFF
--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -112,6 +112,7 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
         this.orders = this.shareFormService.orderDetails;
         this.bags = this.orders.bags;
         this.points = this.orders.points;
+        this.certificateLeft = orderData.points;
         this.bags.forEach((bag) => {
           bag.quantity = null;
           this.orderDetailsForm.addControl('quantity' + String(bag.id), new FormControl(0, [Validators.min(0), Validators.max(999)]));


### PR DESCRIPTION
displayed value now does rely on incoming data, so it not always 0
![image](https://user-images.githubusercontent.com/61364785/128422920-66c840ff-e53d-43ac-b073-bbf40dbba9bb.png)
