### PR TITLE
bugFix/#3384/First three columns chosen by user need to be frozen

### DIFF
--- a/src/app/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -49,6 +49,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
   count: number;
   display = 'none';
   isPopupOpen: boolean;
+  stickyColumn = [];
   @ViewChild(MatSort, { static: true }) sort: MatSort;
 
   constructor(
@@ -90,6 +91,12 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
 
   dropListDropped(event: CdkDragDrop<string[]>) {
     moveItemInArray(this.displayedColumns, event.previousIndex, event.currentIndex);
+    for (let i = 0; i < 4; i++) {
+      this.stickyColumn.push(this.displayedColumns[i]);
+    }
+    this.columns.forEach((item) => {
+      item.sticky = this.stickyColumn.includes(item.title.key);
+    });
   }
 
   isAllSelected() {


### PR DESCRIPTION
Actual result
The first three columns by default are frozen.

Expected result
The first three columns chosen by a user are frozen