### PR TITLE
Bugfix/#4008#4047/[Table view dropdown] "x" button saves changes + "display all" gets checked automatically

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.html
@@ -89,7 +89,7 @@
         {{ 'ubs-tables.export-to-excel' | translate }}
       </button>
       <ul class="dropdown-menu" [style.display]="display">
-        <button type="button" class="reset-settings" (click)="resetSetting()">
+        <button type="button" class="reset-settings" (click)="togglePopUp()">
           <i class="fa fa-close" aria-hidden="true"></i>
         </button>
         <li class="item">

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.html
@@ -93,7 +93,7 @@
           <i class="fa fa-close" aria-hidden="true"></i>
         </button>
         <li class="item">
-          <mat-checkbox class="check" type="checkbox" [checked]="isAll" (change)="showAllColumns(isAll)">
+          <mat-checkbox class="check" type="checkbox" [checked]="isAllColumnsDisplayed" (change)="showAllColumns(isAllColumnsDisplayed)">
             {{ 'ubs-tables.all-elements' | translate }}
           </mat-checkbox>
         </li>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.spec.ts
@@ -133,6 +133,12 @@ describe('UsbAdminTableComponent', () => {
     });
   });
 
+  it('ngOnInit should call checkAllColumnsDisplayed()', () => {
+    spyOn(component, 'checkAllColumnsDisplayed');
+    component.ngOnInit();
+    expect(component.checkAllColumnsDisplayed).toHaveBeenCalled();
+  });
+
   it('ngAfterViewChecked ', () => {
     component.isTableHeightSet = false;
     spyOn((component as any).tableHeightService, 'setTableHeightToContainerHeight').and.returnValue(true);
@@ -141,6 +147,22 @@ describe('UsbAdminTableComponent', () => {
     component.ngAfterViewChecked();
     expect((component as any).cdr.detectChanges).toHaveBeenCalledTimes(1);
     expect(component.isTableHeightSet).toBe(true);
+  });
+
+  it('isAllColumnsDisplayed sould be true ', () => {
+    component.displayedColumnsView.length = 4;
+    component.displayedColumns = ['title1', 'title2', 'title3', 'title4'];
+    component.checkAllColumnsDisplayed();
+
+    expect(component.isAllColumnsDisplayed).toBe(true);
+  });
+
+  it('isAllColumnsDisplayed sould be false ', () => {
+    component.displayedColumnsView.length = 4;
+    component.displayedColumns = ['title1', 'title2', 'title4'];
+    component.checkAllColumnsDisplayed();
+
+    expect(component.isAllColumnsDisplayed).toBe(false);
   });
 
   it('applyFilter call, expect modelChanged should been called with filter', () => {
@@ -194,21 +216,21 @@ describe('UsbAdminTableComponent', () => {
     expect(component.blockedInfo[0].userName).toEqual('name');
   });
 
-  it('changeColumns expect component.isAll to be true', () => {
-    component.isAll = false;
+  it('changeColumns expect component.isAllColumnsDisplayed to be true', () => {
+    component.isAllColumnsDisplayed = false;
     component.displayedColumnsView.length = 4;
     component.displayedColumns = ['title1', 'title2', 'title4'];
     component.changeColumns(true, 'title3', 2);
 
-    expect(component.isAll).toBe(true);
+    expect(component.isAllColumnsDisplayed).toBe(true);
   });
 
-  it('changeColumns expect component.isAll to be false', () => {
-    component.isAll = true;
+  it('changeColumns expect component.isAllColumnsDisplayed to be false', () => {
+    component.isAllColumnsDisplayed = true;
     component.displayedColumns.length = 4;
     component.displayedColumns = ['title1', 'title2', 'title3', 'title4'];
     component.changeColumns(false, 'title2', 1);
-    expect(component.isAll).toBe(false);
+    expect(component.isAllColumnsDisplayed).toBe(false);
   });
 
   it('changeColumns expect to filter columns when box is unchecked', () => {
@@ -378,20 +400,20 @@ describe('UsbAdminTableComponent', () => {
   });
 
   it('setDisplayedColumns  expect displayedColumnsViewTitles should change', () => {
-    component.isAll = false;
+    component.isAllColumnsDisplayed = false;
     component.displayedColumnsView = [{ title: { key: 'key' } }];
     (component as any).setDisplayedColumns();
     expect(component.displayedColumnsViewTitles).toEqual(['key']);
     expect(component.count).toBe(1);
-    expect(component.isAll).toBe(true);
+    expect(component.isAllColumnsDisplayed).toBe(true);
   });
 
   it('setUnDisplayedColumns expect displayedColumnsViewTitles should be empty', () => {
     component.displayedColumnsViewTitles = ['not empty'];
-    component.isAll = true;
+    component.isAllColumnsDisplayed = true;
     (component as any).setUnDisplayedColumns();
     expect(component.displayedColumnsViewTitles).toEqual([]);
-    expect(component.isAll).toBe(false);
+    expect(component.isAllColumnsDisplayed).toBe(false);
   });
 
   it('editSingle expect openPopUpRequires and postData should be call', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.spec.ts
@@ -20,7 +20,7 @@ import { MatDialogConfig } from '@angular/material/dialog';
 import { ServerTranslatePipe } from 'src/app/shared/translate-pipe/translate-pipe.pipe';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
-fdescribe('UsbAdminTableComponent', () => {
+describe('UsbAdminTableComponent', () => {
   let component: UbsAdminTableComponent;
   let fixture: ComponentFixture<UbsAdminTableComponent>;
   const storeMock = jasmine.createSpyObj('store', ['select', 'dispatch']);

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.spec.ts
@@ -20,7 +20,7 @@ import { MatDialogConfig } from '@angular/material/dialog';
 import { ServerTranslatePipe } from 'src/app/shared/translate-pipe/translate-pipe.pipe';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
-describe('UsbAdminTableComponent', () => {
+fdescribe('UsbAdminTableComponent', () => {
   let component: UbsAdminTableComponent;
   let fixture: ComponentFixture<UbsAdminTableComponent>;
   const storeMock = jasmine.createSpyObj('store', ['select', 'dispatch']);
@@ -561,14 +561,6 @@ describe('UsbAdminTableComponent', () => {
     component.columns = [{ width: 300 }, { width: 60 }, { width: 320 }, { width: 300 }, { width: 60 }];
     (component as any).setColumnWidthChanges(4, 200);
     expect((component as any).setColumnWidth).toHaveBeenCalledTimes(2);
-  });
-
-  it('resetSetting', () => {
-    component.display = '';
-    component.previousSettings = ['value'];
-    component.resetSetting();
-    expect(component.displayedColumns).toEqual(['value']);
-    expect(component.display).toBe('none');
   });
 
   it('setColumnsForFiltering', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.spec.ts
@@ -194,19 +194,35 @@ describe('UsbAdminTableComponent', () => {
     expect(component.blockedInfo[0].userName).toEqual('name');
   });
 
-  it('changeColumns true expect  component.isAll to be true', () => {
+  it('changeColumns expect component.isAll to be true', () => {
     component.isAll = false;
-    component.count = 1;
-    component.changeColumns(true, 'key', 2);
+    component.displayedColumnsView.length = 4;
+    component.displayedColumns = ['title1', 'title2', 'title4'];
+    component.changeColumns(true, 'title3', 2);
+
     expect(component.isAll).toBe(true);
   });
 
-  it('changeColumns false expect  component.isAll to be true', () => {
-    component.isAll = false;
-    component.displayedColumns = ['name'];
-    component.count = 1;
-    component.changeColumns(false, '2', 2);
-    expect(component.isAll).toBe(true);
+  it('changeColumns expect component.isAll to be false', () => {
+    component.isAll = true;
+    component.displayedColumns.length = 4;
+    component.displayedColumns = ['title1', 'title2', 'title3', 'title4'];
+    component.changeColumns(false, 'title2', 1);
+    expect(component.isAll).toBe(false);
+  });
+
+  it('changeColumns expect to filter columns when box is unchecked', () => {
+    component.displayedColumns = ['title1', 'title2', 'title3', 'title4'];
+    component.changeColumns(false, 'title3', 2);
+
+    expect(component.displayedColumns).toEqual(['title1', 'title2', 'title4']);
+  });
+
+  it('changeColumns expect to add column when box is checked ', () => {
+    component.displayedColumns = ['title1', 'title2', 'title4'];
+    component.changeColumns(true, 'title3', 2);
+
+    expect(component.displayedColumns).toEqual(['title1', 'title2', 'title3', 'title4']);
   });
 
   it('togglePopUp expect store.dispatch have been called', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -62,7 +62,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
   allChecked = false;
   tableViewHeaders = [];
   public blockedInfo: IAlertInfo[] = [];
-  isAll: boolean;
+  isAll: boolean = true;
   count: number;
   display = 'none';
   filterValue = '';
@@ -154,7 +154,6 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
         this.tableViewHeaders = columns.columnBelongingList;
         this.columns = JSON.parse(JSON.stringify(columns.columnDTOList));
         this.displayedColumnsView = columns.columnDTOList;
-        this.isAll = this.displayedColumns.length === this.displayedColumnsView.length ? true : false;
         this.displayedColumnsViewTitles = this.displayedColumnsView.map((item) => item.title.key);
         this.columns.forEach((column) => {
           if (column.filtered) {
@@ -180,6 +179,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
         this.editDetails();
       }
     });
+
     if (this.isStoreEmpty) {
       this.getColumns();
       this.store.dispatch(GetColumnToDisplay());

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -118,7 +118,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
     this.ordersViewParameters$.subscribe((items: IOrdersViewParameters) => {
       if (items) {
         this.displayedColumns = items.titles.split(',')[0] === '' ? [] : items.titles.split(',');
-        this.isAll = false;
+        this.isAll = this.displayedColumns.length === 35 ? true : false;
       }
     });
 
@@ -276,7 +276,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
     this.displayedColumns = checked
       ? [...this.displayedColumns.slice(0, positionIndex), key, ...this.displayedColumns.slice(positionIndex)]
       : this.displayedColumns.filter((item) => item !== key);
-    this.isAll = this.count === this.displayedColumns.length;
+    this.isAll = this.displayedColumns.length === this.displayedColumnsView.length;
   }
 
   public togglePopUp() {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -62,7 +62,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
   allChecked = false;
   tableViewHeaders = [];
   public blockedInfo: IAlertInfo[] = [];
-  isAll: boolean = true;
+  isAll = true;
   count: number;
   display = 'none';
   filterValue = '';

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -118,7 +118,6 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
     this.ordersViewParameters$.subscribe((items: IOrdersViewParameters) => {
       if (items) {
         this.displayedColumns = items.titles.split(',')[0] === '' ? [] : items.titles.split(',');
-        this.isAll = this.displayedColumns.length === 35 ? true : false;
       }
     });
 
@@ -155,6 +154,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
         this.tableViewHeaders = columns.columnBelongingList;
         this.columns = JSON.parse(JSON.stringify(columns.columnDTOList));
         this.displayedColumnsView = columns.columnDTOList;
+        this.isAll = this.displayedColumns.length === this.displayedColumnsView.length ? true : false;
         this.displayedColumnsViewTitles = this.displayedColumnsView.map((item) => item.title.key);
         this.columns.forEach((column) => {
           if (column.filtered) {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -654,12 +654,6 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
     });
   }
 
-  public resetSetting() {
-    this.displayedColumns = this.previousSettings;
-    this.display = 'none';
-    this.isPopupOpen = false;
-  }
-
   setColumnsForFiltering(columns): void {
     this.adminTableService.setColumnsForFiltering(columns);
   }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -62,7 +62,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
   allChecked = false;
   tableViewHeaders = [];
   public blockedInfo: IAlertInfo[] = [];
-  isAll = true;
+  isAllColumnsDisplayed: boolean;
   count: number;
   display = 'none';
   filterValue = '';
@@ -178,6 +178,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
         this.sortColumnsToDisplay();
         this.editDetails();
       }
+      this.checkAllColumnsDisplayed();
     });
 
     if (this.isStoreEmpty) {
@@ -196,6 +197,10 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
       }
     }
     this.cdr.detectChanges();
+  }
+
+  checkAllColumnsDisplayed() {
+    this.isAllColumnsDisplayed = this.displayedColumns.length === this.displayedColumnsView.length;
   }
 
   applyFilter(filterValue: string): void {
@@ -276,7 +281,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
     this.displayedColumns = checked
       ? [...this.displayedColumns.slice(0, positionIndex), key, ...this.displayedColumns.slice(positionIndex)]
       : this.displayedColumns.filter((item) => item !== key);
-    this.isAll = this.displayedColumns.length === this.displayedColumnsView.length;
+    this.checkAllColumnsDisplayed();
   }
 
   public togglePopUp() {
@@ -424,7 +429,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
     this.displayedColumnsView.forEach((column, index) => {
       this.displayedColumnsViewTitles[index] = column.title.key;
     });
-    this.isAll = true;
+    this.isAllColumnsDisplayed = true;
     this.displayedColumns = this.displayedColumnsViewTitles;
     this.count = this.displayedColumnsViewTitles.length;
   }
@@ -432,7 +437,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
   private setUnDisplayedColumns(): void {
     this.displayedColumnsViewTitles = [];
     this.displayedColumns = ['select'];
-    this.isAll = false;
+    this.isAllColumnsDisplayed = false;
   }
 
   private editSingle(e: IEditCell): void {


### PR DESCRIPTION
ubs-admin-table  -> "table view" dropdown
#4008 - after unchecking some columns and closing dropdown the table stays up to date
#4047 - the "Display all columns" box gets checked when all boxes are checked
