### PR TITLE
BugFix/Fixed fondy redirection to the confirm page/#3558

### DIFF
--- a/src/app/main/component/shared/components/warning-pop-up/warning-pop-up.component.spec.ts
+++ b/src/app/main/component/shared/components/warning-pop-up/warning-pop-up.component.spec.ts
@@ -92,9 +92,14 @@ describe('WarningPopUpComponent', () => {
       const spyGetOrderUrl = spyOn(component.orderService, 'getOrderUrl').and.returnValue(of(sringifyValue));
       const spyTransferOrderId = spyOn(component.ubsOrderFormService, 'transferOrderId');
       const spySetOrderResponseErrorStatus = spyOn(component.ubsOrderFormService, 'setOrderResponseErrorStatus');
+      const localStorageService = 'localStorageService';
+      const removeUbsOrderIdMock = spyOn(component[localStorageService], 'removeUbsOrderId');
+      const removeUbsFondyOrderIdMock = spyOn(component[localStorageService], 'removeUbsFondyOrderId');
       component.userReply(true);
       expect(spyChangeShouldBePaid).toHaveBeenCalled();
       expect(spyGetOrderUrl).toHaveBeenCalled();
+      expect(removeUbsOrderIdMock).toHaveBeenCalled();
+      expect(removeUbsFondyOrderIdMock).toHaveBeenCalled();
       expect(spyTransferOrderId).toHaveBeenCalledWith(123);
       expect(spySetOrderResponseErrorStatus).toHaveBeenCalledWith(false);
       expect(spy).toHaveBeenCalled();

--- a/src/app/main/component/shared/components/warning-pop-up/warning-pop-up.component.ts
+++ b/src/app/main/component/shared/components/warning-pop-up/warning-pop-up.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { ReplaySubject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { OrderService } from '../../../ubs/services/order.service';
@@ -25,7 +26,8 @@ export class WarningPopUpComponent implements OnInit, OnDestroy {
     private matDialogRef: MatDialogRef<WarningPopUpComponent>,
     @Inject(MAT_DIALOG_DATA) public data,
     public orderService: OrderService,
-    public ubsOrderFormService: UBSOrderFormService
+    public ubsOrderFormService: UBSOrderFormService,
+    private localStorageService: LocalStorageService
   ) {}
 
   ngOnInit() {
@@ -66,6 +68,8 @@ export class WarningPopUpComponent implements OnInit, OnDestroy {
             const { orderId } = JSON.parse(response);
             this.ubsOrderFormService.transferOrderId(orderId);
             this.ubsOrderFormService.setOrderResponseErrorStatus(orderId ? false : true);
+            this.localStorageService.removeUbsFondyOrderId();
+            this.localStorageService.removeUbsOrderId();
             this.matDialogRef.close(reply);
             this.isLoading = false;
           },

--- a/src/app/main/component/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
+++ b/src/app/main/component/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
@@ -83,9 +83,11 @@ describe('UbsConfirmPageComponent', () => {
 
   it('in saveDataOnLocalStorage should removeUbsOrderId and saveDataOnLocalStorage be called', () => {
     const localStorageService = 'localStorageService';
-    const localStorageServiceMock = spyOn(component[localStorageService], 'removeUbsOrderId');
+    const removeUbsOrderIdMock = spyOn(component[localStorageService], 'removeUbsOrderId');
+    const removeUbsFondyOrderIdMock = spyOn(component[localStorageService], 'removeUbsFondyOrderId');
     component.saveDataOnLocalStorage();
-    expect(localStorageServiceMock).toHaveBeenCalled();
+    expect(removeUbsOrderIdMock).toHaveBeenCalled();
+    expect(removeUbsFondyOrderIdMock).toHaveBeenCalled();
     expect(fakeUBSOrderFormService.saveDataOnLocalStorage).toHaveBeenCalled();
   });
 

--- a/src/app/main/component/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
+++ b/src/app/main/component/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
@@ -53,7 +53,7 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
             (response) => {
               this.orderResponseError = response.result === 'error' ? true : false;
               this.orderStatusDone = this.orderResponseError ? false : true;
-              this.orderId = response.order_id ? response.order_id.split('_')[0] : this.localStorageService.getUbsOrderId();
+              this.orderId = response.order_id ? response.order_id.split('_')[0] : this.localStorageService.getUbsFondyOrderId();
               this.renderView();
             },
             (error) => {
@@ -79,6 +79,7 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
   saveDataOnLocalStorage(): void {
     this.shareFormService.isDataSaved = true;
     this.localStorageService.removeUbsOrderId();
+    this.localStorageService.removeUbsFondyOrderId();
     this.shareFormService.saveDataOnLocalStorage();
   }
 

--- a/src/app/main/component/ubs/components/ubs-submit-order/ubs-submit-order.component.ts
+++ b/src/app/main/component/ubs/components/ubs-submit-order/ubs-submit-order.component.ts
@@ -163,7 +163,6 @@ export class UBSSubmitOrderComponent extends FormBaseComponent implements OnInit
     }
 
     if (!this.isLiqPay) {
-      this.localStorageService.removeUbsOrderId();
       this.orderService
         .getOrderUrl()
         .pipe(takeUntil(this.destroy))
@@ -187,6 +186,7 @@ export class UBSSubmitOrderComponent extends FormBaseComponent implements OnInit
               this.ubsOrderFormService.setOrderStatus(true);
             } else {
               this.shareFormService.orderUrl = link.toString();
+              this.localStorageService.setUbsFondyOrderId(orderId);
               document.location.href = this.shareFormService.orderUrl;
             }
           },
@@ -228,6 +228,7 @@ export class UBSSubmitOrderComponent extends FormBaseComponent implements OnInit
 
   onNotSaveData() {
     this.shareFormService.isDataSaved = true;
+    this.localStorageService.removeUbsFondyOrderId();
     this.liqPayButton[0].click();
   }
 }

--- a/src/app/main/component/ubs/services/order.service.ts
+++ b/src/app/main/component/ubs/services/order.service.ts
@@ -87,11 +87,22 @@ export class OrderService {
 
   getUbsOrderStatus(): Observable<any> {
     const liqPayOrderId = this.localStorageService.getUbsOrderId();
-    return liqPayOrderId ? this.getLiqPayStatus(liqPayOrderId) : throwError(new Error('There is no OrderId!'));
+    const fondyOrderId = this.localStorageService.getUbsFondyOrderId();
+    if (liqPayOrderId) {
+      return this.getLiqPayStatus(liqPayOrderId);
+    }
+    if (fondyOrderId) {
+      return this.getFondyStatus(fondyOrderId);
+    }
+    return throwError(new Error('There is no OrderId!'));
   }
 
   getLiqPayStatus(orderId: string): Observable<any> {
     return this.http.get(`${this.url}/getLiqPayStatus/${orderId}`);
+  }
+
+  getFondyStatus(orderId: string): Observable<any> {
+    return this.http.get(`${this.url}/getFondyStatus/${orderId}`);
   }
 
   getLocations(): Observable<Locations[]> {
@@ -122,6 +133,7 @@ export class OrderService {
   cancelUBSwithoutSaving(): void {
     this.shareFormService.isDataSaved = true;
     this.localStorageService.removeUbsOrderId();
+    this.localStorageService.removeUbsFondyOrderId();
     this.shareFormService.saveDataOnLocalStorage();
   }
 }

--- a/src/app/main/service/localstorage/local-storage.service.ts
+++ b/src/app/main/service/localstorage/local-storage.service.ts
@@ -126,15 +126,27 @@ export class LocalStorageService {
   }
 
   public setUbsOrderId(orderId: string) {
-    localStorage.setItem('UbsOrderId', JSON.stringify(orderId));
+    localStorage.setItem('UbsLiqPayOrderId', JSON.stringify(orderId));
   }
 
   public getUbsOrderId(): any {
-    return localStorage.getItem('UbsOrderId') === 'undefined' ? false : JSON.parse(localStorage.getItem('UbsOrderId'));
+    return localStorage.getItem('UbsLiqPayOrderId') === 'undefined' ? false : JSON.parse(localStorage.getItem('UbsLiqPayOrderId'));
   }
 
   public removeUbsOrderId() {
-    localStorage.removeItem('UbsOrderId');
+    localStorage.removeItem('UbsLiqPayOrderId');
+  }
+
+  public setUbsFondyOrderId(orderId: string) {
+    localStorage.setItem('UbsFondyOrderId', JSON.stringify(orderId));
+  }
+
+  public getUbsFondyOrderId(): any {
+    return localStorage.getItem('UbsFondyOrderId') === 'undefined' ? false : JSON.parse(localStorage.getItem('UbsFondyOrderId'));
+  }
+
+  public removeUbsFondyOrderId() {
+    localStorage.removeItem('UbsFondyOrderId');
   }
 
   public removeUbsOrderData() {


### PR DESCRIPTION
**Achieved results:**
- improved redirection from fondy
- created unit tests

**Preconditions**
- The registered user is logged in.
- The user goes to the UBS-order page.
- The user chooses services and fulfills all required user data.
- The user makes the order payment via Fondy. 

**Fixed bug:** [[UBS order] Incorrect confirmation page after the Fondy payment #3558](https://github.com/ita-social-projects/GreenCity/issues/3558)