### PR TITLE
Do main page and sidebar responsive #3502

### DIFF
--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
@@ -68,11 +68,7 @@ export class UbsBaseSidebarComponent implements AfterViewInit, OnDestroy {
     setTimeout(() => {
       this.breakpointObserver.observe([Breakpoints.Small, Breakpoints.XSmall]).subscribe((result) => {
         if (this.drawer) {
-          if (result.matches) {
-            this.drawer.mode = 'over';
-          } else {
-            this.drawer.mode = 'side';
-          }
+          this.drawer.mode = 'side';
         }
       });
     }, 0);


### PR DESCRIPTION
**Preconditions**

1. Login to GreenCity as a User https://ita-social-projects.github.io/GreenCityClient/#/

**Steps to reproduce**

1. Go to 'UBS-user'
2. Go to ‘User data’, 'Orders', 'Invoice', 'Messages'
3. Open Devtool
4. Resize the pages by dragging the corner of window to size 960x705
5. Resize the pages by choosing any dimension from 'Dimensions: Responsive' dropdown

**Actual result**
Leftside panel is unfolded, UI controls of ‘User data’, 'Orders', 'Invoice', 'Messages' pages are not visible, not available
![141152740-db20abdf-b19c-41aa-a1a6-142c85365744](https://user-images.githubusercontent.com/51053478/141314289-58f9be6d-fb62-4037-a7e4-07e99c3764f0.png)

**Expected result**

Leftside panel is folded in a way that only icons of its options are visible, UI controls of ‘User data’, 'Orders', 'Invoice', 'Messages' pages are visible and available