### PR TITLE
Leftside panel folded only icons are visible

### DIFF
--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.html
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.html
@@ -8,7 +8,12 @@
 <mat-drawer-container class="sidebar" autosize>
   <mat-drawer #drawer class="sidebar-slider" mode="side" opened disableClose>
     <ul class="sidebar-list">
-      <li class="sidebar-list-item" *ngFor="let listItem of listElements" [routerLink]="listItem.routerLink">
+      <li
+        *ngFor="let listItem of listElements"
+        [ngStyle]="innerWidth <= 960 && { padding: '15px 20px' }"
+        [routerLink]="listItem.routerLink"
+        class="sidebar-list-item"
+      >
         <img
           class="sidebar-list-item-icon"
           src="{{
@@ -16,10 +21,12 @@
           }}"
           alt="sidebar list item icon"
         />
-        <a class="sidebar-list-item-link" [routerLink]="listItem.routerLink">{{ listItem.name | translate }}</a>
-        <div class="count-unread-messages" *ngIf="listItem.name === 'ubs-user.messages' && serviceUserMessages.countOfNoReadeMessages">
-          ({{ serviceUserMessages.countOfNoReadeMessages }})
-        </div>
+        <ng-container *ngIf="innerWidth >= 960">
+          <a class="sidebar-list-item-link" [routerLink]="listItem.routerLink">{{ listItem.name | translate }}</a>
+          <div class="count-unread-messages" *ngIf="listItem.name === 'ubs-user.messages' && serviceUserMessages.countOfNoReadeMessages">
+            ({{ serviceUserMessages.countOfNoReadeMessages }})
+          </div>
+        </ng-container>
       </li>
     </ul>
   </mat-drawer>

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, Input, OnDestroy, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { MatDrawer } from '@angular/material/sidenav';
 import { UserMessagesService } from '../../ubs/ubs-user/services/user-messages.service';
@@ -11,7 +11,7 @@ import { JwtService } from '@global-service/jwt/jwt.service';
   templateUrl: './ubs-base-sidebar.component.html',
   styleUrls: ['./ubs-base-sidebar.component.scss']
 })
-export class UbsBaseSidebarComponent implements AfterViewInit, OnDestroy {
+export class UbsBaseSidebarComponent implements OnInit, AfterViewInit, OnDestroy {
   private destroySub: Subject<boolean> = new Subject<boolean>();
   readonly bellsNoneNotification = 'assets/img/sidebarIcons/none_notification_Bell.svg';
   readonly bellsNotification = 'assets/img/sidebarIcons/notification_Bell.svg';
@@ -19,8 +19,10 @@ export class UbsBaseSidebarComponent implements AfterViewInit, OnDestroy {
   readonly arrowLeft = 'assets/img/ubs-admin-sidebar/arrowLeft.svg';
   public openClose = false;
   public stopClick = false;
+  public innerWidth: number;
   private adminRoleValue = 'ROLE_ADMIN';
   destroy: Subject<boolean> = new Subject<boolean>();
+
   @Input() public listElements: any[] = [];
   @ViewChild('sidebarToggler') sidebarToggler: ElementRef;
   @ViewChild('sideBarIcons') sideBarIcons: ElementRef;
@@ -32,6 +34,10 @@ export class UbsBaseSidebarComponent implements AfterViewInit, OnDestroy {
     public breakpointObserver: BreakpointObserver,
     public jwtService: JwtService
   ) {}
+
+  ngOnInit(): void {
+    this.innerWidth = window.innerWidth;
+  }
 
   public toggleSideBar(): void {
     if (this.openClose) {


### PR DESCRIPTION
**Preconditions**
Log into Green City as user

**Steps to reproduce**

1. Go to 'UBS-user'
2. Go to ‘User data’, 'Orders', 'Invoice', 'Messages'
3. Open Devtool
4. Resize the pages by dragging the corner of window to size 960x705

**Expected result**
Leftside panel is folded in a way that only icons of its options are visible