### PR TITLE
Feature/#3671/customers-excel

### DIFF
--- a/src/app/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate.component.html
+++ b/src/app/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate.component.html
@@ -30,12 +30,12 @@
     *ngIf="!isLoading; else spinner"
     aria-label="certificatesTable"
   >
-    <ng-container *ngFor="let column of columns; let i = index" [matColumnDef]="column.field" [sticky]="column.sticky" class="column.field">
+    <ng-container *ngFor="let column of columns; let i = index" [matColumnDef]="column.title.key" class="column.title.key">
       <mat-header-cell *matHeaderCellDef cdkDrag cdkDragLockAxis="x" cdkDragBoundary="mat-header-row">
-        <th scope="row" *ngIf="column.field !== 'select'">
-          <span class="column-title">{{ column.field }}</span>
+        <th scope="row" *ngIf="column.title.key !== 'select'">
+          <span class="column-title">{{ column.title | serverTranslate: currentLang }}</span>
         </th>
-        <th scope="row" *ngIf="column.field === 'select'" [ngStyle]="{ backgroundColor: '#fff', height: '16px', padding: '0px' }">
+        <th scope="row" *ngIf="column.title.key === 'select'" [ngStyle]="{ backgroundColor: '#fff', height: '16px', padding: '0px' }">
           <mat-checkbox
             (change)="$event ? masterToggle() : null"
             [checked]="selection.hasValue() && isAllSelected()"
@@ -45,9 +45,9 @@
           </mat-checkbox>
         </th>
       </mat-header-cell>
-      <mat-cell *matCellDef="let row" [ngStyle]="column.style" class="column.field">
-        <div *ngIf="column.field !== 'select'; else checkbox">
-          <span [ngClass]="{ 'primary-color': column.field === 'code' }">{{ row[column.field] }}</span>
+      <mat-cell *matCellDef="let row" [ngStyle]="column.style" class="column.title.key">
+        <div *ngIf="column.title.key !== 'select'; else checkbox">
+          <span [ngClass]="{ 'primary-color': column.title.key === 'code' }">{{ row[column.title.key] }}</span>
         </div>
         <ng-template #checkbox class="checkbox">
           <mat-checkbox

--- a/src/app/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate.component.ts
@@ -10,6 +10,7 @@ import { TableHeightService } from '../../services/table-height.service';
 import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { UbsAdminCertificateAddCertificatePopUpComponent } from './ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component';
 import { UbsAdminTableExcelPopupComponent } from '../ubs-admin-table/ubs-admin-table-excel-popup/ubs-admin-table-excel-popup.component';
+import { columnsParamsCertificates } from '../ubs-admin-customers/columnsParams';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 
 @Component({
@@ -44,20 +45,27 @@ export class UbsAdminCertificateComponent implements OnInit, AfterViewChecked, O
   allElements: number;
   filterValue = '';
   modelChanged: Subject<string> = new Subject<string>();
+  currentLang: string;
   @ViewChild(MatSort, { static: true }) sort: MatSort;
 
   constructor(
     private adminCertificateService: AdminCertificateService,
     private tableHeightService: TableHeightService,
     public dialog: MatDialog,
+    private localStorageService: LocalStorageService,
     public dialogRef: MatDialogRef<UbsAdminCertificateAddCertificatePopUpComponent>
   ) {}
 
   ngOnInit() {
+    this.localStorageService.languageBehaviourSubject.pipe(takeUntil(this.destroy)).subscribe((lang) => {
+      this.currentLang = lang;
+    });
     this.modelChanged.pipe(debounceTime(500)).subscribe((model) => {
       this.currentPage = 0;
       this.getTable(model, this.sortingColumn, this.sortType);
     });
+    this.columns = columnsParamsCertificates;
+    this.setDisplayedColumns();
     this.getTable();
   }
 
@@ -80,7 +88,7 @@ export class UbsAdminCertificateComponent implements OnInit, AfterViewChecked, O
   setDisplayedColumns() {
     this.columns.forEach((column, index) => {
       column.index = index;
-      this.displayedColumns[index] = column.field;
+      this.displayedColumns[index] = column.title.key;
     });
   }
 
@@ -116,19 +124,6 @@ export class UbsAdminCertificateComponent implements OnInit, AfterViewChecked, O
         this.totalElements = item[`totalElements`];
         this.allElements = !this.allElements ? this.totalElements : this.allElements;
         this.dataSource = new MatTableDataSource(this.tableData);
-        const requiredColumns = [{ field: 'select', sticky: true }];
-        const dynamicallyColumns = [];
-        const arrayOfProperties = Object.keys(this.tableData[0]);
-        arrayOfProperties.forEach((property) => {
-          const objectOfValue = {
-            field: property,
-            sticky: false
-          };
-          dynamicallyColumns.push(objectOfValue);
-        });
-        this.columns = [].concat(requiredColumns, dynamicallyColumns);
-        this.setDisplayedColumns();
-        this.arrayOfHeaders = arrayOfProperties;
         this.isLoading = false;
         this.isTableHeightSet = false;
       });

