### PR TITLE
feature/#2828mutual friend page

### DIFF
--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-item/friend-item.component.html
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-item/friend-item.component.html
@@ -13,7 +13,9 @@
         {{ friend.rating }}
       </p>
     </div>
-    <p class="friend-mutual">{{ friend.mutualFriends }} {{ 'profile.friends.mutual-friends' | translate }}</p>
+    <p *ngIf="friend.mutualFriends > 0" class="friend-mutual">
+      <span [class.friend-mutual-link]="!userId">{{ friend.mutualFriends }} {{ 'profile.friends.mutual-friends' | translate }}</span>
+    </p>
     <p class="friend-city">{{ friend.city }}</p>
   </div>
   <div class="friend-btn">

--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-item/friend-item.component.scss
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-item/friend-item.component.scss
@@ -51,6 +51,14 @@ button {
   line-height: 20px;
   color: var(--quaternary-grey);
   margin: 2px;
+
+  .friend-mutual-link {
+    transition: 0.2s;
+
+    &:hover {
+      color: var(--tertiary-dark-grey);
+    }
+  }
 }
 
 .friend-rate {

--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-item/friend-item.component.ts
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-item/friend-item.component.ts
@@ -25,11 +25,21 @@ export class FriendItemComponent {
     if (this.userId) {
       return;
     }
-    this.router.navigate([this.friend.name, this.friend.id], { relativeTo: this.route });
+    this.router.navigate([this.friend.name, this.friend.id], { relativeTo: this.route, queryParams: { tab: 'All firends', index: 3 } });
+  }
+
+  private showMutualFriends(): void {
+    this.router.navigate([this.friend.name, this.friend.id], { relativeTo: this.route, queryParams: { tab: 'Mutual friends', index: 4 } });
   }
 
   public clickHandler(event: MouseEvent): void {
-    const target = (event.target as HTMLElement).tagName;
-    target === 'BUTTON' ? this.friendEvent(this.friend.id) : this.toUsersInfo();
+    const target = event.target as HTMLElement;
+    if (target.tagName === 'BUTTON') {
+      this.friendEvent(this.friend.id);
+    } else if (target.tagName === 'SPAN' && !this.userId) {
+      this.showMutualFriends();
+    } else {
+      this.toUsersInfo();
+    }
   }
 }

--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-dashboard/friend-profile-dashboard.component.html
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-dashboard/friend-profile-dashboard.component.html
@@ -1,6 +1,6 @@
 <div class="dashboard">
   <div>
-    <mat-tab-group animationDuration="400ms" (selectedTabChange)="tabChanged($event)">
+    <mat-tab-group animationDuration="400ms" (selectedTabChange)="tabChanged($event)" [(selectedIndex)]="selectedIndex">
       <mat-tab label="{{ 'user.habit.all-habits.title' | translate }}">
         <div class="img-absent">
           <h3 class="title">{{ 'user.habit.all-habits.title' | translate }}</h3>
@@ -23,33 +23,41 @@
       </mat-tab>
 
       <mat-tab label="{{ 'user.habit.invite.all' | translate }}">
-        <div *ngIf="numberAllFriends > 0; else noFriends">
-          <div class="list-wrapper" *ngIf="friendsList.length > 0">
-            <div *ngFor="let friend of friendsList">
-              <app-friend-item
-                [friend]="friend"
-                (friendEventEmit)="addFriend($event)"
-                btnName="{{ 'profile.friends.add-new-friend' | translate }}"
-              >
-              </app-friend-item>
-            </div>
+        <div class="friends-list">
+          <div *ngFor="let friend of friendsList">
+            <app-friend-item
+              [friend]="friend"
+              (friendEventEmit)="addFriend($event)"
+              btnName="{{ 'profile.friends.add-new-friend' | translate }}"
+            >
+            </app-friend-item>
           </div>
           <app-spinner *ngIf="isFetching"></app-spinner>
         </div>
