### PR TITLE
Bug fix/system allows user to sign in with old password after user has changed password to new one/#3482

### DIFF
--- a/src/app/main/model/updatePasswordDto.ts
+++ b/src/app/main/model/updatePasswordDto.ts
@@ -1,0 +1,5 @@
+export class UpdatePasswordDto {
+  confirmPassword: string;
+  currentPassword: string;
+  password: string;
+}

--- a/src/app/main/service/auth/change-password.service.ts
+++ b/src/app/main/service/auth/change-password.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { changePasswordLink, updatePasswordLink } from '../../links';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { RestoreDto } from '../../model/restroreDto';
 import { Observable } from 'rxjs';
 import { UpdatePasswordDto } from '@global-models/updatePasswordDto';
@@ -9,17 +9,11 @@ import { UpdatePasswordDto } from '@global-models/updatePasswordDto';
 export class ChangePasswordService {
   constructor(private http: HttpClient) {}
 
-  private accessToken: string = localStorage.getItem('accessToken');
-
   public restorePassword(dto: RestoreDto): Observable<object> {
     return this.http.post<object>(updatePasswordLink, dto);
   }
 
   public changePassword(updatePasswordDto: UpdatePasswordDto): Observable<object> {
-    const myHeaders = new HttpHeaders({
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${this.accessToken}`
-    });
-    return this.http.put<object>(changePasswordLink, updatePasswordDto, { headers: myHeaders });
+    return this.http.put<UpdatePasswordDto>(changePasswordLink, updatePasswordDto);
   }
 }

--- a/src/app/main/service/auth/change-password.service.ts
+++ b/src/app/main/service/auth/change-password.service.ts
@@ -3,27 +3,23 @@ import { changePasswordLink, updatePasswordLink } from '../../links';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { RestoreDto } from '../../model/restroreDto';
 import { Observable } from 'rxjs';
-import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { UpdatePasswordDto } from '@global-models/updatePasswordDto';
 
 @Injectable({ providedIn: 'root' })
 export class ChangePasswordService {
-  constructor(private http: HttpClient, private localStorageService: LocalStorageService) {}
+  constructor(private http: HttpClient) {}
 
   private accessToken: string = localStorage.getItem('accessToken');
-
-  private httpOptions = {
-    headers: new HttpHeaders({
-      Authorization: 'my-auth-token'
-    })
-  };
 
   public restorePassword(dto: RestoreDto): Observable<object> {
     return this.http.post<object>(updatePasswordLink, dto);
   }
 
   public changePassword(updatePasswordDto: UpdatePasswordDto): Observable<object> {
-    this.httpOptions.headers.set('Authorization', `Bearer ${this.accessToken}`);
-    return this.http.post<object>(changePasswordLink, updatePasswordDto, this.httpOptions);
+    const myHeaders = new HttpHeaders({
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.accessToken}`
+    });
+    return this.http.put<object>(changePasswordLink, updatePasswordDto, { headers: myHeaders });
   }
 }

--- a/src/app/main/service/auth/change-password.service.ts
+++ b/src/app/main/service/auth/change-password.service.ts
@@ -1,14 +1,29 @@
 import { Injectable } from '@angular/core';
-import { updatePasswordLink } from '../../links';
-import { HttpClient } from '@angular/common/http';
+import { changePasswordLink, updatePasswordLink } from '../../links';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { RestoreDto } from '../../model/restroreDto';
 import { Observable } from 'rxjs';
+import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
+import { UpdatePasswordDto } from '@global-models/updatePasswordDto';
 
 @Injectable({ providedIn: 'root' })
 export class ChangePasswordService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private localStorageService: LocalStorageService) {}
+
+  private accessToken: string = localStorage.getItem('accessToken');
+
+  private httpOptions = {
+    headers: new HttpHeaders({
+      Authorization: 'my-auth-token'
+    })
+  };
 
   public restorePassword(dto: RestoreDto): Observable<object> {
     return this.http.post<object>(updatePasswordLink, dto);
+  }
+
+  public changePassword(updatePasswordDto: UpdatePasswordDto): Observable<object> {
+    this.httpOptions.headers.set('Authorization', `Bearer ${this.accessToken}`);
+    return this.http.post<object>(changePasswordLink, updatePasswordDto, this.httpOptions);
   }
 }