--- a/src/app/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate.component.ts
@@ -168,7 +168,7 @@ export class UbsAdminCertificateComponent implements OnInit, AfterViewChecked, O
     dialogRef.componentInstance.allElements = this.allElements;
     dialogRef.componentInstance.sortingColumn = this.sortingColumn;
     dialogRef.componentInstance.sortType = this.sortType;
-    dialogRef.componentInstance.filterValue = this.filterValue;
+    dialogRef.componentInstance.search = this.filterValue;
     dialogRef.componentInstance.name = 'Certificates-Table.xlsx';
   }
 

--- a/src/app/ubs-admin/components/ubs-admin-customers/columnsParams.ts
+++ b/src/app/ubs-admin/components/ubs-admin-customers/columnsParams.ts
@@ -134,3 +134,62 @@ export const columnsParamsViolations = [
     width: 100
   }
 ];
+
+export const columnsParamsCertificates = [
+  {
+    title: {
+      key: 'select',
+      ua: 'Вибір',
+      en: 'Select'
+    }
+  },
+  {
+    title: {
+      key: 'code',
+      ua: 'Код',
+      en: 'Code'
+    }
+  },
+  {
+    title: {
+      key: 'certificateStatus',
+      ua: 'Ступінь порушення',
+      en: 'Sertificate status'
+    }
+  },
+  {
+    title: {
+      key: 'orderId',
+      ua: 'Id замовлення',
+      en: 'Order Id'
+    }
+  },
+  {
+    title: {
+      key: 'points',
+      ua: 'Значення',
+      en: 'Points'
+    }
+  },
+  {
+    title: {
+      key: 'expirationDate',
+      ua: 'Термін придатності',
+      en: 'Expiration date'
+    }
+  },
+  {
+    title: {
+      key: 'creationDate',
+      ua: 'Дата створення',
+      en: 'Creation date'
+    }
+  },
+  {
+    title: {
+      key: 'dateOfUse',
+      ua: 'Дата використання',
+      en: 'Date ot use'
+    }
+  }
+];

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.html
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.html
@@ -150,7 +150,7 @@
   (scrolled)="onScroll()"
   [scrollWindow]="false"
 >
-  <mat-table [dataSource]="dataSource" id="table" class="customers_table" cdkDropListGroup>
+  <mat-table [dataSource]="dataSource" id="table" class="customers_table" *ngIf="!isLoading" cdkDropListGroup>
     <ng-container *ngFor="let column of columns; let i = index" [matColumnDef]="column.title.key">
       <mat-header-cell *matHeaderCellDef (mousedown)="onResizeColumn($event, i)">
         <div class="column_header">

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.ts
@@ -201,7 +201,8 @@ export class UbsAdminCustomersComponent implements OnInit, AfterViewChecked, OnD
     dialogRef.componentInstance.allElements = this.allElements;
     dialogRef.componentInstance.sortingColumn = this.sortingColumn;
     dialogRef.componentInstance.sortType = this.sortType;
-    dialogRef.componentInstance.filterValue = this.filterValue;
+    dialogRef.componentInstance.search = this.filterValue;
+    dialogRef.componentInstance.filters = this.queryString;
     dialogRef.componentInstance.name = 'Customers-Table.xlsx';
   }
 
