### PR TITLE
Bugfix/#2660 verification if text in content field is valid isn't automatic

### DIFF
--- a/src/app/main/component/eco-news/components/create-edit-news/create-edit-news.component.scss
+++ b/src/app/main/component/eco-news/components/create-edit-news/create-edit-news.component.scss
@@ -173,7 +173,7 @@ form label {
 }
 
 input.ng-invalid.ng-touched + span,
-textarea.ng-invalid.ng-touched + p {
+textarea.ng-invalid.ng-dirty + p {
   color: red;
 }
 


### PR DESCRIPTION
The error message is shown after we started typing until we reach 20 characters limit.