### PR TITLE
Bugfix/#1785/View, edit and save additional details for a habit

### DIFF
--- a/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.ts
@@ -130,7 +130,6 @@ export class AddNewHabitComponent implements OnInit, OnDestroy {
 
   public addHabit() {
     const defailtItemsIds = this.newList.filter((item) => item.selected === true).map((item) => item.id);
-    // if (defailtItemsIds.length > 0) {
     this.habitAssignService
       .assignCustomHabit(this.habitId, this.newDuration, defailtItemsIds)
       .pipe(take(1))
@@ -138,15 +137,6 @@ export class AddNewHabitComponent implements OnInit, OnDestroy {
         this.router.navigate(['profile', this.userId]);
         this.snackBar.openSnackBar('habitAdded');
       });
-    // } else {
-    //   this.habitAssignService
-    //   .assignCustomHabit(this.habitId, this.newDuration, defailtItemsIds)
-    //   .pipe(take(1))
-    //     .subscribe(() => {
-    //       this.router.navigate(['profile', this.userId]);
-    //       this.snackBar.openSnackBar('habitAdded');
-    //     });
-    // }
   }
 
   public updateHabit() {

--- a/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.ts
@@ -130,23 +130,23 @@ export class AddNewHabitComponent implements OnInit, OnDestroy {
 
   public addHabit() {
     const defailtItemsIds = this.newList.filter((item) => item.selected === true).map((item) => item.id);
-    if (defailtItemsIds.length > 0) {
-      this.habitAssignService
-        .assignCustomHabit(this.habitId, this.newDuration, defailtItemsIds)
-        .pipe(take(1))
-        .subscribe(() => {
-          this.router.navigate(['profile', this.userId]);
-          this.snackBar.openSnackBar('habitAdded');
-        });
-    } else {
-      this.habitAssignService
-        .assignHabit(this.habitId)
-        .pipe(take(1))
-        .subscribe(() => {
-          this.router.navigate(['profile', this.userId]);
-          this.snackBar.openSnackBar('habitAdded');
-        });
-    }
+    // if (defailtItemsIds.length > 0) {
+    this.habitAssignService
+      .assignCustomHabit(this.habitId, this.newDuration, defailtItemsIds)
+      .pipe(take(1))
+      .subscribe(() => {
+        this.router.navigate(['profile', this.userId]);
+        this.snackBar.openSnackBar('habitAdded');
+      });
+    // } else {
+    //   this.habitAssignService
+    //   .assignCustomHabit(this.habitId, this.newDuration, defailtItemsIds)
+    //   .pipe(take(1))
+    //     .subscribe(() => {
+    //       this.router.navigate(['profile', this.userId]);
+    //       this.snackBar.openSnackBar('habitAdded');
+    //     });
+    // }
   }
 
   public updateHabit() {

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-duration/gradient.directive.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-duration/gradient.directive.ts
@@ -1,9 +1,8 @@
-import { Directive, ElementRef, HostListener, OnInit, Renderer2 } from '@angular/core';
-
+import { AfterViewInit, Directive, ElementRef, HostListener, Renderer2 } from '@angular/core';
 @Directive({
-  selector: '[appGradient]',
+  selector: '[appGradient]'
 })
-export class GradientDirective implements OnInit {
+export class GradientDirective implements AfterViewInit {
   public durationProgres: number;
   public gradientProgres: number;
   public min: number = null;
@@ -14,7 +13,7 @@ export class GradientDirective implements OnInit {
     this.max = this.elm.nativeElement.max;
   }
 
-  ngOnInit(): void {
+  ngAfterViewInit(): void {
     this.durationProgres = this.elm.nativeElement.value;
     this.calcGradientVal();
     this.renderer.setStyle(

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-duration/habit-duration.component.html
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-duration/habit-duration.component.html
@@ -1,5 +1,5 @@
 <div class="title">{{ 'user.habit.duration.title' | translate }}</div>
-<div class="thumbLabel">{{ range.value }} {{ 'user.habit.duration.day' | translate }}</div>
+<div class="thumbLabel">{{ habitDuration.value }} {{ 'user.habit.duration.day' | translate }}</div>
 <input
   [formControl]="habitDuration"
   class="form-control-range"

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-edit-shopping-list/habit-edit-shopping-list.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-edit-shopping-list/habit-edit-shopping-list.component.ts
@@ -94,13 +94,14 @@ export class HabitEditShoppingListComponent implements OnInit, OnDestroy {
           this.getListItems(false);
           return;
         }
-        for (const assigned of response) {
-          if (assigned.habit.id === this.habitId) {
-            this.getListItems(true);
-            break;
-          }
-          this.getListItems(false);
-        }
+        // for (const assigned of response) {
+        //   if (assigned.habit.id === this.habitId) {
+        //     this.getListItems(true);
+        //     break;
+        //   }
+        //   this.getListItems(false);
+        // }
+        response.some((assigned) => assigned.habit.id === this.habitId) ? this.getListItems(true) : this.getListItems(false);
       });
   }
 

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-edit-shopping-list/habit-edit-shopping-list.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-edit-shopping-list/habit-edit-shopping-list.component.ts
@@ -94,13 +94,6 @@ export class HabitEditShoppingListComponent implements OnInit, OnDestroy {
           this.getListItems(false);
           return;
         }
-        // for (const assigned of response) {
-        //   if (assigned.habit.id === this.habitId) {
-        //     this.getListItems(true);
-        //     break;
-        //   }
-        //   this.getListItems(false);
-        // }
         response.some((assigned) => assigned.habit.id === this.habitId) ? this.getListItems(true) : this.getListItems(false);
       });
   }

--- a/src/app/main/component/user/components/profile/eco-places/eco-places.component.ts
+++ b/src/app/main/component/user/components/profile/eco-places/eco-places.component.ts
@@ -9,7 +9,7 @@ import { ProfileService } from '@global-user/components/profile/profile-service/
   styleUrls: ['./eco-places.component.scss']
 })
 export class EcoPlacesComponent implements OnInit {
-  public ecoPlaces: EcoPlaces[];
+  public ecoPlaces: EcoPlaces[] = [];
   public subscription: Subscription;
 
   constructor(private profileService: ProfileService) {}


### PR DESCRIPTION
As a registered user I want to be able to view, edit and save additional details for a habit from a list of standard habits, so that I was able to modify a habit according to my needs if needed
Acceptance Criteria:
1. Registered User can see enabled “More” buttons for each habit on the All Habits page
2. When R. User clicks “More” button, the system redirects him/her on a separate page with habit details.
a. R. User can view:
• Habit category
• How many users acquired this specific habit (Acquired by #)
• Rating (stars)
• description of a habit
• Calendar with the highlighted current date
b. R. User can view and modify:
• Duration (within days limits (min – 7 days, max – 56 days))
• Shopping list (checklist)
c. When R. User Clicks ‘Back to My Habits’ system redirects him to My Habits tab in the profile.
•Habit is not added to the list of My habit.
•Standard Settings for a habit is not changed.
3. R. User can save modified habit by clicking “Add Habit” button
4. System redirects User to the ‘My habit’ page. The newly added habit must be displayed on the top of all habits list. The system opens a pop-up with information: “A habit has been successfully added”
Link to task:
https://github.com/ita-social-projects/GreenCity/issues/1785#issue-734441102