### PR TITLE
Bugfix/change validator for corpus address/#3423

### DIFF
--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-add-address-pop-up/ubs-add-address-pop-up.component.ts
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-add-address-pop-up/ubs-add-address-pop-up.component.ts
@@ -24,6 +24,7 @@ export class UBSAddAddressPopUpComponent implements OnInit, OnDestroy {
   nextDisabled = true;
   isDisabled = false;
   streetPattern = /^[A-Za-zА-Яа-яїЇіІєЄёЁ0-9.\'\,\-\ \\]+$/;
+  corpusPattern = /^[A-Za-zА-Яа-яїЇіІєЄёЁ0-9]{1,4}$/;
   housePattern = /^[A-Za-zА-Яа-яїЇіІєЄёЁ0-9\.\-\/]+$/;
   entranceNumberPattern = /^-?(0|[1-9]\d*)?$/;
   private destroy: Subject<boolean> = new Subject<boolean>();
@@ -93,7 +94,7 @@ export class UBSAddAddressPopUpComponent implements OnInit, OnDestroy {
         this.data.edit ? this.data.address.houseNumber : '',
         [Validators.required, Validators.maxLength(4), Validators.pattern(this.housePattern)]
       ],
-      houseCorpus: [this.data.edit ? this.data.address.houseCorpus : '', [Validators.maxLength(2), Validators.pattern(this.housePattern)]],
+      houseCorpus: [this.data.edit ? this.data.address.houseCorpus : '', [Validators.maxLength(4), Validators.pattern(this.corpusPattern)]],
       entranceNumber: [
         this.data.edit ? this.data.address.entranceNumber : '',
         [Validators.maxLength(2), Validators.pattern(this.entranceNumberPattern)]


### PR DESCRIPTION
**Preconditions**

Login to GreenCity as a User https://ita-social-projects.github.io/GreenCityClient/#/

**Steps to reproduce**

1. Go to 'UBS кур'єр'
2. Click on the "Замовити кур'єра" button
3. Enter valid data into 'Деталі замовлення' tab (min order sum is 500 uah for Kyiv location)
4. Click on the "Далі'"button
5. Fill in "Корпус" field with 4 characters (e.g 1234)
6. Erase data and populate "Корпус" field with special character “-” (hyphen)(e.g --)

**Actual result**

1. User is able to fill in "Корпус" field up to 2 characters
2. Eror message under "Корпус" field appears 'Перевищена максимальна кількість символів.'
3. User is able to fill in "Корпус" field with special character “-” (hyphen)

<img width="159" alt="138333355-87ebbb1e-e16c-44e5-b0aa-9c158f634d85" src="https://user-images.githubusercontent.com/51053478/138611346-045e69e6-964b-4e8f-9719-ec2b1f9db4f4.png">

<img width="157" alt="138334342-28ef10e3-2cd1-4223-9f20-65cf7f67f498" src="https://user-images.githubusercontent.com/51053478/138611370-012854e9-b03c-4f68-aa41-ac8a7e7ed6c2.png">

**Expected result**

1. User should be able to fill in "Корпус" field up to 4 characters
2. Special characters in "Корпус" field are NOT allowed, only alphabetic and numeric characters