@@ -224,7 +225,7 @@ export class UbsAdminCustomersComponent implements OnInit, AfterViewChecked, OnD
   ) {
     this.isLoading = true;
     this.adminCustomerService
-      .getCustomers(columnName, this.currentPage, filterValue, this.pageSize, sortingType)
+      .getCustomers(columnName, this.currentPage, this.queryString, filterValue, this.pageSize, sortingType)
       .pipe(takeUntil(this.destroy$))
       .subscribe((item: ICustomersTable) => {
         this.tableData = item.page;
@@ -239,8 +240,9 @@ export class UbsAdminCustomersComponent implements OnInit, AfterViewChecked, OnD
 
   private updateTableData() {
     this.isUpdate = true;
+    this.sortingColumn = !this.sortingColumn ? 'clientName' : this.sortingColumn;
     this.adminCustomerService
-      .getCustomers(this.sortingColumn || 'clientName', this.currentPage, this.filterValue, this.pageSize, this.sortType || 'ASC')
+      .getCustomers(this.sortingColumn, this.currentPage, this.queryString, this.filterValue, this.pageSize, this.sortType || 'ASC')
       .pipe(takeUntil(this.destroy$))
       .subscribe((item: ICustomersTable) => {
         this.tableData = [...this.tableData, ...item.page];

--- a/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.ts
@@ -16,7 +16,7 @@ import { FormGroup, FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { debounceTime, takeUntil } from 'rxjs/operators';
 import { ICustomersTable } from '../../models/customers-table.model';
 import { nonSortableColumns } from '../../models/non-sortable-columns.model';
 import { AdminCustomersService } from '../../services/admin-customers.service';
@@ -47,6 +47,9 @@ export class UbsAdminCustomersComponent implements OnInit, AfterViewChecked, OnD
   public filterForm: FormGroup;
   public hasChange = false;
   public filters: Filters;
+  public filterValue = '';
+  public modelChanged: Subject<string> = new Subject<string>();
+  public pageSize = 10;
 
   private tableData: any[];
   private sortType: string;
@@ -86,6 +89,10 @@ export class UbsAdminCustomersComponent implements OnInit, AfterViewChecked, OnD
     this.getTable();
     this.initFilterForm();
     this.onCreateGroupFormValueChange();
+    this.modelChanged.pipe(debounceTime(500)).subscribe((model) => {
+      this.currentPage = 0;
+      this.getTable(model, this.sortingColumn, this.sortType);
+    });
   }
 
   ngAfterViewChecked() {
@@ -93,9 +100,13 @@ export class UbsAdminCustomersComponent implements OnInit, AfterViewChecked, OnD
       const table = document.getElementById('table');
       const tableContainer = document.getElementById('table-container');
       this.isTableHeightSet = this.tableHeightService.setTableHeightToContainerHeight(table, tableContainer);
-      this.onScroll();
+      if (!this.isTableHeightSet) {
+        this.onScroll();
+      }
     }
-    this.setTableResize(this.matTableRef.nativeElement.clientWidth);
+    if (!this.isLoading) {
+      this.setTableResize(this.matTableRef.nativeElement.clientWidth);
+    }
     this.cdr.detectChanges();
   }
 
@@ -190,6 +201,7 @@ export class UbsAdminCustomersComponent implements OnInit, AfterViewChecked, OnD
     dialogRef.componentInstance.allElements = this.allElements;
     dialogRef.componentInstance.sortingColumn = this.sortingColumn;
     dialogRef.componentInstance.sortType = this.sortType;
+    dialogRef.componentInstance.filterValue = this.filterValue;
     dialogRef.componentInstance.name = 'Customers-Table.xlsx';
   }
 
@@ -201,13 +213,18 @@ export class UbsAdminCustomersComponent implements OnInit, AfterViewChecked, OnD
   }
 
   public applyFilter(filterValue: string): void {
-    this.dataSource.filter = filterValue.trim().toLowerCase();
+    this.filterValue = filterValue;
+    this.modelChanged.next(filterValue);
   }
 
-  private getTable(columnName = this.sortingColumn || 'recipientName', sortingType = this.sortType || 'ASC') {
+  private getTable(
+    filterValue = this.filterValue || '',
+    columnName = this.sortingColumn || 'clientName',
+    sortingType = this.sortType || 'ASC'
+  ) {
     this.isLoading = true;
     this.adminCustomerService
-      .getCustomers(columnName, this.currentPage, this.queryString, sortingType)
+      .getCustomers(columnName, this.currentPage, filterValue, this.pageSize, sortingType)
       .pipe(takeUntil(this.destroy$))
       .subscribe((item: ICustomersTable) => {
         this.tableData = item.page;
@@ -223,7 +240,7 @@ export class UbsAdminCustomersComponent implements OnInit, AfterViewChecked, OnD
   private updateTableData() {
     this.isUpdate = true;
     this.adminCustomerService
-      .getCustomers(this.sortingColumn || 'recipientName', this.currentPage, this.queryString, this.sortType || 'ASC')
+      .getCustomers(this.sortingColumn || 'clientName', this.currentPage, this.filterValue, this.pageSize, this.sortType || 'ASC')
       .pipe(takeUntil(this.destroy$))
       .subscribe((item: ICustomersTable) => {
         this.tableData = [...this.tableData, ...item.page];

--- a/src/app/ubs-admin/components/ubs-admin-table/ubs-admin-table-excel-popup/ubs-admin-table-excel-popup.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-table/ubs-admin-table-excel-popup/ubs-admin-table-excel-popup.component.ts
@@ -17,9 +17,10 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
   tableData: any[];
   tableView: string;
   totalElements: number;
-  filterValue: string;
+  search: string;
   name: string;
   allElements: number;
+  filters: string;
 
   constructor(
     private adminTableService: AdminTableService,
@@ -53,7 +54,7 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
           });
       }
       if (this.name === 'Customers-Table.xlsx') {
-        this.getCustomersTable(this.onePageForWholeTable, this.allElements, '', 'ASC', 'clientName')
+        this.getCustomersTable(this.onePageForWholeTable, this.allElements, '', '', 'ASC', 'clientName')
           .then((res) => {
             this.tableData = res[`page`];
           })
@@ -63,7 +64,7 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
       }
     } else if (this.tableView === 'currentFilter') {
       if (this.name === 'Orders-Table.xlsx') {
-        this.getOrdersTable(this.onePageForWholeTable, this.totalElements, this.filterValue, this.sortType, this.sortingColumn)
+        this.getOrdersTable(this.onePageForWholeTable, this.totalElements, this.search, this.sortType, this.sortingColumn)
           .then((res) => {
             this.tableData = res[`content`];
           })
@@ -72,7 +73,7 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
           });
       }
       if (this.name === 'Certificates-Table.xlsx') {
-        this.getCertificatesTable(this.onePageForWholeTable, this.totalElements, this.filterValue, this.sortType, this.sortingColumn)
+        this.getCertificatesTable(this.onePageForWholeTable, this.totalElements, this.search, this.sortType, this.sortingColumn)
           .then((res) => {
             this.tableData = res[`page`];
           })
@@ -81,7 +82,7 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
           });
       }
       if (this.name === 'Customers-Table.xlsx') {
-        this.getCustomersTable(this.onePageForWholeTable, this.totalElements, this.filterValue, this.sortType, this.sortingColumn)
+        this.getCustomersTable(this.onePageForWholeTable, this.totalElements, this.filters, this.search, this.sortType, this.sortingColumn)
           .then((res) => {
             this.tableData = res[`page`];
           })
@@ -95,7 +96,7 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
   getOrdersTable(
     currentPage,
     pageSize,
-    filters = this.filterValue || '',
+    filters = this.search || '',
     sortingType = this.sortType || 'DESC',
     columnName = this.sortingColumn || 'id'
   ) {
@@ -105,7 +106,7 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
   getCertificatesTable(
     currentPage,
     pageSize,
-    search = this.filterValue || '',
+    search = this.search || '',
     sortingType = this.sortType || 'DESC',
     columnName = this.sortingColumn || 'code'
   ) {
@@ -115,11 +116,12 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
   getCustomersTable(
     currentPage,
     pageSize,
-    filters = this.filterValue || '',
+    filters = this.filters || '',
+    search = this.search || '',
     sortingType = this.sortType || 'ASC',
     columnName = this.sortingColumn || 'clientName'
   ) {
-    return this.adminCustomerService.getCustomers(columnName, currentPage, filters, pageSize, sortingType).toPromise();
+    return this.adminCustomerService.getCustomers(columnName, currentPage, filters, search, pageSize, sortingType).toPromise();
   }
 
   createXLSX() {

--- a/src/app/ubs-admin/components/ubs-admin-table/ubs-admin-table-excel-popup/ubs-admin-table-excel-popup.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-table/ubs-admin-table-excel-popup/ubs-admin-table-excel-popup.component.ts
@@ -53,7 +53,7 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
           });
       }
       if (this.name === 'Customers-Table.xlsx') {
-        this.getCustomersTable(this.onePageForWholeTable, 'YuriiBoiko', this.sortType, 'recipientName')
+        this.getCustomersTable(this.onePageForWholeTable, this.allElements, '', 'ASC', 'clientName')
           .then((res) => {
             this.tableData = res[`page`];
           })
@@ -81,7 +81,7 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
           });
       }
       if (this.name === 'Customers-Table.xlsx') {
-        this.getCustomersTable(this.onePageForWholeTable, this.totalElements, '', 'recipientName')
+        this.getCustomersTable(this.onePageForWholeTable, this.totalElements, this.filterValue, this.sortType, this.sortingColumn)
           .then((res) => {
             this.tableData = res[`page`];
           })
@@ -112,8 +112,14 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
     return this.adminCertificateService.getTable(columnName, currentPage, search, pageSize, sortingType).toPromise();
   }
 
-  getCustomersTable(currentPage, filters, sortingType = this.sortType || 'DESC', columnName = this.sortingColumn || 'id') {
-    return this.adminCustomerService.getCustomers(columnName, currentPage, filters, sortingType).toPromise();
+  getCustomersTable(
+    currentPage,
+    pageSize,
+    filters = this.filterValue || '',
+    sortingType = this.sortType || 'ASC',
+    columnName = this.sortingColumn || 'clientName'
+  ) {
+    return this.adminCustomerService.getCustomers(columnName, currentPage, filters, pageSize, sortingType).toPromise();
   }
 
   createXLSX() {

--- a/src/app/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -263,7 +263,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
     dialogRef.componentInstance.allElements = this.allElements;
     dialogRef.componentInstance.sortingColumn = this.sortingColumn;
     dialogRef.componentInstance.sortType = this.sortType;
-    dialogRef.componentInstance.filterValue = this.filterValue;
+    dialogRef.componentInstance.search = this.filterValue;
     dialogRef.componentInstance.name = 'Orders-Table.xlsx';
   }
 

--- a/src/app/ubs-admin/services/admin-customers.service.spec.ts
+++ b/src/app/ubs-admin/services/admin-customers.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { AdminCustomersService } from './admin-customers.service';
 import { ICustomersTable } from '../models/customers-table.model';
 
-describe('AdminCertificateService', () => {
+describe('AdminCustomersService', () => {
   let httpMock: HttpTestingController;
   let service: AdminCustomersService;
   let fakeResponse: ICustomersTable;
@@ -27,17 +27,17 @@ describe('AdminCertificateService', () => {
 
   it('should return customers table', () => {
     fakeResponse = {
-      currentPage: 1,
+      currentPage: 0,
       page: ['fake'],
-      totalElements: 2,
+      totalElements: 10,
       totalPages: 3
     };
-    service.getCustomers('code', 0, 'DESC').subscribe((data) => {
+    service.getCustomers('code', 0, '', 10, 'ASC').subscribe((data) => {
       expect(data).toBeDefined();
       expect(data).toEqual(fakeResponse);
     });
-    const req = httpMock.expectOne(`${urlMock}/usersAll?page=0&columnName=code&DESC&sortingOrder=undefined`);
-    req.flush(fakeResponse);
+    const req = httpMock.expectOne(`${urlMock}/usersAll?pageNumber=0&pageSize=10&columnName=code&search=&sortingOrder=ASC`);
     expect(req.request.method).toBe('GET');
+    req.flush(fakeResponse);
   });
 });

--- a/src/app/ubs-admin/services/admin-customers.service.spec.ts
+++ b/src/app/ubs-admin/services/admin-customers.service.spec.ts
@@ -32,11 +32,11 @@ describe('AdminCustomersService', () => {
       totalElements: 10,
       totalPages: 3
     };
-    service.getCustomers('code', 0, '', 10, 'ASC').subscribe((data) => {
+    service.getCustomers('code', 0, '', '', 10, 'ASC').subscribe((data) => {
       expect(data).toBeDefined();
       expect(data).toEqual(fakeResponse);
     });
-    const req = httpMock.expectOne(`${urlMock}/usersAll?pageNumber=0&pageSize=10&columnName=code&search=&sortingOrder=ASC`);
+    const req = httpMock.expectOne(`${urlMock}/usersAll?pageNumber=0&pageSize=10&columnName=code&&search=&sortingOrder=ASC`);
     expect(req.request.method).toBe('GET');
     req.flush(fakeResponse);
   });

--- a/src/app/ubs-admin/services/admin-customers.service.ts
+++ b/src/app/ubs-admin/services/admin-customers.service.ts
@@ -13,15 +13,9 @@ export class AdminCustomersService {
 
   constructor(private http: HttpClient) {}
 
-  getCustomers(
-    column: string,
-    pageNumber?: number,
-    filters?: string,
-    pageSize?: number,
-    sortingType?: string
-  ): Observable<ICustomersTable> {
+  getCustomers(column: string, page?: number, search?: string, size?: number, sortType?: string): Observable<ICustomersTable> {
     return this.http.get<ICustomersTable>(
-      `${this.url}/usersAll?pageNumber=${pageNumber}&pageSize=${pageSize}&columnName=${column}&search=${filters}&sortingOrder=${sortingType}`
+      `${this.url}/usersAll?pageNumber=${page}&pageSize=${size}&columnName=${column}&search=${search}&sortingOrder=${sortType}`
     );
   }
 

--- a/src/app/ubs-admin/services/admin-customers.service.ts
+++ b/src/app/ubs-admin/services/admin-customers.service.ts
@@ -13,9 +13,9 @@ export class AdminCustomersService {
 
   constructor(private http: HttpClient) {}
 
-  getCustomers(column: string, page?: number, search?: string, size?: number, sortType?: string): Observable<ICustomersTable> {
+  getCustomers(clmn: string, page?: number, fltr?: string, search?: string, size?: number, sortType?: string): Observable<ICustomersTable> {
     return this.http.get<ICustomersTable>(
-      `${this.url}/usersAll?pageNumber=${page}&pageSize=${size}&columnName=${column}&search=${search}&sortingOrder=${sortType}`
+      `${this.url}/usersAll?pageNumber=${page}&pageSize=${size}&columnName=${clmn}&${fltr}&search=${search}&sortingOrder=${sortType}`
     );
   }
 

--- a/src/app/ubs-admin/services/admin-customers.service.ts
+++ b/src/app/ubs-admin/services/admin-customers.service.ts
@@ -13,8 +13,16 @@ export class AdminCustomersService {
 
   constructor(private http: HttpClient) {}
 
-  getCustomers(column: string, page?: number, filters?: string, sortingType?: string): Observable<ICustomersTable> {
-    return this.http.get<ICustomersTable>(`${this.url}/usersAll?page=${page}&columnName=${column}&${filters}&sortingOrder=${sortingType}`);
+  getCustomers(
+    column: string,
+    pageNumber?: number,
+    filters?: string,
+    pageSize?: number,
+    sortingType?: string
+  ): Observable<ICustomersTable> {
+    return this.http.get<ICustomersTable>(
+      `${this.url}/usersAll?pageNumber=${pageNumber}&pageSize=${pageSize}&columnName=${column}&search=${filters}&sortingOrder=${sortingType}`
+    );
   }
 
   getCustomerOrders(id: string, page: number, column: string, sortingType: string): Observable<ICustomerOrdersTable> {


### PR DESCRIPTION
As an administrator, I want to be able to export customers data in excel format so that I can use excel functionality in different systems.
Preconditions
The user is logged in as an administrator
The user navigates to Admin Cabinet on tab “Клієнти”
The table with customers contains at least 2 records
Business rules
Only administrators with access should be able to view the Admin Cabinet.
Acceptance Criteria
“Експортувати в Excel” button is added to the admin view
By clicking on ‘Експортувати в Excel’ - pop-up window with radio-buttons near save options is shown. In the top-right corner ‘Далі’ and ‘Скасувати’ buttons are placed
‘Далі’ - Opens explorer window to select a saving destination and excel file format.
‘Скасувати’ - Closes the pop-up window without saving
Saving options are:
‘Зберегти поточний вигляд’ - when the selected current table view is saved into Excel file, including all filter options and sorting
‘Зберегти всю таблицю’ - when selected full table with all fields and columns is saved to excel independent from selected filters\sorting
mockup:
https://www.figma.com/file/092AhCGadc1Hq8nAysxmYB/ITA-Greencity-%D0%A3%D0%91%D0%A1?node-id=15200%3A2746
Out of scope
Epic #2195