-        <ng-template #noFriends>
-          <div class="img-absent">
-            <h3 class="no-friends">{{ 'profile.zero-user-friends' | translate }}</h3>
-            <img [src]="absentContent" alt="absent-friends" />
-          </div>
-        </ng-template>
-      </mat-tab>
-
-      <mat-tab label="{{ 'profile.friends.all-mutual-friends' | translate }}">
-        <div class="img-absent">
-          <h3 class="title">{{ 'profile.friends.all-mutual-friends' | translate }}</h3>
+        <div class="img-absent" *ngIf="numberAllFriends === 0 && !isFetching">
+          <h3 class="no-friends">{{ 'profile.zero-user-friends' | translate }}</h3>
           <img [src]="absentContent" alt="absent-friends" />
         </div>
       </mat-tab>
+
+      <mat-tab label="{{ 'profile.friends.all-mutual-friends' | translate }}">
+        <div class="friends-list">
+          <div *ngFor="let friend of mutualFriendsList">
+            <app-friend-item
+              [friend]="friend"
+              (friendEventEmit)="addFriend($event)"
+              btnName="{{ 'profile.friends.add-new-friend' | translate }}"
+            >
+            </app-friend-item>
+          </div>
+          <app-spinner *ngIf="isFetching"></app-spinner>
+        </div>
+        <div class="img-absent" *ngIf="numberAllMutualFriends === 0 && !isFetching">
+          <h3 class="no-friends">{{ 'profile.zero-user-friends' | translate }}</h3>
+          <img [src]="absentContent" alt="absent-friends" />
+        </div>
+      </mat-tab>
+
       <div
         infiniteScroll
         [infiniteScrollDistance]="1"

--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-dashboard/friend-profile-dashboard.component.scss
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-dashboard/friend-profile-dashboard.component.scss
@@ -3,9 +3,10 @@
   margin-bottom: 30px;
 }
 
-.list-wrapper {
+.friends-list {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   margin-top: 25px;
 }
 

--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-dashboard/friend-profile-dashboard.component.spec.ts
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-dashboard/friend-profile-dashboard.component.spec.ts
@@ -1,6 +1,6 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { UserFriendsService } from '@global-user/services/user-friends.service';
 import { TranslateModule } from '@ngx-translate/core';
 import { of, Subject } from 'rxjs';
@@ -37,14 +37,16 @@ describe('FriendProfileDashboardComponent', () => {
   let userFriendsServiceMock: UserFriendsService;
   userFriendsServiceMock = jasmine.createSpyObj('UserFriendsService', {
     getAllFriends: of({}),
-    addFriend: of({})
+    addFriend: of({}),
+    getPossibleFriends: of({})
   });
   const activatedRouteMock = {
     snapshot: {
       params: {
         userId: 1,
         id: 2
-      }
+      },
+      queryParams: { index: 4 }
     }
   };
   beforeEach(async(() => {
@@ -52,7 +54,8 @@ describe('FriendProfileDashboardComponent', () => {
       declarations: [FriendProfileDashboardComponent],
       providers: [
         { provide: UserFriendsService, useValue: userFriendsServiceMock },
-        { provide: ActivatedRoute, useValue: activatedRouteMock }
+        { provide: ActivatedRoute, useValue: activatedRouteMock },
+        { provide: Router, useValue: {} }
       ],
       imports: [TranslateModule.forRoot()],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
@@ -76,13 +79,13 @@ describe('FriendProfileDashboardComponent', () => {
   });
 
   it('method onScroll should call getAllFriends', () => {
-    // @ts-ignore
-    component.totalPages = 24;
+    component.numberAllFriends = 24;
+    component.selectedIndex = 3;
     const spy = spyOn(component as any, 'getAllFriends').and.callFake(() => {});
     component.onScroll();
-    // @ts-ignore
     expect(spy).toHaveBeenCalled();
-    expect(userFriendsServiceMock.getAllFriends).toHaveBeenCalledWith(1, undefined, 2);
+    fixture.detectChanges();
+    expect(userFriendsServiceMock.getAllFriends).toHaveBeenCalledWith(1, undefined);
   });
 
   it('method addFriend should userFriendsService.addFriend', () => {


### PR DESCRIPTION
Acceptance Criteria
When a user is on the All Friends tab, a user should see a number of mutual friends on each person’s card following the rule:
a.People with the biggest number of mutual friends are shown first.
If there are no mutual friends, the system should not display the linked number.
The number of mutual friends should be linked to the mutual friends list.
When a user clicks on a number of mutual friends, then the system redirects a user to the Mutual Friends tab.
Epic link
Epic “My habit”[ #938]