### PR TITLE
Bugfix/#1887/list-view-576

### DIFF
--- a/src/app/main/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
+++ b/src/app/main/component/eco-news/components/news-list/news-list-list-view/news-list-list-view.component.scss
@@ -84,8 +84,9 @@ div {
 }
 
 .eco-news_data-text-date {
-  min-width: 95px;
+  width: 95px;
   margin-right: 20px;
+  font-size: 13px;
 
   img {
     width: 10px;

--- a/src/app/main/component/eco-news/components/news-list/news-list.component.scss
+++ b/src/app/main/component/eco-news/components/news-list/news-list.component.scss
@@ -10,9 +10,9 @@ div hr {
 
 .main-header {
   font-family: var(--secondary-font);
-  font-size: 55px;
-  line-height: 48px;
-  width: 256px;
+  font-size: 42px;
+  line-height: 56px;
+  width: 201px;
   white-space: nowrap;
   font-weight: 500;
   margin: 0 0 34px -3px;
@@ -135,6 +135,7 @@ li:focus {
 @media (min-width: 576px) {
   .container {
     padding: 0;
-    max-width: 96%;
+    width: 100%;
+    margin: 0 18px;
   }
 }


### PR DESCRIPTION
Environment:
Microsoft Windows 10 Home, Version 10.0.19041
Mozilla Firefox Browser 82.0.3 (64-bit)
Google Chrome Version 86.0.4240.198 (Official Build) (64-bit)
Reproducible: always

Actual result:

1. The size of the main header "Eco News" is 256x48
![![image](https://user-images.githubusercontent.com/49165350/143561897-66006adf-e8a2-4ed2-b122-f4cf62b2ae0b.png)](https://user-images.githubusercontent.com/49165350/143561838-6949c2a2-276e-4a19-bcc4-99e4582b5669.png)

2. The size of the 'Title' label is 504,95x28
![image](https://user-images.githubusercontent.com/49165350/143561962-8b5f8026-5d8d-42b3-a3a9-4cf2e08f6912.png)

3. The size of the list card is 452,4x192
![image](https://user-images.githubusercontent.com/49165350/143562202-cf5c9f62-9a0a-4752-9945-af7a83f688ce.png)

4. The size of the 'Date' label is 99,25x20
![image](https://user-images.githubusercontent.com/49165350/143562346-26596c4f-f782-4a5f-b874-008fb3af8ff2.png)

5.Incorrect alignment of the news item . Width is 23,05
![image](https://user-images.githubusercontent.com/49165350/143562328-7dec41b0-2b3e-4de3-b2a6-7195e55d8223.png)

Expected result:

1. The size of the main header "Eco News" is 201x56
2. The size of the 'Title' label is 492x28
3. The size of the list card is 540x192
4. The size of the 'Date' label is 95x20
5. Alignment of the news item: Width is 18.