### PR TITLE
Bugfix/likes and accordion/#3584

### DIFF
--- a/src/app/main/component/eco-news/components/eco-news-detail/eco-news-detail.component.ts
+++ b/src/app/main/component/eco-news/components/eco-news-detail/eco-news-detail.component.ts
@@ -68,7 +68,7 @@ export class EcoNewsDetailComponent implements OnInit, OnDestroy {
   }
 
   private postToggleLike(): void {
-    this.ecoNewsService.postToggleLike(this.newsId);
+    this.ecoNewsService.postToggleLike(this.newsId).subscribe();
   }
 
   private shareLinks() {

--- a/src/app/main/component/eco-news/components/eco-news-detail/eco-news-detail.component.ts
+++ b/src/app/main/component/eco-news/components/eco-news-detail/eco-news-detail.component.ts
@@ -68,7 +68,7 @@ export class EcoNewsDetailComponent implements OnInit, OnDestroy {
   }
 
   private postToggleLike(): void {
-    this.ecoNewsService.postToggleLike(this.newsId).subscribe();
+    this.ecoNewsService.postToggleLike(this.newsId).pipe(take(1)).subscribe();
   }
 
   private shareLinks() {

--- a/src/app/ubs-user/ubs-user-messages/ubs-user-messages.component.html
+++ b/src/app/ubs-user/ubs-user-messages/ubs-user-messages.component.html
@@ -15,46 +15,43 @@
     </div>
     <div *ngIf="!isAnyMessages" class="if-empty">У вас ще немає повідомлень</div>
     <div *ngIf="isAnyMessages">
-      <div
-        *ngFor="
-          let notification of notifications
-            | paginate
-              : {
-                  id: 'pag',
-                  itemsPerPage: pageSize,
-                  currentPage: page,
-                  totalItems: count
-                }
-        "
-      >
-        <mat-accordion>
-          <mat-expansion-panel
-            (click)="setRead(notification.id, notification.read)"
-            (opened)="panelOpenState = true"
-            (closed)="panelOpenState = false"
-          >
-            <mat-expansion-panel-header>
-              <mat-panel-title [ngClass]="{ textColorTitle: !notification.read }">
-                <div class="col-2">{{ notification.id }}</div>
-              </mat-panel-title>
-              <mat-panel-description [ngClass]="{ textColorTitle: !notification.read }" class="title">
-                {{ notification.title }}
-              </mat-panel-description>
-              <mat-panel-description class="date" [ngClass]="{ textColorTitle: !notification.read }">
-                {{ notification.notificationTime | date: 'HH:mm dd.MM.yyyy' }}
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-            <div class="load-spinner small" *ngIf="isLoadSmallSpinner && !notification.isOpen">
-              <mat-spinner class="custom-spinner" diameter="60"></mat-spinner>
-            </div>
-            <div class="description" *ngIf="!isLoadSmallSpinner">
-              <app-notification-body [body]="notification.body" [orderId]="notification.orderId"></app-notification-body>
-            </div>
-            <div *ngIf="notification.img" class="description title-img">Фотографії порушення</div>
-            <div *ngIf="notification.img" class="description img"><img src="{{ notification.img }}" alt="" /></div>
-          </mat-expansion-panel>
-        </mat-accordion>
-      </div>
+      <mat-accordion multi="false">
+        <mat-expansion-panel
+          *ngFor="
+            let notification of notifications
+              | paginate
+                : {
+                    id: 'pag',
+                    itemsPerPage: pageSize,
+                    currentPage: page,
+                    totalItems: count
+                  }
+          "
+          (click)="setRead(notification.id, notification.read)"
+          (opened)="panelOpenState = true"
+          (closed)="panelOpenState = false"
+        >
+          <mat-expansion-panel-header>
+            <mat-panel-title [ngClass]="{ textColorTitle: !notification.read }">
+              <div class="col-2">{{ notification.id }}</div>
+            </mat-panel-title>
+            <mat-panel-description [ngClass]="{ textColorTitle: !notification.read }" class="title">
+              {{ notification.title }}
+            </mat-panel-description>
+            <mat-panel-description class="date" [ngClass]="{ textColorTitle: !notification.read }">
+              {{ notification.notificationTime | date: 'HH:mm dd.MM.yyyy' }}
+            </mat-panel-description>
+          </mat-expansion-panel-header>
+          <div class="load-spinner small" *ngIf="isLoadSmallSpinner && !notification.isOpen">
+            <mat-spinner class="custom-spinner" diameter="60"></mat-spinner>
+          </div>
+          <div class="description" *ngIf="!isLoadSmallSpinner">
+            <app-notification-body [body]="notification.body" [orderId]="notification.orderId"> </app-notification-body>
+          </div>
+          <div *ngIf="notification.img" class="description title-img">Фотографії порушення</div>
+          <div *ngIf="notification.img" class="description img"><img src="{{ notification.img }}" alt="" /></div>
+        </mat-expansion-panel>
+      </mat-accordion>
       <div class="d-flex justify-content-center">
         <pagination-controls
           autoHide="true"

--- a/src/app/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.scss
+++ b/src/app/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.scss
@@ -41,7 +41,7 @@
 
 .empty_card {
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
 
   &-arrows {


### PR DESCRIPTION
**Achieved results:**
- the user can add likes on the eco news page
- when the user clicks next exploring data table on the ubs message page the previous one will be closed

Fixed Bug: [[Eco News, UBS Messages] Likes are not added when clicked and the accordion feature on the message page does not work #3584](https://github.com/ita-social-projects/GreenCity/issues/3584)