### PR TITLE
Bugfix/ubs employee photo/#3410

### DIFF
--- a/src/app/ubs-admin/components/ubs-admin-employee/employee-form/employee-form.component.html
+++ b/src/app/ubs-admin/components/ubs-admin-employee/employee-form/employee-form.component.html
@@ -65,7 +65,12 @@
     </ng-template>
     <div class="button-row">
       <button mat-dialog-close class="cancelButton">{{ 'ubs-employee.cancel' | translate }}</button>
-      <button type="submit" class="addButton" [disabled]="employeeForm.invalid || !employeePositions.length || !receivingStations.length">
+      <button
+        type="submit"
+        class="addButton"
+        [disabled]="employeeForm.invalid || !employeePositions.length || !receivingStations.length || isUploading"
+      >
+        <span *ngIf="isUploading" class="spinner-border spinner-border-sm" role="status" aria-hidden="true"> </span>
         {{ (isUpdatingEmployee ? 'ubs-employee.update' : 'ubs-employee.add') | translate }}
       </button>
     </div>

--- a/src/app/ubs-admin/components/ubs-admin-employee/employee-form/employee-form.component.scss
+++ b/src/app/ubs-admin/components/ubs-admin-employee/employee-form/employee-form.component.scss
@@ -114,7 +114,7 @@ label {
 .cancelButton,
 .addButton {
   height: 36px;
-  padding: 6px 14px;
+  padding: 8px 4px;
   border-radius: 5px;
   font-size: 14px;
   font-weight: 500;
@@ -132,6 +132,9 @@ label {
   color: var(--ubs-quaternary-dark-grey);
   border: 1px solid var(--ubs-button-light-green);
   background: var(--ubs-button-light-green);
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
 
   &:disabled {
     background: var(--ubs-quaternary-light-grey);

--- a/src/app/ubs-admin/components/ubs-admin-employee/employee-form/employee-form.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-employee/employee-form/employee-form.component.ts
@@ -18,9 +18,10 @@ export class EmployeeFormComponent implements OnInit {
   phoneMask = '{+38} (000) 00 000 00';
   private maxImageSize = 10485760;
   public isWarning = false;
-  imageURL: string | ArrayBuffer;
+  imageURL: string;
   imageName = 'Your Avatar';
   selectedFile;
+  imageFile;
   defaultPhotoURL = 'https://csb10032000a548f571.blob.core.windows.net/allfiles/90370622-3311-4ff1-9462-20cc98a64d1ddefault_image.jpg';
 
   ngOnInit() {
@@ -105,24 +106,33 @@ export class EmployeeFormComponent implements OnInit {
     return this.receivingStations.some((station) => location.id === station.id);
   }
 
-  prepareEmployeeDataToSend(dto: string): FormData {
+  prepareEmployeeDataToSend(dto: string, image?: string): FormData {
     const employeeDataToSend = {
       ...this.employeeForm.value,
-      image: this.imageURL || this.defaultPhotoURL,
       employeePositions: this.employeePositions,
       receivingStations: this.receivingStations
     };
     if (this.isUpdatingEmployee) {
       employeeDataToSend.id = this.data.id;
     }
+    if (image) {
+      employeeDataToSend.image = image;
+    }
     const formData: FormData = new FormData();
     const stringifiedDataToSend = JSON.stringify(employeeDataToSend);
     formData.append(dto, stringifiedDataToSend);
+    this.selectedFile && formData.append('image', this.selectedFile);
     return formData;
   }
 
   updateEmployee(): void {
-    const dataToSend = this.prepareEmployeeDataToSend('employeeDto');
+    let image: string;
+    if (this.selectedFile) {
+      image = this.defaultPhotoURL;
+    } else {
+      image = this.imageURL || this.defaultPhotoURL;
+    }
+    const dataToSend = this.prepareEmployeeDataToSend('employeeDto', image);
     this.employeeService.updateEmployee(dataToSend).subscribe(() => {
       this.dialogRef.close();
     });
@@ -173,5 +183,6 @@ export class EmployeeFormComponent implements OnInit {
   removeImage() {
     this.imageURL = null;
     this.imageName = null;
+    this.selectedFile = null;
   }
 }

--- a/src/app/ubs-admin/components/ubs-admin-employee/employee-form/employee-form.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-employee/employee-form/employee-form.component.ts
@@ -128,12 +128,7 @@ export class EmployeeFormComponent implements OnInit {
   }
 
   updateEmployee(): void {
-    let image: string;
-    if (this.selectedFile) {
-      image = this.defaultPhotoURL;
-    } else {
-      image = this.imageURL || this.defaultPhotoURL;
-    }
+    const image = this.selectedFile ? this.defaultPhotoURL : this.imageURL || this.defaultPhotoURL;
     const dataToSend = this.prepareEmployeeDataToSend('employeeDto', image);
     this.employeeService.updateEmployee(dataToSend).subscribe(
       () => {

--- a/src/app/ubs-admin/components/ubs-admin-employee/employee-form/employee-form.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-employee/employee-form/employee-form.component.ts
@@ -18,6 +18,7 @@ export class EmployeeFormComponent implements OnInit {
   phoneMask = '{+38} (000) 00 000 00';
   private maxImageSize = 10485760;
   public isWarning = false;
+  public isUploading = false;
   imageURL: string;
   imageName = 'Your Avatar';
   selectedFile;
@@ -107,6 +108,7 @@ export class EmployeeFormComponent implements OnInit {
   }
 
   prepareEmployeeDataToSend(dto: string, image?: string): FormData {
+    this.isUploading = true;
     const employeeDataToSend = {
       ...this.employeeForm.value,
       employeePositions: this.employeePositions,
@@ -133,16 +135,28 @@ export class EmployeeFormComponent implements OnInit {
       image = this.imageURL || this.defaultPhotoURL;
     }
     const dataToSend = this.prepareEmployeeDataToSend('employeeDto', image);
-    this.employeeService.updateEmployee(dataToSend).subscribe(() => {
-      this.dialogRef.close();
-    });
+    this.employeeService.updateEmployee(dataToSend).subscribe(
+      () => {
+        this.dialogRef.close();
+        this.isUploading = false;
+      },
+      () => {
+        this.isUploading = false;
+      }
+    );
   }
 
   createEmployee(): void {
     const dataToSend = this.prepareEmployeeDataToSend('addEmployeeDto');
-    this.employeeService.postEmployee(dataToSend).subscribe(() => {
-      this.dialogRef.close();
-    });
+    this.employeeService.postEmployee(dataToSend).subscribe(
+      () => {
+        this.dialogRef.close();
+        this.isUploading = false;
+      },
+      () => {
+        this.isUploading = false;
+      }
+    );
   }
 
   treatFileInput(event: Event): void {

--- a/src/app/ubs-admin/components/ubs-admin-employee/employee-form/employee-form.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-employee/employee-form/employee-form.component.ts
@@ -123,7 +123,9 @@ export class EmployeeFormComponent implements OnInit {
     const formData: FormData = new FormData();
     const stringifiedDataToSend = JSON.stringify(employeeDataToSend);
     formData.append(dto, stringifiedDataToSend);
-    this.selectedFile && formData.append('image', this.selectedFile);
+    if (this.selectedFile) {
+      formData.append('image', this.selectedFile);
+    }
     return formData;
   }
 


### PR DESCRIPTION
**Achieved results::**
- the admin can add and change employee's photo

**Preconditions:**
1. The User should be logged in GreenCity as Admin
2. Go to the UBS-Admin page
3. Click on the "Employees" on the sidebar menu
4a. Click the "Add Employee" button and create a new employee with a photo
4b. Click the "Edit" button on the employee's and update the photo

**Fixed bug:** [[UBS Admin, Employees] Admin can't change employee's photo #3410](https://github.com/ita-social-projects/GreenCity/issues/3410)