### PR TITLE
Bugfix/save order data to localstorage/#3604

### DIFF
--- a/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/main/component/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -105,7 +105,6 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
     } else {
       this.openLocationDialog();
     }
-    localStorage.removeItem('UBSorderData');
     this.orderService.locationSubject.pipe(takeUntil(this.destroy)).subscribe(() => {
       this.takeOrderData();
       this.subscribeToLangChange();

--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.html
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.html
@@ -61,7 +61,7 @@
       {{ 'personal-info.info-other-client' | translate }}
     </label>
   </div>
-  <div class="row personal-data" *ngIf="anotherClient">
+  <div class="row personal-data" *ngIf="anotherClient" (change)="changeAnotherClientInPersonalData()">
     <div class="col-12 col-sm-6 form-group">
       <label>{{ 'personal-info.info-name' | translate }}</label>
       <input

--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
@@ -68,6 +68,9 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
   }
 
   ngOnInit() {
+    if (localStorage.getItem('anotherClient')) {
+      this.anotherClient = JSON.parse(localStorage.getItem('anotherClient'));
+    }
     this.takeUserData();
     this.orderService.locationSub.subscribe((data) => {
       this.currentLocation = data;
@@ -170,12 +173,24 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
     this.shareFormService.saveDataOnLocalStorage();
   }
 
+  changeAnotherClientInPersonalData() {
+    this.personalData.anotherClientFirstName = this.personalDataForm.get('anotherClientFirstName').value;
+    this.personalData.anotherClientLastName = this.personalDataForm.get('anotherClientLastName').value;
+    this.personalData.anotherClientEmail = this.personalDataForm.get('anotherClientEmail').value;
+    this.personalData.anotherClientPhoneNumber = this.personalDataForm.get('anotherClientPhoneNumber').value.slice(3);
+    this.shareFormService.saveDataOnLocalStorage();
+  }
+
   setFormData(): void {
     this.personalDataForm.patchValue({
       firstName: this.personalData.firstName,
       lastName: this.personalData.lastName,
       email: this.personalData.email,
       phoneNumber: '380' + this.personalData.phoneNumber,
+      anotherClientFirstName: this.personalData.anotherClientFirstName,
+      anotherClientLastName: this.personalData.anotherClientLastName,
+      anotherClientEmail: this.personalData.anotherClientEmail,
+      anotherClientPhoneNumber: this.personalData.anotherClientPhoneNumber,
       addressComment: this.addresses.length > 0 ? this.personalData.addressComment : ''
     });
   }
@@ -191,6 +206,7 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
       anotherClientLastName.setValidators(this.personalDataFormValidators);
       anotherClientPhoneNumber.setValidators([Validators.required, Validators.minLength(12)]);
       anotherClientPhoneNumber.setValue('+380');
+      localStorage.setItem('anotherClient', JSON.stringify(true));
     } else {
       anotherClientFirstName.setValue('');
       anotherClientFirstName.clearValidators();
@@ -199,10 +215,12 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
       anotherClientPhoneNumber.setValue('');
       anotherClientPhoneNumber.clearValidators();
       anotherClientEmail.setValue('');
+      localStorage.removeItem('anotherClient');
     }
     anotherClientFirstName.updateValueAndValidity();
     anotherClientLastName.updateValueAndValidity();
     anotherClientPhoneNumber.updateValueAndValidity();
+    this.changeAnotherClientInPersonalData();
   }
 
   editAddress(addressId: number) {

--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
@@ -97,13 +97,13 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
       .subscribe((list) => {
         this.addresses = this.getLastAddresses(list.addressList);
         localStorage.setItem('addresses', JSON.stringify(this.addresses));
-
         this.personalDataForm.patchValue({
           address: this.addresses
         });
 
+        const addressId = JSON.parse(localStorage.getItem('addressId'));
         if (this.addresses[0] && isCheck) {
-          this.checkAddress(this.addresses[0].id);
+          this.checkAddress(addressId ?? this.addresses[0].id);
         }
       });
   }
@@ -153,7 +153,7 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
         this.orderService.setCurrentAddress(address);
       }
     });
-
+    localStorage.setItem('addressId', JSON.stringify(addressId));
     this.changeAddressInPersonalData();
   }
 
@@ -167,6 +167,7 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
     this.personalData.entranceNumber = activeAddress.entranceNumber;
     this.personalData.latitude = activeAddress.coordinates.latitude;
     this.personalData.longitude = activeAddress.coordinates.longitude;
+    this.shareFormService.saveDataOnLocalStorage();
   }
 
   setFormData(): void {

--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
@@ -177,7 +177,7 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
     this.personalData.anotherClientFirstName = this.personalDataForm.get('anotherClientFirstName').value;
     this.personalData.anotherClientLastName = this.personalDataForm.get('anotherClientLastName').value;
     this.personalData.anotherClientEmail = this.personalDataForm.get('anotherClientEmail').value;
-    this.personalData.anotherClientPhoneNumber = this.personalDataForm.get('anotherClientPhoneNumber').value.slice(3);
+    this.personalData.anotherClientPhoneNumber = this.personalDataForm.get('anotherClientPhoneNumber').value;
     this.shareFormService.saveDataOnLocalStorage();
   }
 
@@ -304,7 +304,9 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
     this.personalData.anotherClientFirstName = this.personalDataForm.get('anotherClientFirstName').value;
     this.personalData.anotherClientLastName = this.personalDataForm.get('anotherClientLastName').value;
     this.personalData.anotherClientEmail = this.personalDataForm.get('anotherClientEmail').value;
