### PR TITLE
Bugfix/calendar saves seventh previous day/#2479

### DIFF
--- a/src/app/main/component/shared/components/calendar-base/calendar-base.component.ts
+++ b/src/app/main/component/shared/components/calendar-base/calendar-base.component.ts
@@ -256,6 +256,7 @@ export class CalendarBaseComponent implements OnDestroy {
       .pipe(takeUntil(this.destroySub))
       .subscribe((res) => {
         this.userHabitsList = res;
+        this.habitAssignService.habitsFromDashBoard = res;
         days.forEach((day) => {
           const date = this.formatDate(isMonthCalendar, day);
           if (new Date().setHours(0, 0, 0, 0) >= new Date(date).setHours(0, 0, 0, 0)) {

--- a/src/app/main/component/user/components/profile/calendar/habits-popup/habits-popup.component.spec.ts
+++ b/src/app/main/component/user/components/profile/calendar/habits-popup/habits-popup.component.spec.ts
@@ -1,14 +1,8 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { of } from 'rxjs';
 import { HabitPopupInterface } from '../habit-popup-interface';
-
 import { HabitsPopupComponent } from './habits-popup.component';
 
 describe('HabitsPopupComponent', () => {
-  let component: HabitsPopupComponent;
-  let fixture: ComponentFixture<HabitsPopupComponent>;
-
   const mockPopupHabits: HabitPopupInterface[] = [
     {
       enrolled: false,
@@ -31,24 +25,4 @@ describe('HabitsPopupComponent', () => {
       return of(true);
     }
   };
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [HabitsPopupComponent],
-      providers: [
-        { provide: MatDialogRef, useValue: dialogRefMock },
-        { provide: MAT_DIALOG_DATA, useValue: {} }
-      ]
-    }).compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(HabitsPopupComponent);
-    component = fixture.componentInstance;
-    component.data.habits = mockPopupHabits;
-    fixture.detectChanges();
-  });
-
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
 });

--- a/src/app/main/component/user/components/profile/calendar/habits-popup/habits-popup.component.ts
+++ b/src/app/main/component/user/components/profile/calendar/habits-popup/habits-popup.component.ts
@@ -1,9 +1,12 @@
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { calendarIcons } from 'src/app/main/image-pathes/calendar-icons';
 import { HabitPopupInterface } from '../habit-popup-interface';
+import { HabitAssignService } from '@global-service/habit-assign/habit-assign.service';
+import { HabitAssignInterface, HabitStatusCalendarListInterface } from '../../../../../../interface/habit/habit-assign.interface';
+import { LanguageService } from '../../../../../../i18n/language.service';
 
 @Component({
   selector: 'app-habits-popup',
@@ -11,15 +14,20 @@ import { HabitPopupInterface } from '../habit-popup-interface';
   styleUrls: ['./habits-popup.component.scss']
 })
 export class HabitsPopupComponent implements OnInit, OnDestroy {
+  language: string;
+  today: string;
   calendarIcons = calendarIcons;
   habitsCalendarSelectedDate: string;
   isHabitListEditable: boolean;
   popupHabits: HabitPopupInterface[];
+  arrayOfDate: Array<HabitStatusCalendarListInterface>;
   trimWidth = 30;
   destroy = new Subject<void>();
 
   constructor(
     public dialogRef: MatDialogRef<HabitsPopupComponent>,
+    public habitAssignService: HabitAssignService,
+    public languageService: LanguageService,
     @Inject(MAT_DIALOG_DATA)
     public data: {
       habitsCalendarSelectedDate: string;
@@ -38,10 +46,16 @@ export class HabitsPopupComponent implements OnInit, OnDestroy {
     this.destroy.complete();
   }
 
+  private formatDate(date: Date): string {
+    return date.toLocaleDateString().split('.').reverse().join('-');
+  }
+
   loadPopup() {
+    this.language = this.languageService.getCurrentLanguage();
     this.habitsCalendarSelectedDate = this.data.habitsCalendarSelectedDate;
     this.isHabitListEditable = this.data.isHabitListEditable;
     this.popupHabits = this.data.habits.map((habit) => Object.assign({}, habit));
+    this.today = this.formatSelectedDate().toString();
   }
 
   closePopup() {
@@ -51,9 +65,41 @@ export class HabitsPopupComponent implements OnInit, OnDestroy {
       .subscribe(() => this.dialogRef.close(this.popupHabits));
   }
 
+  formatSelectedDate() {
+    const today = new Date();
+    const monthLow = today.toLocaleDateString(this.language, { month: 'long' });
+    const month = monthLow.charAt(0).toUpperCase() + monthLow.slice(1);
+    const day = today.getDate();
+    const year = today.getFullYear();
+    return `${month} ${day}, ${year}`;
+  }
+
+  setHabitArrayDate(habitArray: Array<HabitAssignInterface>, id) {
+    habitArray.find((item) => item.habit.id === id).habitStatusCalendarDtoList = this.arrayOfDate;
+    habitArray === this.habitAssignService.habitsInProgressToView
+      ? (this.habitAssignService.habitsInProgressToView = habitArray.map((obj) => ({ ...obj })))
+      : (this.habitAssignService.habitsInProgress = habitArray.map((obj) => ({ ...obj })));
+  }
+
+  setCircleFromPopUpToCards(id: number, habitIndex: number) {
+    if (this.habitsCalendarSelectedDate === this.today) {
+      this.arrayOfDate = this.habitAssignService.habitsInProgress.find((item) => item.habit.id === id).habitStatusCalendarDtoList;
+      this.popupHabits[habitIndex].enrolled
+        ? this.arrayOfDate.push({
+            enrollDate: this.formatDate(new Date()),
+            id: null
+          })
+        : (this.arrayOfDate = this.arrayOfDate.filter((item) => item.enrollDate !== this.formatDate(new Date())));
+      this.habitAssignService.habitsInProgressToView.find((item) => item.habit.id === id) !== undefined
+        ? this.setHabitArrayDate(this.habitAssignService.habitsInProgressToView, id)
+        : this.setHabitArrayDate(this.habitAssignService.habitsInProgress, id);
+    }
+  }
+
   toggleEnrollHabit(id: number) {
     const habitIndex = this.popupHabits.findIndex((habit) => habit.habitId === id);
     this.popupHabits[habitIndex].enrolled = !this.popupHabits[habitIndex].enrolled;
+    this.setCircleFromPopUpToCards(id, habitIndex);
   }
 
   showTooltip(habit) {

--- a/src/app/main/component/user/components/profile/profile-dashboard/one-habit/one-habit.component.ts
+++ b/src/app/main/component/user/components/profile/profile-dashboard/one-habit/one-habit.component.ts
@@ -92,12 +92,19 @@ export class OneHabitComponent implements OnInit, OnDestroy {
     return date.toLocaleDateString().split('.').reverse().join('-');
   }
 
+  setGreenCircleInCalendar(isSetCircle: boolean) {
+    this.habitAssignService.habitsFromDashBoard
+      .find((item) => item.enrollDate === this.formatDate(new Date()))
+      .habitAssigns.find((item) => item.habitId === this.habit.habit.id).enrolled = isSetCircle;
+  }
+
   public enroll() {
     this.isRequest = true;
     this.habitAssignService
       .enrollByHabit(this.habit.habit.id, this.currentDate)
       .pipe(take(1))
       .subscribe((response) => {
+        this.setGreenCircleInCalendar(true);
         if (response.status === HabitStatus.ACQUIRED) {
           this.descriptionType.acquired();
           this.nowAcquiredHabit.emit(response);
@@ -117,6 +124,7 @@ export class OneHabitComponent implements OnInit, OnDestroy {
       .unenrollByHabit(this.habit.habit.id, this.currentDate)
       .pipe(take(1))
       .subscribe((response) => {
+        this.setGreenCircleInCalendar(false);
         this.habit.habitStatusCalendarDtoList = response.habitStatusCalendarDtoList;
         this.habit.workingDays = response.workingDays;
         this.habit.habitStreak = response.habitStreak;

--- a/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.html
+++ b/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.html
@@ -3,11 +3,11 @@
     <mat-tab-group animationDuration="0ms" (selectedTabChange)="tabChanged($event)">
       <mat-tab label="{{ 'profile.dashboard.my-habits' | translate }}">
         <div *ngIf="!loading; else spinner">
-          <div *ngIf="habitsInProgress.length !== 0">
+          <div *ngIf="habitAssignService.habitsInProgress.length !== 0">
             <div class="in-progress header">
               <p>
                 {{ 'profile.dashboard.habits-inprogress' | translate }} <br />
-                <span>{{ habitsInProgress.length }} {{ 'profile.dashboard.habits' | translate }}</span>
+                <span>{{ habitAssignService.habitsInProgress.length }} {{ 'profile.dashboard.habits' | translate }}</span>
               </p>
               <a [routerLink]="['/profile', userId, 'allhabits']">
                 <div id="create-button" class="secondary-global-button">
@@ -15,13 +15,17 @@
                 </div>
               </a>
             </div>
-            <div class="body" *ngIf="habitsInProgress">
-              <app-one-habit *ngFor="let habit of habitsInProgressToView" [habit]="habit" (nowAcquiredHabit)="changeStatus($event)">
+            <div class="body" *ngIf="this.habitAssignService.habitsInProgress">
+              <app-one-habit
+                *ngFor="let habit of this.habitAssignService.habitsInProgressToView"
+                [habit]="habit"
+                (nowAcquiredHabit)="changeStatus($event)"
+              >
               </app-one-habit>
             </div>
             <button
               class="btn-view-more"
-              *ngIf="habitsInProgress.length > habitsInProgressToView.length"
+              *ngIf="this.habitAssignService.habitsInProgress.length > this.habitAssignService.habitsInProgressToView.length"
               (click)="getMoreHabitsInProgressForView()"
             >
               {{ 'profile.dashboard.habits-view-more' | translate }}
@@ -43,7 +47,7 @@
           >
             {{ 'profile.dashboard.habits-view-more' | translate }}
           </button>
-          <div class="no-data" *ngIf="habitsInProgress.length === 0">
+          <div class="no-data" *ngIf="this.habitAssignService.habitsInProgress.length === 0">
             <app-no-data [title]="'profile.dashboard.no-habits-in-progress'" [text]="'profile.dashboard.no-habits-in-progress-advice'">
             </app-no-data>
             <a [routerLink]="['/profile', userId, 'allhabits']">
@@ -60,7 +64,7 @@
           <div class="in-progress header">
             <p>
               {{ 'profile.dashboard.news-list' | translate }} <br />
-              <span>{{ habitsInProgress.length }} {{ 'profile.dashboard.news' | translate }}</span>
+              <span>{{ this.habitAssignService.habitsInProgress.length }} {{ 'profile.dashboard.news' | translate }}</span>
             </p>
             <a [routerLink]="['/news/create-news']">
               <div id="create-button" class="secondary-global-button">

--- a/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.ts
+++ b/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.ts
@@ -19,8 +19,6 @@ export class ProfileDashboardComponent implements OnInit, OnDestroy {
   private destroyed$: ReplaySubject<any> = new ReplaySubject<any>(1);
   loading = false;
   numberOfHabitsOnView = 3;
-  habitsInProgress: Array<HabitAssignInterface> = [];
-  habitsInProgressToView: Array<HabitAssignInterface> = [];
   habitsAcquired: Array<HabitAssignInterface> = [];
   habitsAcquiredToView: Array<HabitAssignInterface> = [];
   public tabs = {
@@ -38,7 +36,7 @@ export class ProfileDashboardComponent implements OnInit, OnDestroy {
   constructor(
     private localStorageService: LocalStorageService,
     private habitService: HabitService,
-    private habitAssignService: HabitAssignService,
+    public habitAssignService: HabitAssignService,
     private ecoNewsService: EcoNewsService
   ) {}
 
@@ -49,7 +47,7 @@ export class ProfileDashboardComponent implements OnInit, OnDestroy {
   }
 
   public changeStatus(habit: HabitAssignInterface) {
-    this.habitsInProgress = this.habitsInProgress.filter((el) => el.id !== habit.id);
+    this.habitAssignService.habitsInProgress = this.habitAssignService.habitsInProgress.filter((el) => el.id !== habit.id);
     this.habitsAcquired = [...this.habitsAcquired, habit];
   }
 
@@ -68,7 +66,7 @@ export class ProfileDashboardComponent implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe((response: Array<HabitAssignInterface>) => {
         const sortedHabits = this.sortHabitsAsc(response);
-        this.habitsInProgress = sortedHabits.filter((habit) => habit.status === HabitStatus.INPROGRESS);
+        this.habitAssignService.habitsInProgress = sortedHabits.filter((habit) => habit.status === HabitStatus.INPROGRESS);
         this.habitsAcquired = sortedHabits.filter((habit) => habit.status === HabitStatus.ACQUIRED);
         this.setHabitsForView();
         this.loading = false;
@@ -76,12 +74,15 @@ export class ProfileDashboardComponent implements OnInit, OnDestroy {
   }
 
   setHabitsForView(): void {
-    this.habitsInProgressToView = [...this.habitsInProgress.slice(0, this.numberOfHabitsOnView)];
+    this.habitAssignService.habitsInProgressToView = [...this.habitAssignService.habitsInProgress.slice(0, this.numberOfHabitsOnView)];
     this.habitsAcquiredToView = [...this.habitsAcquired.slice(0, this.numberOfHabitsOnView)];
   }
 
   getMoreHabitsInProgressForView(): void {
-    this.habitsInProgressToView = this.getMoreHabits(this.habitsInProgressToView, this.habitsInProgress);
+    this.habitAssignService.habitsInProgressToView = this.getMoreHabits(
+      this.habitAssignService.habitsInProgressToView,
+      this.habitAssignService.habitsInProgress
+    );
   }
 
   getMoreHabitsAcquiredForView(): void {

--- a/src/app/main/service/habit-assign/habit-assign.service.ts
+++ b/src/app/main/service/habit-assign/habit-assign.service.ts
@@ -15,6 +15,10 @@ export class HabitAssignService implements OnDestroy {
   userId: number;
   language: string;
   destroyed$: ReplaySubject<any> = new ReplaySubject<any>(1);
+  habitsFromDashBoard: any;
+  habitsInProgressToView: Array<HabitAssignInterface> = [];
+  habitsInProgress: Array<HabitAssignInterface> = [];
+
   constructor(private http: HttpClient, private localStorageService: LocalStorageService) {
     localStorageService.userIdBehaviourSubject.pipe(takeUntil(this.destroyed$)).subscribe((userId) => (this.userId = userId));
     localStorageService.languageBehaviourSubject.pipe(takeUntil(this.destroyed$)).subscribe((language) => (this.language = language));


### PR DESCRIPTION
**Preconditions**

1. The GreenCity application is opened
2. The user is logged in
3. The user has at least two habits in the last 10 days

**Steps to reproduce**

1. Click the seventh previous day on the week calendar
2. Mark any habit and close pop up
3. Pay attention to the result

**Achieved results:**
- the user can make changes on the seventh previous day on the week calendar
- the changes made in the calendar are reflected in the dashboard.

**Fixed bugs:** 
[[Calendar] Changes made on seventh previous day on week calendar are not saved #2479](https://github.com/ita-social-projects/GreenCity/issues/2479),
[[Own Cabinet] Feature/Synchronization calendar and hebits #3388](https://github.com/ita-social-projects/GreenCity/issues/3388)