### PR TITLE
Refactored Bugfix/get location error/#3368

### DIFF
--- a/src/app/shared/interceptors/interceptor.service.ts
+++ b/src/app/shared/interceptors/interceptor.service.ts
@@ -114,7 +114,7 @@ export class InterceptorService implements HttpInterceptor {
    * @param error - {@link HttpErrorResponse}
    */
   private handleRefreshTokenIsNotValid(error: HttpErrorResponse): Observable<HttpEvent<any>> {
-    const isUbsUrl = this.router.url.includes('/ubs');
+    const currentUrl = this.router.url;
     this.isRefreshing = false;
     this.localStorageService.clear();
     this.dialog.closeAll();
@@ -129,9 +129,9 @@ export class InterceptorService implements HttpInterceptor {
         }
       })
       .afterClosed()
-      .pipe(takeWhile(() => isUbsUrl))
+      .pipe(take(1))
       .subscribe(() => {
-        this.router.navigateByUrl('/ubs');
+        this.router.navigateByUrl(currentUrl);
       });
     return of<HttpEvent<any>>();
   }


### PR DESCRIPTION
**Preconditions**

1. The registered user is logged in.
2. The user goes to the UBS-courier page and clicks on the "call-up the courier" button.

**Achieved result:**
- the user is redirected to the login page after the access token has expired

**Refactoring of:** [#1181](https://github.com/ita-social-projects/GreenCityClient/pull/1181)

**Fixed bug:** [[UBS Curier] Does not redirect to the login page if the access token has expired. #3368](https://github.com/ita-social-projects/GreenCity/issues/3368)