### PR TITLE
Bugfix/#3326/Add autochecked to first address element

### DIFF
--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.html
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.html
@@ -132,13 +132,7 @@
     <ng-template #addressesList>
       <div class="w-50 d-flex mt-2 mb-2 col-lg-6 col-md-6 col-sm-12 col-12" *ngFor="let address of addresses">
         <div class="custom-radio d-flex">
-          <input
-            formControlName="address"
-            type="radio"
-            [value]="address.id"
-            [checked]="address.actual"
-            (click)="checkAddress(address.id)"
-          />
+          <input name="address" type="radio" [value]="address.id" [checked]="address.actual" (click)="checkAddress(address.id)" />
         </div>
         <app-address [address]="address" class="col-md-6"></app-address>
         <div class="edit-address" (click)="editAddress(address.id)">


### PR DESCRIPTION
As a registered user I want to make new order. And I have, for example 2 addresses. The first one should be checked when I open Personal data page.
Before:
![image](https://user-images.githubusercontent.com/49165350/135838720-e267c654-48f8-4f37-bb3c-2473d1e2a1c8.png)
After:
![image](https://user-images.githubusercontent.com/49165350/135838788-146400fb-0852-4935-a33d-fe1b02807598.png)
Problem card:
https://github.com/ita-social-projects/GreenCity/issues/3326#issue-1014908461