### PR TITLE
Bugfix/List view edit sizes/#1903

### DIFF
--- a/src/app/main/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
+++ b/src/app/main/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
@@ -93,8 +93,7 @@ div {
     display: block;
     object-fit: cover;
     -o-object-fit: cover;
-    margin: auto;
-    height: 100%;
+    height: 92.31%;
     width: 100%;
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
@@ -113,8 +112,8 @@ div {
 @media (min-width: 1024px) {
   .eco-news_list-view-wrp {
     height: 204px;
-    -ms-grid-columns: 299px auto;
-    grid-template-columns: 299px auto;
+    -ms-grid-columns: 359px auto;
+    grid-template-columns: 359px auto;
   }
 }
 
@@ -125,10 +124,15 @@ div {
     word-break: break-all;
   }
 
-  .eco-news_list-view-wrp {
-    height: 204px;
-    -ms-grid-columns: 359px auto;
-    grid-template-columns: 359px auto;
+  .eco-news_list-img {
+    display: block;
+    object-fit: cover;
+    -o-object-fit: cover;
+    height: 100%;
+    width: 100%;
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
Steps to reproduce:

     Click on the 'Eco news' button
     Click on the button to sort news as column
     Click on the 'List view' icon
     Verify UI elements' size and alignments of the news item on 1199-992 resolution (ex. 1024 as we have mock - up with resolution 1024)with dev tool help.
     Pay attention to the result.

I edited sizes of elements in list view according to mock-up.

Before:
![image](https://user-images.githubusercontent.com/49165350/134905902-16a449f7-bee1-4b2d-821f-1b56403937d2.png)

After:
![example](https://user-images.githubusercontent.com/49165350/134906871-dccc2902-76ff-43db-a438-ca07ff7b4020.png)

Bug fixed:
https://github.com/ita-social-projects/GreenCity/issues/1903