### PR TITLE
Bugfix/#1903/Edit size of view list

### DIFF
--- a/src/app/main/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
+++ b/src/app/main/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
@@ -12,6 +12,7 @@ div {
 }
 
 .eco-news_list-view-wrp {
+  width: 540px;
   height: 192px;
   -webkit-box-shadow: 1px 1px 12px rgba(27, 51, 38, 0.15);
   box-shadow: 1px 1px 12px rgba(27, 51, 38, 0.15);
@@ -93,7 +94,7 @@ div {
     display: block;
     object-fit: cover;
     -o-object-fit: cover;
-    height: 92.31%;
+    height: 100%;
     width: 100%;
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
@@ -102,6 +103,7 @@ div {
 
   .eco-news_list-view-wrp {
     height: 204px;
+    width: 720px;
     display: -ms-grid;
     display: grid;
     -ms-grid-columns: 204px auto;
@@ -112,12 +114,17 @@ div {
 @media (min-width: 1024px) {
   .eco-news_list-view-wrp {
     height: 204px;
+    width: 960px;
     -ms-grid-columns: 359px auto;
     grid-template-columns: 359px auto;
   }
 }
 
 @media (min-width: 1440px) {
+  .eco-news_list-view-wrp {
+    width: 1140px;
+  }
+
   .eco-news_list-content {
     height: 204px;
     grid-template-rows: 20px 96px 20px;


### PR DESCRIPTION
Steps to reproduce:
 Click on the 'Eco news' button
 Click on the button to sort news as column
 Click on the 'List view' icon
 Verify UI elements' size and alignments of the news item on 1199-992 resolution (ex. 1024 as we have mock - up with resolution 1024)with dev tool help.
 Pay attention to the result.

Bug fixed: https://github.com/ita-social-projects/GreenCity/issues/1903#issue-748037903