### PR TITLE
Feature/#3440/Customer details page

### DIFF
--- a/src/app/main/service/localstorage/local-storage.service.ts
+++ b/src/app/main/service/localstorage/local-storage.service.ts
@@ -156,7 +156,7 @@ export class LocalStorageService {
     return JSON.parse(localStorage.getItem('currentCustomer'));
   }
 
-  public remuveCurrentCustomer(): void {
+  public removeCurrentCustomer(): void {
     localStorage.removeItem('currentCustomer');
   }
 }

--- a/src/app/main/service/localstorage/local-storage.service.ts
+++ b/src/app/main/service/localstorage/local-storage.service.ts
@@ -147,4 +147,16 @@ export class LocalStorageService {
   public getLocations(): any {
     return JSON.parse(localStorage.getItem('locations'));
   }
+
+  public setCustomer(customer) {
+    return localStorage.setItem('currentCustomer', JSON.stringify(customer));
+  }
+
+  public getCustomer() {
+    return JSON.parse(localStorage.getItem('currentCustomer'));
+  }
+
+  public remuveCurrentCustomer(): void {
+    localStorage.removeItem('currentCustomer');
+  }
 }

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.html
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.html
@@ -1,0 +1,49 @@
+<div class="ubs_customer-container mx-auto">
+  <div class="container">
+    <div class="row">
+      <div class="ubs_customer-back">
+        <p (click)="goBack()">< {{ 'customer-details.goBack' | translate }}</p>
+      </div>
+      <div class="ubs_customer-header">
+        <div class="header-text">
+          <h3>{{ 'customer-details.data' | translate }}</h3>
+        </div>
+      </div>
+      <div class="input-group input-group-sm">
+        <div>
+          <h5>{{ 'customer-details.personal' | translate }}</h5>
+          <div class="form-group col-sm-5">
+            <label for="clientName">{{ 'customer-details.name' | translate }}</label>
+            <p>{{ customer?.clientName }}</p>
+          </div>
+          <h5>{{ 'customer-details.contacts' | translate }}</h5>
+          <div class="form-group col-sm-5">
+            <label for="recipientEmail" class="form-label">{{ 'customer-details.email' | translate }}</label>
+            <p>{{ customer?.recipientEmail }}</p>
+          </div>
+          <div class="form-group col-sm-4">
+            <label for="recipientPhone" class="form-label">{{ 'customer-details.phone' | translate }}</label>
+            <p>{{ customer?.recipientPhone }}</p>
+          </div>
+          <h5>{{ 'customer-details.additionalInfo' | translate }}</h5>
+          <div class="form-group col-sm-3">
+            <label for="dateOfRegistration" class="form-label">{{ 'customer-details.dateOfRegistration' | translate }}</label>
+            <p>{{ customer?.dateOfRegistration }}</p>
+          </div>
+          <div class="form-group col-sm-3">
+            <label for="number_of_orders" class="form-label">{{ 'customer-details.number_of_orders' | translate }}</label>
+            <p>{{ customer?.number_of_orders }}</p>
+          </div>
+          <div class="form-group col-sm-3">
+            <label for="orderDate" class="form-label">{{ 'customer-details.orderDate' | translate }}</label>
+            <p>{{ customer?.orderDate }}</p>
+          </div>
+          <div class="form-group col-sm-3">
+            <label for="violations" class="form-label">{{ 'customer-details.violations' | translate }}</label>
+            <p>{{ customer?.violations }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.scss
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.scss
@@ -1,0 +1,77 @@
+.ubs_customer-container {
+  font-family: var(--primary-font);
+  font-size: 0.9em;
+  max-width: 1200px;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 100px;
+
+  .ubs_customer-back {
+    background-color: transparent;
+    color: var(--ubs-primary-green);
+    border: none;
+    font-size: 18px;
+    font-weight: bold;
+
+    p {
+      cursor: pointer;
+      margin-bottom: 0;
+    }
+  }
+
+  .ubs_customer-header {
+    width: 905px;
+
+    .header-text {
+      padding-top: 25px;
+    }
+  }
+
+  .input-group {
+    padding: 20px;
+    width: 905px;
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25);
+
+    form {
+      margin-left: 15px;
+    }
+  }
+
+  label {
+    margin: 0;
+    color: var(--ubs-secondary-grey);
+    white-space: nowrap;
+  }
+
+  h5 {
+    font-weight: bold;
+    margin: 30px 0 30px 15px;
+  }
+
+  h3 {
+    font-weight: bold;
+    color: black;
+  }
+
+  .form-group {
+    p {
+      padding: 13px 0;
+      color: black;
+      font-size: 16px;
+      white-space: nowrap;
+      margin-bottom: 0;
+    }
+  }
+}
+
+@media (max-width: 1439px) {
+  .ubs_customer-container {
+    max-width: 800px;
+  }
+}
+
+@media (max-width: 992px) {
+  .ubs_customer-container {
+    max-width: 600px;
+  }
+}

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.spec.ts
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.spec.ts
@@ -11,7 +11,7 @@ describe('UbsAdminCustomerDetailsComponent', () => {
   let fixture: ComponentFixture<UbsAdminCustomerDetailsComponent>;
 
   let localStorageServiceMock: LocalStorageService;
-  localStorageServiceMock = jasmine.createSpyObj('LocalStorageService', ['getCustomer', 'remuveCurrentCustomer']);
+  localStorageServiceMock = jasmine.createSpyObj('LocalStorageService', ['getCustomer', 'removeCurrentCustomer']);
   let locationMock: Location;
 
   beforeEach(async(() => {

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.spec.ts
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.spec.ts
@@ -11,7 +11,7 @@ describe('UbsAdminCustomerDetailsComponent', () => {
   let fixture: ComponentFixture<UbsAdminCustomerDetailsComponent>;
 
   let localStorageServiceMock: LocalStorageService;
-  localStorageServiceMock = jasmine.createSpyObj('LocalStorageService', ['getCustomer', 'setCustomer', 'remuveCurrentCustomer']);
+  localStorageServiceMock = jasmine.createSpyObj('LocalStorageService', ['getCustomer', 'remuveCurrentCustomer']);
   let locationMock: Location;
 
   beforeEach(async(() => {

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.spec.ts
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.spec.ts
@@ -1,0 +1,42 @@
+import { Location } from '@angular/common';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { UbsAdminCustomerDetailsComponent } from './ubs-admin-customer-details.component';
+
+describe('UbsAdminCustomerDetailsComponent', () => {
+  let component: UbsAdminCustomerDetailsComponent;
+  let fixture: ComponentFixture<UbsAdminCustomerDetailsComponent>;
+
+  let localStorageServiceMock: LocalStorageService;
+  localStorageServiceMock = jasmine.createSpyObj('LocalStorageService', ['getCustomer', 'setCustomer', 'remuveCurrentCustomer']);
+  let locationMock: Location;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+      declarations: [UbsAdminCustomerDetailsComponent],
+      providers: [{ provide: LocalStorageService, useValue: localStorageServiceMock }, Location],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UbsAdminCustomerDetailsComponent);
+    component = fixture.componentInstance;
+    locationMock = TestBed.inject(Location);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('goBack() should be called', () => {
+    const spyLock = spyOn(locationMock, 'back');
+    component.goBack();
+    expect(spyLock).toHaveBeenCalled();
+  });
+});

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
+import { Location } from '@angular/common';
+
+@Component({
+  selector: 'app-ubs-admin-customer-details',
+  templateUrl: './ubs-admin-customer-details.component.html',
+  styleUrls: ['./ubs-admin-customer-details.component.scss']
+})
+export class UbsAdminCustomerDetailsComponent implements OnInit {
+  customer: any;
+
+  constructor(private localStorageService: LocalStorageService, private location: Location) {}
+
+  ngOnInit(): void {
+    this.customer = this.localStorageService.getCustomer();
+  }
+
+  goBack(): void {
+    this.localStorageService.remuveCurrentCustomer();
+    this.location.back();
+  }
+}

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component.ts
@@ -17,7 +17,7 @@ export class UbsAdminCustomerDetailsComponent implements OnInit {
   }
 
   goBack(): void {
-    this.localStorageService.remuveCurrentCustomer();
+    this.localStorageService.removeCurrentCustomer();
     this.location.back();
   }
 }

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.html
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.html
@@ -41,8 +41,8 @@
           [matTooltip]="row[column.title.key]"
           matTooltipShowDelay="700"
           matTooltipClass="tooltip_style"
-          (click)="column.title.key === 'clientName' && openCustomer(row, row[column.title.key])"
           [class.pointer]="column.title.key === 'clientName'"
+          (click)="column.title.key === 'clientName' && openCustomer(row, row[column.title.key])"
         >
           {{ row[column.title.key] }}
         </div>

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.html
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.html
@@ -36,7 +36,14 @@
         </div>
       </mat-header-cell>
       <mat-cell *matCellDef="let row">
-        <div class="column_cell" [matTooltip]="row[column.title.key]" matTooltipShowDelay="700" matTooltipClass="tooltip_style">
+        <div
+          class="column_cell"
+          [matTooltip]="row[column.title.key]"
+          matTooltipShowDelay="700"
+          matTooltipClass="tooltip_style"
+          (click)="column.title.key === 'clientName' && openCustomer(row, row[column.title.key])"
+          [class.pointer]="column.title.key === 'clientName'"
+        >
           {{ row[column.title.key] }}
         </div>
       </mat-cell>

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.scss
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.scss
@@ -154,3 +154,7 @@
 .tooltip_style {
   font-size: 14px;
 }
+
+.pointer {
+  cursor: pointer;
+}

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.ts
@@ -12,6 +12,7 @@ import {
 } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { MatTable, MatTableDataSource } from '@angular/material/table';
+import { Router } from '@angular/router';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -62,7 +63,8 @@ export class UbsAdminCustomersComponent implements OnInit, AfterViewChecked, OnD
     private tableHeightService: TableHeightService,
     private adminCustomerService: AdminCustomersService,
     public dialog: MatDialog,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private router: Router
   ) {}
 
   ngOnInit() {
@@ -232,6 +234,11 @@ export class UbsAdminCustomersComponent implements OnInit, AfterViewChecked, OnD
   @HostListener('window:resize', ['$event'])
   onResize() {
     this.setTableResize(this.matTableRef.nativeElement.clientWidth);
+  }
+
+  public openCustomer(row, username): void {
+    this.localStorageService.setCustomer(row);
+    this.router.navigate(['ubs-admin', 'customers', `${username.replaceAll(' ', '')}`]);
   }
 
   ngOnDestroy() {

--- a/src/app/ubs-admin/ubs-admin-routing.module.ts
+++ b/src/app/ubs-admin/ubs-admin-routing.module.ts
@@ -9,6 +9,7 @@ import { UbsAdminCertificateComponent } from './components/ubs-admin-certificate
 import { UbsAdminCustomersComponent } from './components/ubs-admin-customers/ubs-admin-customers.component';
 import { UbsAdminTariffsLocationDashboardComponent } from './components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component';
 import { UbsAdminTariffsPricingPageComponent } from './components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component';
+import { UbsAdminCustomerDetailsComponent } from './components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component';
 
 const ubsAdminRoutes: Routes = [
   {
@@ -17,6 +18,7 @@ const ubsAdminRoutes: Routes = [
     canActivate: [UbsAdminGuardGuard],
     children: [
       { path: 'customers', component: UbsAdminCustomersComponent },
+      { path: 'customers/:username', component: UbsAdminCustomerDetailsComponent },
       { path: 'certificates', component: UbsAdminCertificateComponent },
       { path: 'orders', component: UbsAdminTableComponent },
       { path: 'employee/:page', component: UbsAdminEmployeeComponent },

--- a/src/app/ubs-admin/ubs-admin.module.ts
+++ b/src/app/ubs-admin/ubs-admin.module.ts
@@ -53,6 +53,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { UbsAdminTariffsDeletePopUpComponent } from './components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-delete-pop-up/ubs-admin-tariffs-delete-pop-up.component';
 import { UbsAdminTariffsAddServicePopUpComponent } from './components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component';
 import { UbsAdminEmployeeTableComponent } from './components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component';
+import { UbsAdminCustomerDetailsComponent } from './components/ubs-admin-customers/ubs-admin-customer-details/ubs-admin-customer-details.component';
 
 @NgModule({
   declarations: [
@@ -87,7 +88,8 @@ import { UbsAdminEmployeeTableComponent } from './components/ubs-admin-employee/
     UbsAdminTariffsPricingPageComponent,
     UbsAdminTariffsAddTariffServicePopUpComponent,
     UbsAdminTariffsLocationDashboardComponent,
-    UbsAdminEmployeeTableComponent
+    UbsAdminEmployeeTableComponent,
+    UbsAdminCustomerDetailsComponent
   ],
   imports: [
     CommonModule,

--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -130,6 +130,20 @@
       "button": "Add violation"
     }
   },
+  "customer-details": {
+    "data": "Customer Data",
+    "personal": "Personal",
+    "name": "Name",
+    "contacts": "Contacts",
+    "email": "Email",
+    "phone": "Phone",
+    "additionalInfo": "Additional information",
+    "number_of_orders": "Number of orders",
+    "orderDate": "Date of order",
+    "violations": "Violations",
+    "dateOfRegistration": "Date of registration",
+    "goBack": "Back"
+  },
   "order-details": {
     "title": "Order details",
     "service": "Service",

--- a/src/assets/i18n/ubs-admin/ua.json
+++ b/src/assets/i18n/ubs-admin/ua.json
@@ -128,6 +128,20 @@
       "button": "Додати порушення"
     }
   },
+  "customer-details": {
+    "data": "Дані клієнта",
+    "personal": "Особисте",
+    "name": "Нікнейм ",
+    "contacts": "Контакти",
+    "email": "Електронна скринька",
+    "phone": "№ телефону",
+    "additionalInfo": "Додаткова інформація",
+    "number_of_orders": "Кількість замовлень",
+    "orderDate": "Дата замовлення",
+    "violations": "Порушення",
+    "dateOfRegistration": "Дата реєстрації",
+    "goBack": "Назад"
+  },
   "order-details": {
     "title": "Деталі замовлення",
     "service": "Послуга",


### PR DESCRIPTION
As an administrator, I want to see all information about current client.
Preconditions

1. User is logged in as administrator
2. The administrator navigates to Admin Cabinet
3. Click on the name of any client in the table

Result:
![image](https://user-images.githubusercontent.com/49165350/139397541-87f774de-b33b-4816-9ec3-423eb8c7a242.png)

Feature:
https://github.com/ita-social-projects/GreenCity/issues/3440#issue-1037675579
