### PR TITLE
Feature/order confirm page (part 4): save unpaid order/#3348

### DIFF
--- a/src/app/main/component/shared/components/form-base/form-base.component.ts
+++ b/src/app/main/component/shared/components/form-base/form-base.component.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { OrderService } from '../../../ubs/services/order.service';
+import { UBSOrderFormService } from '../../../ubs/services/ubs-order-form.service';
 
 @Component({
   selector: 'app-form-base',
@@ -34,7 +35,12 @@ export class FormBaseComponent implements ComponentCanDeactivate {
     // TODO: add functionality to this method
   }
 
-  constructor(public router: Router, public dialog: MatDialog, public orderService?: OrderService) {}
+  constructor(
+    public router: Router,
+    public dialog: MatDialog,
+    public orderService?: OrderService,
+    public ubsOrderFormService?: UBSOrderFormService
+  ) {}
 
   @HostListener('window:beforeunload')
   canDeactivate(): boolean | Observable<boolean> {
@@ -70,8 +76,9 @@ export class FormBaseComponent implements ComponentCanDeactivate {
         .subscribe((confirm) => {
           if (confirm) {
             this.orderService.changeShouldBePaid();
-            this.orderService.getOrderUrl().subscribe((res) => {
-              console.log(res);
+            this.orderService.getOrderUrl().subscribe((orderId) => {
+              this.ubsOrderFormService.transferOrderId(orderId);
+              this.ubsOrderFormService.setOrderResponseErrorStatus(orderId ? false : true);
               this.areChangesSaved = true;
               this.router.navigate(['ubs', 'confirm']);
             });

--- a/src/app/main/component/shared/components/form-base/form-base.component.ts
+++ b/src/app/main/component/shared/components/form-base/form-base.component.ts
@@ -5,6 +5,7 @@ import { WarningPopUpComponent } from '@shared/components';
 import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
+import { OrderService } from '../../../ubs/services/order.service';
 
 @Component({
   selector: 'app-form-base',
@@ -33,7 +34,7 @@ export class FormBaseComponent implements ComponentCanDeactivate {
     // TODO: add functionality to this method
   }
 
-  constructor(public router: Router, public dialog: MatDialog) {}
+  constructor(public router: Router, public dialog: MatDialog, public orderService?: OrderService) {}
 
   @HostListener('window:beforeunload')
   canDeactivate(): boolean | Observable<boolean> {
@@ -68,8 +69,12 @@ export class FormBaseComponent implements ComponentCanDeactivate {
         .pipe(take(1))
         .subscribe((confirm) => {
           if (confirm) {
-            this.areChangesSaved = true;
-            this.router.navigate(['ubs', 'confirm']);
+            this.orderService.changeShouldBePaid();
+            this.orderService.getOrderUrl().subscribe((res) => {
+              console.log(res);
+              this.areChangesSaved = true;
+              this.router.navigate(['ubs', 'confirm']);
+            });
           }
         });
       return;

--- a/src/app/main/component/shared/components/form-base/form-base.component.ts
+++ b/src/app/main/component/shared/components/form-base/form-base.component.ts
@@ -61,6 +61,11 @@ export class FormBaseComponent implements ComponentCanDeactivate {
     }
   }
 
+  cancelUBSwithoutSaving(): void {
+    this.orderService.cancelUBSwithoutSaving();
+    this.router.navigateByUrl('/ubs');
+  }
+
   cancelUBS(): void {
     const condition = this.getFormValues();
     this.cancelPopupJustifying(condition);

--- a/src/app/main/component/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
+++ b/src/app/main/component/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
@@ -66,10 +66,8 @@ describe('UbsConfirmPageComponent', () => {
   it('in renderView should saveDataOnLocalStorage and openSnackBar be called', () => {
     component.orderStatusDone = false;
     component.orderResponseError = false;
-    const activatedRoute = 'activatedRoute';
-    const queryParams = 'queryParams';
+    component.orderId = '132';
     const saveDataOnLocalStorageMock = spyOn(component, 'saveDataOnLocalStorage');
-    component[activatedRoute][queryParams] = of({ order_id: '132', response_status: true });
     component.renderView();
     expect(saveDataOnLocalStorageMock).toHaveBeenCalled();
     expect(fakeSnackBar.openSnackBar).toHaveBeenCalledWith('successConfirmSaveOrder', '132');

--- a/src/app/main/component/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
+++ b/src/app/main/component/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
 import { JwtService } from '@global-service/jwt/jwt.service';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
@@ -15,14 +15,12 @@ import { UBSOrderFormService } from '../../services/ubs-order-form.service';
 })
 export class UbsConfirmPageComponent implements OnInit, OnDestroy {
   orderId: string;
-  responseStatus: string;
   orderResponseError = false;
   orderStatusDone: boolean;
   isSpinner = true;
   private destroy$: Subject<boolean> = new Subject<boolean>();
 
   constructor(
-    private activatedRoute: ActivatedRoute,
     private snackBar: MatSnackBarComponent,
     private jwtService: JwtService,
     private ubsOrderFormService: UBSOrderFormService,
@@ -72,12 +70,7 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
     this.isSpinner = false;
     if (!this.orderResponseError && !this.orderStatusDone) {
       this.saveDataOnLocalStorage();
-      this.activatedRoute.queryParams.subscribe((params) => {
-        this.orderId = params.order_id;
-        // Hardcoded. Need a logic from back-end to save orderId for saved unpaid order
-        this.responseStatus = params.response_status;
-        this.snackBar.openSnackBar('successConfirmSaveOrder', this.orderId);
-      });
+      this.snackBar.openSnackBar('successConfirmSaveOrder', this.orderId);
     } else if (!this.orderResponseError && this.orderStatusDone) {
       this.saveDataOnLocalStorage();
     }

--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.html
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.html
@@ -276,7 +276,7 @@
 </div>
 
 <div class="w-100 d-flex justify-content-end buttons">
-  <button type="button" class="secondary-global-button btn cancel-button btn-main" (click)="cancelUBS()">
+  <button type="button" class="secondary-global-button btn cancel-button btn-main" (click)="cancelUBSwithoutSaving()">
     {{ 'order-details.cancel' | translate }}
   </button>
   <button

--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -82,14 +82,14 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
 
   constructor(
     private fb: FormBuilder,
-    private orderService: OrderService,
     private shareFormService: UBSOrderFormService,
     private localStorageService: LocalStorageService,
+    public orderService: OrderService,
     public renderer: Renderer2,
     router: Router,
     dialog: MatDialog
   ) {
-    super(router, dialog);
+    super(router, dialog, orderService);
     this.initForm();
   }
 

--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.html
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.html
@@ -192,7 +192,7 @@
     <i class="fas fa-chevron-left" aria-hidden="true"></i> &nbsp; {{ 'personal-info.info-back' | translate }}
   </button>
   <div class="w-100 d-flex justify-content-end">
-    <button class="secondary-global-button btn cansel-button" type="button" (click)="cancelUBS()">
+    <button class="secondary-global-button btn cansel-button" type="button" (click)="cancelUBSwithoutSaving()">
       {{ 'personal-info.info-cancel' | translate }}
     </button>
     <button type="submit" class="primary-global-button btn m-0" matStepperNext [disabled]="personalDataForm.invalid">

--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
@@ -57,12 +57,12 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
 
   constructor(
     public router: Router,
-    private orderService: OrderService,
+    public orderService: OrderService,
     private shareFormService: UBSOrderFormService,
     private fb: FormBuilder,
     public dialog: MatDialog
   ) {
-    super(router, dialog);
+    super(router, dialog, orderService);
     this.initForm();
   }
 

--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
@@ -21,6 +21,7 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
   orderDetails: OrderDetails;
   personalData: PersonalData;
   personalDataForm: FormGroup;
+  shouldBePaid = true;
   order: Order;
   addresses: Address[] = [];
   maxAddressLength = 4;
@@ -289,7 +290,8 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
       this.shareFormService.orderDetails.certificates,
       this.shareFormService.orderDetails.orderComment,
       this.personalData,
-      this.shareFormService.orderDetails.pointsToUse
+      this.shareFormService.orderDetails.pointsToUse,
+      this.shouldBePaid
     );
     this.orderService.setOrder(this.order);
   }

--- a/src/app/main/component/ubs/components/ubs-submit-order/ubs-submit-order.component.ts
+++ b/src/app/main/component/ubs/components/ubs-submit-order/ubs-submit-order.component.ts
@@ -22,6 +22,7 @@ export class UBSSubmitOrderComponent extends FormBaseComponent implements OnInit
   liqPayButtonForm: SafeHtml;
   liqPayButton: NodeListOf<HTMLElement>;
   isLiqPay = false;
+  shouldBePaid: boolean;
   order: Order;
   addressId: number;
   bags: Bag[] = [];
@@ -125,7 +126,8 @@ export class UBSSubmitOrderComponent extends FormBaseComponent implements OnInit
       this.orderDetails.certificates,
       this.orderDetails.orderComment,
       this.personalData,
-      this.orderDetails.pointsToUse
+      this.orderDetails.pointsToUse,
+      this.shouldBePaid
     );
   }
 

--- a/src/app/main/component/ubs/components/ubs-submit-order/ubs-submit-order.component.ts
+++ b/src/app/main/component/ubs/components/ubs-submit-order/ubs-submit-order.component.ts
@@ -54,16 +54,16 @@ export class UBSSubmitOrderComponent extends FormBaseComponent implements OnInit
   isTotalAmountZero = true;
 
   constructor(
-    private orderService: OrderService,
-    private shareFormService: UBSOrderFormService,
+    public orderService: OrderService,
     public ubsOrderFormService: UBSOrderFormService,
+    private shareFormService: UBSOrderFormService,
     private localStorageService: LocalStorageService,
     private sanitizer: DomSanitizer,
     private fb: FormBuilder,
     router: Router,
     dialog: MatDialog
   ) {
-    super(router, dialog);
+    super(router, dialog, orderService);
   }
 
   ngOnInit(): void {

--- a/src/app/main/component/ubs/models/ubs.model.ts
+++ b/src/app/main/component/ubs/models/ubs.model.ts
@@ -8,6 +8,7 @@ export class Order {
   orderComment: string;
   personalData: PersonalData;
   pointsToUse: number;
+  shouldBePaid: boolean;
   constructor(
     additionalOrders: Array<string>,
     addressId: number,
@@ -15,7 +16,8 @@ export class Order {
     certificates: Array<string>,
     orderComment: string,
     personalData: PersonalData,
-    pointsToUse: number
+    pointsToUse: number,
+    shouldBePaid: boolean
   ) {
     this.additionalOrders = additionalOrders;
     this.addressId = addressId;
@@ -24,5 +26,6 @@ export class Order {
     this.orderComment = orderComment;
     this.personalData = personalData;
     this.pointsToUse = pointsToUse;
+    this.shouldBePaid = shouldBePaid;
   }
 }

--- a/src/app/main/component/ubs/services/order.service.spec.ts
+++ b/src/app/main/component/ubs/services/order.service.spec.ts
@@ -65,7 +65,7 @@ describe('OrderService', () => {
     houseNumber: ''
   };
 
-  const orderMock = new Order([''], 7, [bagMock], [''], '8', personalData, 9);
+  const orderMock = new Order([''], 7, [bagMock], [''], '8', personalData, 9, true);
 
   let service: OrderService;
   let httpMock: HttpTestingController;

--- a/src/app/main/component/ubs/services/order.service.ts
+++ b/src/app/main/component/ubs/services/order.service.ts
@@ -75,6 +75,12 @@ export class OrderService {
     this.orderSubject.next(order);
   }
 
+  changeShouldBePaid() {
+    const order = this.orderSubject.getValue();
+    order.shouldBePaid = false;
+    this.setOrder(order);
+  }
+
   getOrderUrl(): Observable<Order> {
     return this.processOrder(this.orderSubject.getValue());
   }
@@ -90,7 +96,6 @@ export class OrderService {
 
   getLocations(): Observable<Locations[]> {
     return this.http.get<Locations[]>(`${this.url}/order/get-locations`);
-
   }
 
   addLocation(location): Observable<any> {

--- a/src/app/main/component/ubs/services/order.service.ts
+++ b/src/app/main/component/ubs/services/order.service.ts
@@ -118,4 +118,10 @@ export class OrderService {
     const lang = localStorage.getItem('language') === 'ua' ? 1 : 2;
     return this.http.get(`${this.url}/client/get-data-for-order-surcharge/${orderId}/${lang}`);
   }
+
+  cancelUBSwithoutSaving(): void {
+    this.shareFormService.isDataSaved = true;
+    this.localStorageService.removeUbsOrderId();
+    this.shareFormService.saveDataOnLocalStorage();
+  }
 }


### PR DESCRIPTION
**Achieved results:**
- the user can save the order by clicking the "Cancel" button on the submit page 
- after clicking the 'Order' button the user is redirected to the payment or confirmation page

**Preconditions**
- The registered user is logged in.
- The user goes to the UBS-order page.
- The user chooses services and fulfills all required user data.
- The user makes the order payment via a selected method. 

**Fixed bug:** [[UBS order] 404 error when submit #3514](https://github.com/ita-social-projects/GreenCity/issues/3514)
**Done:** [[UBS confirm page] To receive order confirmation and get the payment status of the order #3348](https://github.com/ita-social-projects/GreenCity/issues/3348)