### PR TITLE
Bugfix/#2945/List view edit description line

### DIFF
--- a/src/app/main/component/eco-news/components/news-list/news-list-list-view/breakpoints.ts
+++ b/src/app/main/component/eco-news/components/news-list/news-list-list-view/breakpoints.ts
@@ -6,7 +6,7 @@ export const possibleDescHeight = {
     78: 'one-row',
     96: 'd-none',
     100: 'one-row',
-    104: 'd-none',
+    104: 'd-none'
   },
   bigHeight: {
     24: 'tree-row',
@@ -16,8 +16,8 @@ export const possibleDescHeight = {
     72: 'one-row',
     78: 'one-row',
     96: 'one-row',
-    100: 'one-row',
-  },
+    100: 'one-row'
+  }
 };
 
 export const possibleTitleHeight = {
@@ -25,7 +25,7 @@ export const possibleTitleHeight = {
     26: 'one-row',
     52: 'two-row',
     78: 'tree-row',
-    104: 'two-row',
+    104: 'two-row'
   },
   bigHeight: {
     24: 'one-row',
@@ -33,9 +33,9 @@ export const possibleTitleHeight = {
     48: 'two-row',
     52: 'two-row',
     72: 'tree-row',
-    78: 'four-row',
-    96: 'four-row',
-    100: 'four-row',
-    104: 'four-row',
-  },
+    78: 'tree-row',
+    96: 'tree-row',
+    100: 'tree-row',
+    104: 'tree-row'
+  }
 };

--- a/src/app/main/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
+++ b/src/app/main/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
@@ -45,9 +45,9 @@ div {
   font-family: var(--secondary-font);
   font-style: normal;
   font-weight: 500;
-  font-size: 21px;
+  font-size: 20px;
   color: var(--quaternary-dark-grey);
-  line-height: 28px;
+  line-height: 24px;
   margin-bottom: 5px;
   overflow: hidden;
   word-break: break-all;

--- a/src/app/main/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.ts
+++ b/src/app/main/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.ts
@@ -56,15 +56,13 @@ export class NewsListListViewComponent implements AfterViewChecked {
     const result = possibleDescHeight[this.getDomWidth()][titleHeight];
     const smallTitleHeight = titleHeight > 26 ? 'two-row' : 'tree-row';
     const midTitleHeught = titleHeight > 52 ? 'one-row' : smallTitleHeight;
-    const largeTitleheight = titleHeight > 78 ? 'd-none' : midTitleHeught;
-    return result ? result : largeTitleheight;
+    return result ? result : midTitleHeught;
   }
 
   private getHeightOfTitle(titleHeight: number): string {
     const result = possibleTitleHeight[this.getDomWidth()][titleHeight];
     const smallTitleHeight = titleHeight > 26 ? 'two-row' : 'one-row';
     const midTitleHeught = titleHeight > 52 ? 'tree-row' : smallTitleHeight;
-    const largeTitleheight = titleHeight > 78 ? 'four-row' : midTitleHeught;
-    return result ? result : largeTitleheight;
+    return result ? result : midTitleHeught;
   }
 }


### PR DESCRIPTION
Preconditions

1.https://ita-social-projects.github.io/GreenCityClient/ is opened.
2.News items are created in the DB and are displayed as first news item in the list view.

Steps to reproduce
1.Click on 'Eco news' link in the header.
2. Set browser window width to 1440px.
3. Click on the View as a List option on the right side of the page.
4. Verify created news Title UI (Title should displayed and consist of 3 rows and be 96px in heights.)
5. Verify created news Description UI (Description should displayed and consist of 1 row and be 32px in heights.)

Before:
![image](https://user-images.githubusercontent.com/49165350/135078335-ab64bf2f-205c-4abc-84ef-b4387b316e9f.png)
After:
![image](https://user-images.githubusercontent.com/49165350/135078281-e30f5193-30fa-48cc-a047-b666ddb32ab7.png)

Bug fixed:
ita-social-projects/GreenCity#2945