--- a/src/app/shared/interceptors/interceptor.service.ts
+++ b/src/app/shared/interceptors/interceptor.service.ts
@@ -42,6 +42,9 @@ export class InterceptorService implements HttpInterceptor {
    * @param next - {@link HttpHandler}
    */
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    if (this.localStorageService.getAccessToken()) {
+      req = this.addAccessTokenToHeader(req, this.localStorageService.getAccessToken());
+    }
     if (this.isQueryWithSecurity(req.url)) {
       return next.handle(req).pipe(
         catchError((error: HttpErrorResponse) => {
@@ -51,9 +54,6 @@ export class InterceptorService implements HttpInterceptor {
           return throwError(error);
         })
       );
-    }
-    if (this.localStorageService.getAccessToken()) {
-      req = this.addAccessTokenToHeader(req, this.localStorageService.getAccessToken());
     }
     if (this.isQueryWithProcessOrder(req.url)) {
       return next.handle(req).pipe(

--- a/src/app/ubs-user/ubs-user-profile-page/ubs-profile-change-password-pop-up/ubs-profile-change-password-pop-up.component.html
+++ b/src/app/ubs-user/ubs-user-profile-page/ubs-profile-change-password-pop-up/ubs-profile-change-password-pop-up.component.html
@@ -31,7 +31,7 @@
   <div class="action-btns">
     <mat-dialog-actions align="end">
       <button class="btn btn-outline-success" mat-dialog-close>{{ 'ubs-client-profile.btn.change-password-cancel' | translate }}</button>
-      <button class="btn btn-success" mat-dialog-close [disabled]="formConfig.invalid" cdkFocusInitial>
+      <button class="btn btn-success" (click)="onSubmit()" mat-dialog-close [disabled]="formConfig.invalid" cdkFocusInitial>
         {{ 'ubs-client-profile.btn.change-password' | translate }}
       </button>
     </mat-dialog-actions>

--- a/src/app/ubs-user/ubs-user-profile-page/ubs-profile-change-password-pop-up/ubs-profile-change-password-pop-up.component.ts
+++ b/src/app/ubs-user/ubs-user-profile-page/ubs-profile-change-password-pop-up/ubs-profile-change-password-pop-up.component.ts
@@ -1,6 +1,8 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { UpdatePasswordDto } from '@global-models/updatePasswordDto';
+import { ChangePasswordService } from '@global-service/auth/change-password.service';
 
 @Component({
   selector: 'app-ubs-profile-change-password-pop-up',
@@ -10,11 +12,13 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 export class UbsProfileChangePasswordPopUpComponent implements OnInit {
   public formConfig: FormGroup;
   private readonly passRegexp = /^(?=.*[A-Za-z]+)(?=.*\d+)(?=.*[~`!@#$%^&*()+=_\-{}|:;”’?\/<>,.\]\[]+).{8,}$/;
+  public updatePasswordDto: UpdatePasswordDto;
 
-  constructor(@Inject(MAT_DIALOG_DATA) public data: any, private fb: FormBuilder) {}
+  constructor(private changePasswordService: ChangePasswordService, @Inject(MAT_DIALOG_DATA) public data: any, private fb: FormBuilder) {}
 
   ngOnInit() {
     this.initForm();
+    this.updatePasswordDto = new UpdatePasswordDto();
   }
 
   private initForm(): void {
@@ -38,5 +42,12 @@ export class UbsProfileChangePasswordPopUpComponent implements OnInit {
     const password = group.get('password').value;
     const currentPassword = group.get('currentPassword').value;
     return password !== currentPassword ? null : { same: true };
+  }
+
+  public onSubmit(): void {
+    this.updatePasswordDto.confirmPassword = this.formConfig.value.confirmPassword;
+    this.updatePasswordDto.currentPassword = this.formConfig.value.currentPassword;
+    this.updatePasswordDto.password = this.formConfig.value.password;
+    this.changePasswordService.changePassword(this.updatePasswordDto).subscribe();
   }
 }


### PR DESCRIPTION
**Preconditions**

1. Login to GreenCity as a User https://ita-social-projects.github.io/GreenCityClient/#/

**Steps to reproduce**

1. Click on logged in user in the right top corner of the screen
2. Select 'UBS-user' from drop down list
3. Click on "Дані користувача" tab and scroll to the end of a page
4. Click on "Змінити пароль" button
5. Fill in pop up window with correct data (old password, new password and confirm password)
6. Click on "Змінити пароль" button
7. Log out from personal cabinet (select "Вийти" from drop down list)
8. Click on "Увійти" button on menu bar
9. Fill in form with email address and NEW password and click on "Увійти" button
10. Erase password field and populated this field with OLD password

**Actual result**

1. System does't allow user to sing in with new password and warning message "Неправильна пошта або пароль" appears
<img width="413" alt="140659551-71badc93-df62-47f4-84f2-627ab5f7559a" src="https://user-images.githubusercontent.com/51053478/141374284-4e451675-03a3-4c8c-936d-a2838dc59f24.png">
2. System allow user to sing in with old password

**Expected result**

1. System should allow user to sing in with NEW password
2. System shouldn't allow user to sing in with OLD password

