### PR TITLE
Feature/#4006/[admin-order]'Save' button on admin-order-page sets changes to store

### DIFF
--- a/src/app/store/actions/bigOrderTable.actions.ts
+++ b/src/app/store/actions/bigOrderTable.actions.ts
@@ -11,11 +11,17 @@ export enum BigOrderTableActions {
   GetTable = '[BigOrderTable] Get Table',
   GetTableSuccess = '[BigOrderTable] Get Table Success',
   ChangingOrderData = '[BigOrderTable] Changing Order Data',
+  ChangingOrderPaymentStatus = '[BigOrderTable] Changing Order Payment Status',
   ChangingOrderDataSuccess = '[BigOrderTable] Changing Order Data Success',
   ReceivedFailure = '[BigOrderTable] Received Failure'
 }
 
 export const GetColumnToDisplay = createAction(BigOrderTableActions.GetColumnToDisplay);
+
+export const ChangingOrderPaymentStatus = createAction(
+  BigOrderTableActions.ChangingOrderPaymentStatus,
+  props<{ orderId?: number; newValue?: string }>()
+);
 
 export const GetColumnToDisplaySuccess = createAction(
   BigOrderTableActions.GetColumnToDisplaySuccess,

--- a/src/app/store/reducers/bigOrderTable.reducer.ts
+++ b/src/app/store/reducers/bigOrderTable.reducer.ts
@@ -3,6 +3,7 @@ import {
   GetColumnToDisplaySuccess,
   SetColumnToDisplaySuccess,
   ChangingOrderDataSuccess,
+  ChangingOrderPaymentStatus,
   GetColumnsSuccess,
   GetTableSuccess,
   ReceivedFailure
@@ -43,6 +44,24 @@ export const bigOrderTableReducer = createReducer(
           if (orderData.id === action.orderId[0]) {
             const newOrderData = { ...orderData };
             newOrderData[action.columnName] = action.newValue;
+            return newOrderData;
+          }
+          return orderData;
+        })
+      }
+    };
+  }),
+
+  on(ChangingOrderPaymentStatus, (state, action) => {
+    return {
+      ...state,
+      bigOrderTable: {
+        ...state.bigOrderTable,
+        content: state.bigOrderTable.content.map((orderData) => {
+          if (orderData.id === action.orderId) {
+            const newOrderData = { ...orderData };
+            const columnName = 'orderPaymentStatus';
+            newOrderData[columnName] = action.newValue;
             return newOrderData;
           }
           return orderData;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.spec.ts
@@ -4,13 +4,16 @@ import { TranslateModule } from '@ngx-translate/core';
 import { LocalizedCurrencyPipe } from 'src/app/shared/localized-currency-pipe/localized-currency.pipe';
 import { IEmployee, IOrderInfo, IPaymentInfoDto } from '../../models/ubs-admin.interface';
 import { OrderService } from '../../services/order.service';
-import { StoreModule } from '@ngrx/store';
+import { Store, StoreModule } from '@ngrx/store';
 
 import { UbsAdminOrderPaymentComponent } from './ubs-admin-order-payment.component';
+import { ChangingOrderPaymentStatus } from 'src/app/store/actions/bigOrderTable.actions';
+import { Subject } from 'rxjs';
 
 describe('UbsAdminOrderPaymentComponent', () => {
   let component: UbsAdminOrderPaymentComponent;
   let fixture: ComponentFixture<UbsAdminOrderPaymentComponent>;
+  let storeMock;
   const matDialogMock = () => ({
     open: () => ({
       afterClosed: () => ({ pipe: () => ({ subscribe: (f) => f({}) }) })
@@ -229,12 +232,17 @@ describe('UbsAdminOrderPaymentComponent', () => {
   };
 
   beforeEach(async(() => {
+    storeMock = {
+      dispatch: jasmine.createSpy('dispatch')
+    };
+
     TestBed.configureTestingModule({
       declarations: [UbsAdminOrderPaymentComponent, LocalizedCurrencyPipe],
       imports: [MatDialogModule, TranslateModule.forRoot(), StoreModule.forRoot({})],
       providers: [
         { provide: MatDialog, useFactory: matDialogMock },
-        { provide: OrderService, useValue: orderServiceMock }
+        { provide: OrderService, useValue: orderServiceMock },
+        { provide: Store, useValue: storeMock }
       ]
     }).compileComponents();
   }));
@@ -308,6 +316,12 @@ describe('UbsAdminOrderPaymentComponent', () => {
     component.paymentsArray.forEach((payment: IPaymentInfoDto) => {
       expect(payment.amount).toBeGreaterThan(0);
     });
+  });
+
+  it('method postDataItem', () => {
+    (component as any).postDataItem(250, 'PAID');
+
+    expect(storeMock.dispatch).toHaveBeenCalled();
   });
 
   it('method getStringDate', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.spec.ts
@@ -4,6 +4,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { LocalizedCurrencyPipe } from 'src/app/shared/localized-currency-pipe/localized-currency.pipe';
 import { IEmployee, IOrderInfo, IPaymentInfoDto } from '../../models/ubs-admin.interface';
 import { OrderService } from '../../services/order.service';
+import { StoreModule } from '@ngrx/store';
 
 import { UbsAdminOrderPaymentComponent } from './ubs-admin-order-payment.component';
 
@@ -230,7 +231,7 @@ describe('UbsAdminOrderPaymentComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [UbsAdminOrderPaymentComponent, LocalizedCurrencyPipe],
-      imports: [MatDialogModule, TranslateModule.forRoot()],
+      imports: [MatDialogModule, TranslateModule.forRoot(), StoreModule.forRoot({})],
       providers: [
         { provide: MatDialog, useFactory: matDialogMock },
         { provide: OrderService, useValue: orderServiceMock }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.ts
@@ -1,16 +1,20 @@
-import { Component, Input, OnInit, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, OnInit, OnChanges, SimpleChanges, OnDestroy } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { take } from 'rxjs/operators';
+import { Subject, Subscription } from 'rxjs';
+import { take, takeUntil } from 'rxjs/operators';
+import { ChangingOrderPaymentStatus } from 'src/app/store/actions/bigOrderTable.actions';
 import { IPaymentInfo, IPaymentInfoDto, IOrderInfo, PaymentDetails } from '../../models/ubs-admin.interface';
 import { OrderService } from '../../services/order.service';
 import { AddPaymentComponent } from '../add-payment/add-payment.component';
+import { IAppState } from 'src/app/store/state/app.state';
+import { Store } from '@ngrx/store';
 
 @Component({
   selector: 'app-ubs-admin-order-payment',
   templateUrl: './ubs-admin-order-payment.component.html',
   styleUrls: ['./ubs-admin-order-payment.component.scss']
 })
-export class UbsAdminOrderPaymentComponent implements OnInit, OnChanges {
+export class UbsAdminOrderPaymentComponent implements OnInit, OnChanges, OnDestroy {
   @Input() orderInfo: IOrderInfo;
   @Input() actualPrice: number;
   @Input() totalPaid: number;
@@ -25,8 +29,9 @@ export class UbsAdminOrderPaymentComponent implements OnInit, OnChanges {
   public paymentInfo: IPaymentInfo;
   public paymentsArray: IPaymentInfoDto[];
   public currentOrderStatus: string;
+  private destroy$: Subject<boolean> = new Subject<boolean>();
 
-  constructor(private orderService: OrderService, private dialog: MatDialog) {}
+  constructor(private orderService: OrderService, private dialog: MatDialog, private store: Store<IAppState>) {}
 
   ngOnInit() {
     this.currentOrderStatus = this.orderStatus;
@@ -130,6 +135,10 @@ export class UbsAdminOrderPaymentComponent implements OnInit, OnChanges {
     }
   }
 
+  private postDataItem(orderId: number, newValue: string): void {
+    this.store.dispatch(ChangingOrderPaymentStatus({ orderId, newValue }));
+  }
+
   public openPopup(viewMode: boolean, paymentIndex?: number): void {
     this.dialog
       .open(AddPaymentComponent, {
@@ -156,7 +165,20 @@ export class UbsAdminOrderPaymentComponent implements OnInit, OnChanges {
         if (extraPayment !== null && typeof extraPayment === 'object') {
           this.preconditionChangePaymentData(extraPayment);
           this.setOverpayment(this.totalPaid - this.actualPrice);
+
+          this.orderService
+            .getOrderInfo(this.orderId)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe((data: IOrderInfo) => {
+              const newValue = data.generalOrderInfo.orderPaymentStatus;
+              this.postDataItem(this.orderId, newValue);
+            });
         }
       });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit, OnChanges, SimpleChanges, OnDestroy } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { Subject, Subscription } from 'rxjs';
+import { Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 import { ChangingOrderPaymentStatus } from 'src/app/store/actions/bigOrderTable.actions';
 import { IPaymentInfo, IPaymentInfoDto, IOrderInfo, PaymentDetails } from '../../models/ubs-admin.interface';

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
@@ -2,7 +2,7 @@
 <app-search-popup></app-search-popup>
 <div *ngIf="orderInfo; else spinner" class="container">
   <div class="row">
-    <button class="back-button-top" (click)="openGoBackModal()">< {{ 'order-edit.btn.back' | translate }}</button>
+    <button class="back-button-top" (click)="goBack()">{{ 'order-edit.btn.back' | translate }}</button>
   </div>
   <form [formGroup]="orderForm">
     <div class="box">
@@ -46,14 +46,14 @@
       <app-ubs-admin-order-history [orderId]="orderId"></app-ubs-admin-order-history>
     </div>
     <div class="row">
-      <button class="back-button" (click)="openGoBackModal()">
+      <button class="back-button" (click)="goBack()">
         {{ 'order-edit.btn.back' | translate }}
       </button>
       <div class="controls">
         <button type="reset" class="cancel-button" (click)="$event.preventDefault(); openCancelModal()">
           {{ 'order-edit.btn.cancel' | translate }}
         </button>
-        <button type="submit" class="save-button" [disabled]="!orderForm.valid || !isMinOrder" (click)="onSubmit()">
+        <button type="submit" class="save-button" [disabled]="orderForm.pristine || !orderForm.valid || !isMinOrder" (click)="onSubmit()">
           {{ 'order-edit.btn.save' | translate }}
           <span class="inform-window">
             {{ 'information-window.message' | translate }}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy, AfterContentChecked, ChangeDetectorRef, Injector } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { ActivatedRoute, Params } from '@angular/router';
+import { ActivatedRoute, Params, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { UbsAdminCancelModalComponent } from '../ubs-admin-cancel-modal/ubs-admin-cancel-modal.component';
 import { UbsAdminGoBackModalComponent } from '../ubs-admin-go-back-modal/ubs-admin-go-back-modal.component';
@@ -25,6 +25,9 @@ import {
 } from '../../models/ubs-admin.interface';
 import { formatDate } from '@angular/common';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
+import { IAppState } from 'src/app/store/state/app.state';
+import { Store } from '@ngrx/store';
+import { ChangingOrderData } from 'src/app/store/actions/bigOrderTable.actions';
 
 @Component({
   selector: 'app-ubs-admin-order',
@@ -51,6 +54,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
   currentOrderStatus: string;
   overpayment: number;
   isMinOrder = true;
+  submitted = false;
   private matSnackBar: MatSnackBarComponent;
   private orderService: OrderService;
   constructor(
@@ -59,8 +63,10 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
     private fb: FormBuilder,
     private dialog: MatDialog,
     private route: ActivatedRoute,
+    private router: Router,
     private changeDetector: ChangeDetectorRef,
-    private injector: Injector
+    private injector: Injector,
+    private store: Store<IAppState>
   ) {
     this.matSnackBar = injector.get<MatSnackBarComponent>(MatSnackBarComponent);
     this.orderService = injector.get<OrderService>(OrderService);
@@ -143,6 +149,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
     this.orderForm = this.fb.group({
       generalOrderInfo: this.fb.group({
         orderStatus: this.generalInfo.orderStatus,
+        paymentStatus: this.generalInfo.orderPaymentStatus,
         adminComment: this.generalInfo.adminComment,
         cancellationComment: '', // TODO add this fields to controller
         cancellationReason: '' // TODO
@@ -228,10 +235,14 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       });
   }
 
-  openGoBackModal() {
-    this.dialog.open(UbsAdminGoBackModalComponent, {
-      hasBackdrop: true
-    });
+  goBack() {
+    if (this.orderForm.dirty && !this.submitted) {
+      this.dialog.open(UbsAdminGoBackModalComponent, {
+        hasBackdrop: true
+      });
+    } else {
+      this.router.navigate(['ubs-admin', 'orders']);
+    }
   }
 
   onChangedOrderStatus(status: string) {
@@ -296,6 +307,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
   }
 
   public onSubmit(): void {
+    this.submitted = true;
     const changedValues: any = {};
     this.getUpdates(this.orderForm, changedValues);
 
@@ -331,9 +343,21 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       .pipe(takeUntil(this.destroy$))
       .subscribe((response) => {
         response.ok ? this.matSnackBar.snackType.changesSaved() : this.matSnackBar.snackType.error();
-        this.getOrderInfo(this.orderId);
+        if (response.ok) {
+          this.getOrderInfo(this.orderId);
+          for (const key in changedValues.generalOrderInfo) {
+            if (key && changedValues.generalOrderInfo[key]) {
+              this.postDataItem([this.orderId], key, changedValues.generalOrderInfo[key]);
+            }
+          }
+        }
       });
   }
+
+  private postDataItem(orderId: number[], columnName: string, newValue: string): void {
+    this.store.dispatch(ChangingOrderData({ orderId, columnName, newValue }));
+  }
+
   private getUpdates(formItem: FormGroup | FormArray | FormControl, changedValues: IOrderInfo, name?: string) {
     if (formItem instanceof FormControl) {
       if (name && formItem.dirty) {


### PR DESCRIPTION
new values of orderStatus and paymentStatus are set to store after clicking Save and before clicking Go Back button on admin order page -> Admin Orders Table gets updated before reloadng