### PR TITLE
BugFix/show street suggestions from google after adding address each time/#3424

### DIFF
--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-add-address-pop-up/ubs-add-address-pop-up.component.scss
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-add-address-pop-up/ubs-add-address-pop-up.component.scss
@@ -1,5 +1,19 @@
 ::ng-deep .pac-container {
   position: fixed !important;
+
+  top: 376px !important;
+
+  @media only screen and (max-width: 300px) {
+    top: 384px !important;
+  }
+
+  @media only screen and (min-width: 301px) and (max-width: 500px) {
+    top: 364px !important;
+  }
+
+  @media only screen and (min-width: 501px) and (max-width: 1000px) {
+    top: 338px !important;
+  }
 }
 
 form {


### PR DESCRIPTION
**Preconditions**

1. Login to GreenCity as a User https://ita-social-projects.github.io/GreenCityClient/#/
2. 'Додати адресу' link should be enabled on the 'Особисті дані' tab (pay attention to the added addresses, maximum 4 are allowed)

**Steps to reproduce**

1. Go to 'UBS кур'єр'
2. Click on the "Замовити кур'єра" button
3. Enter valid data into 'Деталі замовлення' tab (min order sum is 500 uah for Kyiv location)
4. Click on the "Далі" button
5. Click on the 'Додати адресу' link
6. Fill in "Вулиця" field with 1 characters (e.g. А)
7. Pick address from drop down list
8. Click on the 'Додати адресу' link and Fill in "Вулиця" field (e.g. А)

**Actual result**

1. The system shows the street suggestions after user had typed 1 char (when user adding address for the first time)
<img width="451" alt="138336261-576e3a31-ff1a-4ef1-b372-69b7eec60c70" src="https://user-images.githubusercontent.com/51053478/138915108-9b84e620-d855-4290-86c6-92fa259bce2c.png">
2. Drop down list with street suggestions doesn't appear when user adding address for the second time

**Expected result**

1. After typing 3 characters, the system shall show the street suggestions based on the Places API (Place Autocomplete) - in both cases