### PR TITLE
BugFix/user-able-to-add-more-than-5-order-from-Eco-shop/#3516

### DIFF
--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.html
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.html
@@ -242,7 +242,7 @@
             />
             <span input-close-button tabindex="{{ isDisabled() }}" (click)="deleteOrder(i)" (keyup)="removeOrder($event, i)">&times;</span>
           </div>
-          <div class="order-notification">
+          <div *ngIf="canAddEcoShopOrderNumber()" class="order-notification">
             <small class="text-danger" *ngIf="!displayOrderBtn && additionalOrders.touched && shop.value !== 'no'">
               {{ 'order-details.order-error' | translate }}
             </small>

--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -56,6 +56,8 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
   certStatus: string;
   failedCert = false;
   userOrder: FinalOrder;
+  ecoShopOrdersNumbersCounter = 1;
+  limitOfEcoShopOrdersNumbers = 5;
   object: {};
   private destroy: Subject<boolean> = new Subject<boolean>();
   public currentLanguage: string;
@@ -423,6 +425,7 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
   }
 
   addOrder(): void {
+    this.ecoShopOrdersNumbersCounter++;
     const additionalOrdersArray = this.orderDetailsForm.get('additionalOrders') as FormArray;
     additionalOrdersArray.markAsUntouched();
     const additionalOrder = new FormControl('', [Validators.minLength(10)]);
@@ -433,7 +436,12 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
     }, 0);
   }
 
+  canAddEcoShopOrderNumber(): boolean {
+    return this.ecoShopOrdersNumbersCounter < this.limitOfEcoShopOrdersNumbers ? true : false;
+  }
+
   deleteOrder(index: number): void {
+    this.ecoShopOrdersNumbersCounter--;
     const orders = this.additionalOrders;
     orders.length > 1 ? orders.removeAt(index) : orders.reset(['']);
     this.changeOrderDetails();

--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -437,7 +437,7 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
   }
 
   canAddEcoShopOrderNumber(): boolean {
-    return this.ecoShopOrdersNumbersCounter < this.limitOfEcoShopOrdersNumbers ? true : false;
+    return this.ecoShopOrdersNumbersCounter < this.limitOfEcoShopOrdersNumbers;
   }
 
   deleteOrder(index: number): void {


### PR DESCRIPTION
**Preconditions**

1. Login to GreenCity as a User https://ita-social-projects.github.io/GreenCityClient/#/

**Steps to reproduce**

1. Go to 'UBS кур'єр'
2. Click on the "Замовити кур'єра" button
3. Scroll the page till the section "Еко магазин" and mark checkbox "Так"
4. Fill in "Номер замовлення" field with order id (e.g. 1234567890)
5. Click on the link “Додати ще номер замовлення” under the first shop order input field
6. Add 5 more orders from the "Еко мазагин" store

**Actual result**

1. User is able to add more than 5 orders from the "Еко мазагин" store per the one UBS Courier
![image](https://user-images.githubusercontent.com/51053478/143490048-22e4113a-dfa5-453c-9ad1-f31f88d32a89.png)

**Expected result**

1. The limit for shop order input fields per the one UBS Courier order form is 5 input fields, so the link “Додати ще номер замовлення” after 5th field should NOT appear