### PR TITLE
BugFix/Fixed displaying empty and extra rows

### DIFF
--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.spec.ts
@@ -77,6 +77,7 @@ describe('OrderDetailsFormComponent', () => {
     orderService = TestBed.inject(OrderService);
     spyOn(global, 'setTimeout');
     const spy = spyOn(orderService, 'getOrders').and.returnValue(of(mock));
+    spyOn(component as any, 'changeBagsIfLanguageChanged').and.returnValue(mock.bags);
     shareFormService.orderDetails = mock;
     localStorageService.getCurrentLanguage.and.callFake(() => Language.UA);
     fixture.detectChanges();

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -205,6 +205,20 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
     });
   }
 
+  private changeBagsIfLanguageChanged(bags) {
+    const currenLanguageBags = bags.filter((bag) => bag.quantity && bag.code === this.currentLanguage);
+    if (!currenLanguageBags.length) {
+      const notCurrentLanguageBags = bags.reduce(
+        (acc, bag) => (bag.code !== this.currentLanguage ? { ...acc, [bag.id]: bag.quantity } : acc),
+        {}
+      );
+      bags.forEach((bag) => {
+        bag.quantity = bag.code !== this.currentLanguage ? null : notCurrentLanguageBags[bag.id];
+      });
+    }
+    return bags;
+  }
+
   public takeOrderData() {
     this.isFetching = true;
     this.currentLanguage = this.localStorageService.getCurrentLanguage();
@@ -213,7 +227,7 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
       .pipe(takeUntil(this.destroy))
       .subscribe((orderData: OrderDetails) => {
         this.orders = this.shareFormService.orderDetails;
-        this.bags = this.orders.bags;
+        this.bags = this.changeBagsIfLanguageChanged(this.orders.bags);
         this.points = this.orders.points;
         this.defaultPoints = this.points;
         this.certificateLeft = orderData.points;

--- a/src/app/ubs/ubs/components/ubs-personal-information/ubs-personal-information.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-personal-information/ubs-personal-information.component.spec.ts
@@ -71,13 +71,17 @@ describe('UBSPersonalInformationComponent', () => {
       courierDtos: [],
       courierLimit: 'fake',
       courierLocationId: 1,
-      locationsDtos: [
+      locationInfoDtos: [
         {
-          latitude: 50,
-          locationId: 1,
-          locationStatus: 'fake',
-          locationTranslationDtoList: [{ locationName: 'Київ', languageCode: 'ua' }],
-          longitude: 30
+          locationsDto: [
+            {
+              latitude: 50,
+              locationId: 1,
+              locationStatus: 'fake',
+              locationTranslationDtoList: [{ locationName: 'Київ', languageCode: 'ua' }],
+              longitude: 30
+            }
+          ]
         }
       ],
       maxAmountOfBigBags: 99,

--- a/src/app/ubs/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
+++ b/src/app/ubs/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
@@ -81,8 +81,10 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
     if (localStorage.getItem('currentLocationId')) {
       this.currentLocationId = JSON.parse(localStorage.getItem('currentLocationId'));
       this.locations = JSON.parse(localStorage.getItem('locations'));
-      const loc = this.locations.find((el) => el.locationsDtos[0].locationId === this.currentLocationId);
-      const location = loc.locationsDtos[0].locationTranslationDtoList.find((el) => el.languageCode === this.currentLanguage);
+      const loc = this.locations.find((el) => el.locationInfoDtos[0].locationsDto[0].locationId === this.currentLocationId);
+      const location = loc.locationInfoDtos[0].locationsDto[0].locationTranslationDtoList.find(
+        (el) => el.languageCode === this.currentLanguage
+      );
       this.currentLocation = location.locationName;
     }
     this.orderService.locationSub.subscribe((data) => {


### PR DESCRIPTION
**Achieved results:**
- fixed displaying empty and extra rows
- changed location filtering due to the changes in dto form back-end

**Fixed Bug:** [[Ubs courier. Confirmation page] Empty rows are displayed in "Ваше замовлення"('Your order') table #3845](https://github.com/ita-social-projects/GreenCity/issues/3845)