### PR TITLE
Feature/violation photo update

### DIFF
--- a/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.ts
+++ b/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.ts
@@ -37,6 +37,7 @@ export class AddViolationsComponent implements OnInit, OnDestroy {
   imgArray = [];
   imagesFromDBLength: number;
   imagesFromDB = [];
+  deletedImages: string[] | null = [];
   initialData: InitialData;
   isInitialDataChanged = false;
   isInitialImageDataChanged = false;
@@ -124,13 +125,16 @@ export class AddViolationsComponent implements OnInit, OnDestroy {
     }
   }
 
-  prepareDataToSend(dto: string, image?: string): FormData {
+  prepareDataToSend(dto: string): FormData {
     const { violationLevel, violationDescription } = this.addViolationForm.value;
     const data = {
       orderID: this.orderId,
       violationDescription,
       violationLevel
     };
+    if (this.editMode) {
+      data['imagesToDelete'] = this.deletedImages.length ? this.deletedImages : null;
+    }
     const formData: FormData = new FormData();
     const stringifiedDataToSend = JSON.stringify(data);
     formData.append(dto, stringifiedDataToSend);
@@ -295,6 +299,7 @@ export class AddViolationsComponent implements OnInit, OnDestroy {
     }
     if (this.editMode && i < this.imagesFromDBLength) {
       this.imagesFromDBLength--;
+      this.deletedImages.push(this.imagesFromDB[i]);
       this.imagesFromDB.splice(i, 1);
       this.isInitialImageDataChanged = true;
     }

--- a/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.ts
+++ b/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.ts
@@ -16,6 +16,13 @@ interface InitialData {
   initialImagesLength: number;
 }
 
+interface DataToSend {
+  orderID: number;
+  violationDescription: string;
+  violationLevel: string;
+  imagesToDelete?: string[] | null;
+}
+
 @Component({
   selector: 'app-add-violations',
   templateUrl: './add-violations.component.html',
@@ -127,13 +134,13 @@ export class AddViolationsComponent implements OnInit, OnDestroy {
 
   prepareDataToSend(dto: string): FormData {
     const { violationLevel, violationDescription } = this.addViolationForm.value;
-    const data = {
+    const data: DataToSend = {
       orderID: this.orderId,
       violationDescription,
       violationLevel
     };
     if (this.editMode) {
-      data['imagesToDelete'] = this.deletedImages.length ? this.deletedImages : null;
+      data.imagesToDelete = this.deletedImages.length ? this.deletedImages : null;
     }
     const formData: FormData = new FormData();
     const stringifiedDataToSend = JSON.stringify(data);

--- a/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.ts
+++ b/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.ts
@@ -139,7 +139,7 @@ export class AddViolationsComponent implements OnInit, OnDestroy {
     const stringifiedDataToSend = JSON.stringify(data);
     formData.append(dto, stringifiedDataToSend);
     for (const images of this.imgArray) {
-      formData.append('files', images);
+      formData.append(this.editMode ? 'multipartFiles' : 'files', images);
     }
     return formData;
   }


### PR DESCRIPTION
**Achieved results:**
- improved possibility to edit photos in the violation of the current order

**Preconditions:**
1. User is logged in as administrator.
2. Administrator has opened an order from current orders view table
3. Administrator has already added violation for current order

**Business rules:**
1. Only administrators with access should be able to view Admin Cabinet
2. Violations should be displayed for a user who created an order, not the receiver.

**Done:** 

[[UBS Admin Cabinet ] Edit violation of the current order #2863](https://github.com/ita-social-projects/GreenCity/issues/2863)