### PR TITLE
bugfix/source field content for eco news/#1718

### DIFF
--- a/src/app/main/component/eco-news/components/eco-news-detail/eco-news-detail.component.html
+++ b/src/app/main/component/eco-news/components/eco-news-detail/eco-news-detail.component.html
@@ -58,7 +58,7 @@
             <div class="source-title">
               {{ 'eco-news-single-view.news-source' | translate }}
             </div>
-            <a href="{{ newsItem?.text }}" class="source-text word-wrap">
+            <a href="{{ newsItem?.source }}" class="source-text word-wrap">
               {{ newsItem?.source }}
             </a>
           </div>


### PR DESCRIPTION
- Fixed: In source field Attribute 'href' always equals to Content field, even if source filed is empty.

Before: 
![GreenCity-news-source-before](https://user-images.githubusercontent.com/34275837/132106950-a8dc86fb-3027-4619-b89d-39784e200012.png)

After:
![GreenCity-news-source-after](https://user-images.githubusercontent.com/34275837/132107036-9b68e016-b027-413a-816d-80b421376e71.png)
