### PR TITLE
Fix bug/#3712-Close-'X'-icon-is-not-present-on-pop-up.

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.html
@@ -15,6 +15,9 @@
         {{ 'ubs-tables.export-to-excel' | translate }}
       </button>
       <ul class="dropdown-menu" [style.display]="display">
+        <button class="reset-settings" (click)="resetSetting()">
+          <i class="fa fa-close" aria-hidden="true"></i>
+        </button>
         <li class="item">
           <mat-checkbox class="check" type="checkbox" [checked]="isAll" (change)="showAllColumns(isAll)">
             {{ 'ubs-tables.all-elements' | translate }}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.scss
@@ -396,3 +396,8 @@ ul::-webkit-scrollbar-thumb {
   justify-content: space-between;
   position: relative;
 }
+.reset-settings {
+  float: right;
+  border: none;
+  border-radius: 100px;
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.scss
@@ -396,6 +396,7 @@ ul::-webkit-scrollbar-thumb {
   justify-content: space-between;
   position: relative;
 }
+
 .reset-settings {
   float: right;
   border: none;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -58,6 +58,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
   startX: number;
   startWidth: number;
   isResizingRight: boolean;
+  previousSettings: string[];
   resizableMousemove: () => void;
   resizableMouseup: () => void;
   @ViewChild(MatTable, { read: ElementRef }) private matTableRef: ElementRef;
@@ -186,6 +187,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
     if (this.isPopupOpen === false) {
       this.orderService.setColumnToDisplay(encodeURIComponent(this.displayedColumns.join(','))).subscribe();
     }
+    this.previousSettings = this.displayedColumns;
   }
 
   public showAllColumns(isCheckAll: boolean): void {
@@ -478,6 +480,11 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
     columnEls.forEach((el: any) => {
       el.style.width = column.width + 'px';
     });
+  }
+
+  public resetSetting() {
+    this.displayedColumns = this.previousSettings;
+    this.display = 'none';
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
Close 'X' icon is displayed on pop-up.
When you chose something on pop-up and then want reset chosen settings click on 'X' and you reset settings to previous.