-    this.personalData.anotherClientPhoneNumber = this.personalDataForm.get('anotherClientPhoneNumber').value.slice(3);
+    this.personalData.anotherClientPhoneNumber = this.personalDataForm.get('anotherClientPhoneNumber').value
+      ? this.personalDataForm.get('anotherClientPhoneNumber').value.slice(3)
+      : '';
     this.personalData.addressComment = this.personalDataForm.get('addressComment').value;
     this.order = new Order(
       this.shareFormService.orderDetails.additionalOrders,

--- a/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
+++ b/src/app/main/component/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
@@ -304,9 +304,7 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
     this.personalData.anotherClientFirstName = this.personalDataForm.get('anotherClientFirstName').value;
     this.personalData.anotherClientLastName = this.personalDataForm.get('anotherClientLastName').value;
     this.personalData.anotherClientEmail = this.personalDataForm.get('anotherClientEmail').value;
-    this.personalData.anotherClientPhoneNumber = this.personalDataForm.get('anotherClientPhoneNumber').value
-      ? this.personalDataForm.get('anotherClientPhoneNumber').value.slice(3)
-      : '';
+    this.personalData.anotherClientPhoneNumber = this.personalDataForm.get('anotherClientPhoneNumber').value;
     this.personalData.addressComment = this.personalDataForm.get('addressComment').value;
     this.order = new Order(
       this.shareFormService.orderDetails.additionalOrders,

--- a/src/app/main/component/ubs/services/order.service.ts
+++ b/src/app/main/component/ubs/services/order.service.ts
@@ -122,6 +122,7 @@ export class OrderService {
   cancelUBSwithoutSaving(): void {
     this.shareFormService.isDataSaved = true;
     this.shareFormService.orderDetails = null;
+    this.shareFormService.personalData = null;
     this.localStorageService.removeUbsOrderId();
     this.shareFormService.saveDataOnLocalStorage();
   }

--- a/src/app/main/component/ubs/services/order.service.ts
+++ b/src/app/main/component/ubs/services/order.service.ts
@@ -121,6 +121,7 @@ export class OrderService {
 
   cancelUBSwithoutSaving(): void {
     this.shareFormService.isDataSaved = true;
+    this.shareFormService.orderDetails = null;
     this.localStorageService.removeUbsOrderId();
     this.shareFormService.saveDataOnLocalStorage();
   }

--- a/src/app/main/service/localstorage/local-storage.service.ts
+++ b/src/app/main/service/localstorage/local-storage.service.ts
@@ -143,6 +143,7 @@ export class LocalStorageService {
     localStorage.removeItem('currentLocationId');
     localStorage.removeItem('locations');
     localStorage.removeItem('addressId');
+    localStorage.removeItem('anotherClient');
   }
 
   public getUbsPersonalData(): any {

--- a/src/app/main/service/localstorage/local-storage.service.ts
+++ b/src/app/main/service/localstorage/local-storage.service.ts
@@ -142,6 +142,7 @@ export class LocalStorageService {
     localStorage.removeItem('UBSorderData');
     localStorage.removeItem('currentLocationId');
     localStorage.removeItem('locations');
+    localStorage.removeItem('addressId');
   }
 
   public getUbsPersonalData(): any {

--- a/src/app/shared/header/header.component.spec.ts
+++ b/src/app/shared/header/header.component.spec.ts
@@ -163,10 +163,13 @@ describe('HeaderComponent', () => {
     });
 
     it('should log out the user', () => {
-      // @ts-ignore
-      const spy = spyOn(component.localeStorageService, 'clear');
+      const localeStorageService = 'localeStorageService';
+      const orderService = 'orderService';
+      const spy = spyOn(component[localeStorageService], 'clear');
+      const cancelUBSwithoutSavingSpy = spyOn(component[orderService], 'cancelUBSwithoutSaving');
       component.signOut();
       expect(spy).toHaveBeenCalled();
+      expect(cancelUBSwithoutSavingSpy).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -17,6 +17,7 @@ import { environment } from '@environment/environment';
 import { Subject } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { HeaderService } from '@global-service/header/header.service';
+import { OrderService } from 'src/app/main/component/ubs/services/order.service';
 
 @Component({
   selector: 'app-header',
@@ -62,6 +63,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   private searchSearch: SearchService;
   private userOwnAuthService: UserOwnAuthService;
   private headerService: HeaderService;
+  private orderService: OrderService;
 
   constructor(private injector: Injector) {
     this.dialog = injector.get(MatDialog);
@@ -75,6 +77,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
     this.searchSearch = injector.get(SearchService);
     this.userOwnAuthService = injector.get(UserOwnAuthService);
     this.headerService = injector.get(HeaderService);
+    this.orderService = injector.get(OrderService);
   }
 
   ngOnInit() {
@@ -269,6 +272,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
     this.habitStatisticService.onLogout();
     this.achievementService.onLogout();
     this.router.navigateByUrl(this.isUBS ? '/ubs' : '/').then((r) => r);
+    this.orderService.cancelUBSwithoutSaving();
     this.userOwnAuthService.getDataFromLocalStorage();
     this.jwtService.userRole$.next('');
   }


### PR DESCRIPTION
**Achieved results:**
- all entered data, with the exception of certificates and points, will be saved when the user returns to the order page.
- if the user cancels the order or logs out, all entered data will be deleted.

**Preconditions**
- The registered user is logged in.
- The user goes to the UBS-order page.
- The user chooses services and fulfills some data.
- The user closes the browser or exits the page.

**Fixed Bug:** [[UBS Order] Order data are not saved when leave the page #3604](https://github.com/ita-social-projects/GreenCity/issues/3604)