### PR TITLE
Bugfix/#3232 Changed output of error message for certificate

### DIFF
--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.html
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.html
@@ -170,7 +170,7 @@
               {{ 'order-details.activated' | translate: { certificateSum: certificateSum, certDate: certDate } }}
             </small>
             <small class="text-danger" *ngIf="certificateError">
-              {{ 'order-details.not-found-certificate' | translate }}
+              {{ 'order-details.failed-certificate' | translate }}
             </small>
             <small class="text-danger" *ngIf="certStatus === 'USED'">
               {{


### PR DESCRIPTION
-  Changed validation message when an invalid value is entered into the 'Введіть номер сертифіката' input field on the 'Деталі замовлення' tab.

![image](https://user-images.githubusercontent.com/34275837/134465612-3aee4616-a82d-4233-82d2-f39876e92072.png)

Fixed bug:
[[UBS courier] Validation message does not meet to the requirements when invalid value is entered into the 'Введіть номер сертифіката' input field #3232](https://github.com/ita-social-projects/GreenCity/issues/3232)

User story: [#2329](https://github.com/ita-social-projects/GreenCity/issues/2329)