### PR TITLE
bugfix/ubs bonuses to payment/#3319

### DIFF
--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.html
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.html
@@ -157,15 +157,15 @@
           </button>
           <div class="points">
             <h5>{{ 'order-details.bonus-need' | translate }}</h5>
-            <p>{{ 'order-details.bonus-left' | translate }} {{ points | currency | localizedCurrency }}</p>
+            <p>{{ 'order-details.bonus-left' | translate }} {{ defaultPoints | currency | localizedCurrency }}</p>
             <p>
               <a href="#!" class="bonus-how-to-link">{{ 'order-details.bonus-how-to-get' | translate }}</a>
             </p>
-            <div class="radio-btn" *ngIf="points !== 0 && finalSum !== 0">
+            <div class="radio-btn" *ngIf="defaultPoints !== 0 && showTotal !== 0">
               <label class="custom-radio-btn"
                 >{{ 'order-details.no' | translate }}
-                <input formControlName="bonus" type="radio" value="no" tabindex="-1" />
-                <span class="checkmark" tabindex="0" (keyup)="selectPointsRadioBtn($event, 'no')"></span>
+                <input formControlName="bonus" type="radio" value="no" tabindex="-1" (click)="resetPoints()" />
+                <span class="checkmark" tabindex="0" (keyup)="selectPointsRadioBtn($event, 'no'); resetPoints()"></span>
               </label>
               <label class="custom-radio-btn"
                 >{{ 'order-details.yes' | translate }}

--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -35,6 +35,7 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
   totalOfBigBags: number;
   cancelCertBtn = false;
   points: number;
+  defaultPoints: number;
   displayMinOrderMes = false;
   displayMinBigBagsMes = false;
   displayMes = false;
@@ -170,6 +171,7 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
         this.minAmountOfBigBags = orderData.minAmountOfBigBags;
         this.bags = this.orders.bags;
         this.points = this.orders.points;
+        this.defaultPoints = this.points;
         this.certificateLeft = orderData.points;
         this.bags.forEach((bag) => {
           bag.quantity = null;
@@ -318,6 +320,9 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
     });
     this.checkTotalBigBags();
     this.calculateTotal();
+    if (this.orderDetailsForm.controls.bonus.value === 'yes') {
+      this.calculatePoints();
+    }
   }
 
   calculatePoints(): void {
@@ -365,6 +370,7 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
     this.certificateSum = 0;
     this.finalSum = this.total;
     this.points = this.orders.points;
+    this.pointsUsed = 0;
     this.certificateReset(true);
     this.calculateTotal();
   }


### PR DESCRIPTION
Achieved results:
- fixed points reset if radio-button "no" was selected
- radio-buttons do not disappear when bonuses are used
- "On your bonus account" shows only the initial amount of the bonuses that come from the back-end and it won't change
- if the option field “yes” is selected for bonuses and then “Number of packages” is changed, unused bonuses are applied to the amount due
- the amount due includes bonuses on the payment side

Actual result:
Bonuses taken
![image](https://user-images.githubusercontent.com/34275837/135730789-841f18b8-156f-4239-94a8-0289d927e335.png)

Payment
![image](https://user-images.githubusercontent.com/34275837/135730820-044cab19-acee-4539-9ab9-d16907bfbd0b.png)

Bug fixed:
[[UBS Order] The amount due does not include any bonuses on the payment side #3319](https://github.com/ita-social-projects/GreenCity/issues/3319)