### PR TITLE
bugfix/#3025 & #3052 & #3022 ubs-courier-add-address-popup

### DIFF
--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-add-address-pop-up/ubs-add-address-pop-up.component.html
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-add-address-pop-up/ubs-add-address-pop-up.component.html
@@ -67,7 +67,7 @@
   <button class="secondary-global-button btn m-0 mr-2" mat-button (click)="onNoClick()">
     {{ 'personal-info.pop-up-cancel' | translate }}
   </button>
-  <button class="primary-global-button btn m-0" (click)="addAdress()">
+  <button class="primary-global-button btn m-0" (click)="addAdress()" [disabled]="!addAddressForm.valid">
     {{ (data.edit ? 'personal-info.pop-up-save-changes' : 'personal-info.pop-up-add-address') | translate }}
   </button>
 </div>

--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-add-address-pop-up/ubs-add-address-pop-up.component.ts
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-add-address-pop-up/ubs-add-address-pop-up.component.ts
@@ -27,7 +27,7 @@ export class UBSAddAddressPopUpComponent implements OnInit, OnDestroy {
   private destroy: Subject<boolean> = new Subject<boolean>();
 
   cities = [
-    { cityName: 'Kiev', northLat: 50.59079800991073, southLat: 50.21327301525928, eastLng: 30.82594104187906, westLng: 30.23944009690609 }
+    { cityName: 'Київ', northLat: 50.59079800991073, southLat: 50.21327301525928, eastLng: 30.82594104187906, westLng: 30.23944009690609 }
   ];
 
   constructor(

--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-add-address-pop-up/ubs-add-address-pop-up.component.ts
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-add-address-pop-up/ubs-add-address-pop-up.component.ts
@@ -22,7 +22,7 @@ export class UBSAddAddressPopUpComponent implements OnInit, OnDestroy {
   districtDisabled = true;
   nextDisabled = true;
   streetPattern = /^[A-Za-zА-Яа-яїієё0-9.\'\,\-\ \\]+$/;
-  houseCorpusPattern = /^[A-Za-zА-Яа-яїієё0-9]+$/;
+  housePattern = /^[A-Za-zА-Яа-яїієё0-9]+$/;
   entranceNumberPattern = /^-?(0|[1-9]\d*)?$/;
   private destroy: Subject<boolean> = new Subject<boolean>();
 
@@ -69,11 +69,11 @@ export class UBSAddAddressPopUpComponent implements OnInit, OnDestroy {
         this.data.edit ? this.data.address.street : '',
         [Validators.required, Validators.minLength(3), Validators.maxLength(40), Validators.pattern(this.streetPattern)]
       ],
-      houseNumber: [this.data.edit ? this.data.address.houseNumber : '', [Validators.required]],
-      houseCorpus: [
-        this.data.edit ? this.data.address.houseCorpus : '',
-        [Validators.maxLength(2), Validators.pattern(this.houseCorpusPattern)]
+      houseNumber: [
+        this.data.edit ? this.data.address.houseNumber : '',
+        [Validators.required, Validators.maxLength(4), Validators.pattern(this.housePattern)]
       ],
+      houseCorpus: [this.data.edit ? this.data.address.houseCorpus : '', [Validators.maxLength(2), Validators.pattern(this.housePattern)]],
       entranceNumber: [
         this.data.edit ? this.data.address.entranceNumber : '',
         [Validators.maxLength(2), Validators.pattern(this.entranceNumberPattern)]

--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-add-address-pop-up/ubs-add-address-pop-up.component.ts
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-add-address-pop-up/ubs-add-address-pop-up.component.ts
@@ -78,8 +78,8 @@ export class UBSAddAddressPopUpComponent implements OnInit, OnDestroy {
         this.data.edit ? this.data.address.entranceNumber : '',
         [Validators.maxLength(2), Validators.pattern(this.entranceNumberPattern)]
       ],
-      longitude: [this.data.edit ? this.data.address.longitude : '', Validators.required],
-      latitude: [this.data.edit ? this.data.address.latitude : '', Validators.required],
+      longitude: [this.data.edit ? this.data.address.longitude : ''],
+      latitude: [this.data.edit ? this.data.address.latitude : ''],
       id: [this.data.edit ? this.data.address.id : 0],
       actual: true
     });

--- a/src/app/main/component/ubs/components/ubs-submit-order/ubs-submit-order.component.html
+++ b/src/app/main/component/ubs/components/ubs-submit-order/ubs-submit-order.component.html
@@ -78,7 +78,7 @@
             <ul class="order-list">
               <li class="order-list-item">{{ personalData.city }}</li>
               <li class="order-list-item">
-                <span>{{ 'submit-order.str' | translate }}{{ personalData.street }}, {{ personalData.houseNumber }}</span
+                <span>{{ personalData.street }}, {{ personalData.houseNumber }}</span
                 >, {{ personalData.houseCorpus }}
               </li>
               <li class="order-list-item">{{ personalData.district }}</li>


### PR DESCRIPTION
The bug #3025 is fixed.
The bug #3052 is fixed.
The bug #3022 is fixed.
![add-btn-fixed](https://user-images.githubusercontent.com/69986847/128916260-673727dc-4359-4cb4-a291-9f9516350df9.png)
![add-btn-fixed-2](https://user-images.githubusercontent.com/69986847/128916263-82955dca-81f0-4507-957d-6843265231a2.png)
![fixed-validate](https://user-images.githubusercontent.com/69986847/128939114-009d0e75-87af-43e1-b85a-81eaed0075e5.png)
