### PR TITLE
Bugfix/#4179#4077/[UBS-Admin-Order] "Save" button is active if the only change in order is additional payment

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnChanges, SimpleChanges, OnDestroy } from '@angular/core';
+import { Component, Input, OnInit, OnChanges, SimpleChanges, OnDestroy, Output, EventEmitter } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
@@ -19,6 +19,8 @@ export class UbsAdminOrderPaymentComponent implements OnInit, OnChanges, OnDestr
   @Input() actualPrice: number;
   @Input() totalPaid: number;
   @Input() orderStatus: string;
+
+  @Output() newPaymentStatus = new EventEmitter<string>();
 
   public message: string;
   public pageOpen: boolean;
@@ -173,6 +175,7 @@ export class UbsAdminOrderPaymentComponent implements OnInit, OnChanges, OnDestr
             .subscribe((data: IOrderInfo) => {
               const newValue = data.generalOrderInfo.orderPaymentStatus;
               this.postDataItem(this.orderId, newValue);
+              this.newPaymentStatus.emit(newValue);
             });
         }
       });

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
@@ -34,7 +34,7 @@
                 <label for="payment" class="form__label">
                   {{ 'order-edit.status.payment-label' | translate }}
                 </label>
-                <select id="payment" class="form-control payment" disabled>
+                <select id="payment" class="form-control payment" formControlName="paymentStatus" disabled>
                   <option
                     *ngFor="let status of generalInfo.orderPaymentStatusesDto"
                     [selected]="status?.key === generalInfo.orderPaymentStatus"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.spec.ts
@@ -30,6 +30,7 @@ describe('UbsAdminOrderStatusComponent', () => {
 
   const FormGroupMock = new FormGroup({
     orderStatus: new FormControl(''),
+    paymentStatus: new FormControl(''),
     adminComment: new FormControl(''),
     cancellationReason: new FormControl(''),
     cancellationComment: new FormControl('')

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
@@ -18,6 +18,8 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
   @Input() totalPaid: number;
   @Input() generalInfo: IGeneralOrderInfo;
   @Input() currentLanguage: string;
+  @Input() additionalPayment: string;
+
   @Output() changedOrderStatus = new EventEmitter<string>();
 
   constructor(public orderService: OrderService, private dialog: MatDialog) {}
@@ -26,6 +28,9 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
   public availableOrderStatuses;
 
   ngOnChanges(changes: SimpleChanges): void {
+    if (changes.additionalPayment) {
+      this.generalInfo.orderPaymentStatus = changes.additionalPayment.currentValue;
+    }
     if (changes.currentOrderPrice || changes.totalPaid) {
       this.setOrderPaymentStatus();
     }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
@@ -12,6 +12,7 @@
         [generalInfo]="generalInfo"
         [totalPaid]="totalPaid"
         [currentLanguage]="currentLanguage"
+        [additionalPayment]="additionalPayment"
         (changedOrderStatus)="onChangedOrderStatus($event)"
       >
       </app-ubs-admin-order-status>
@@ -35,6 +36,7 @@
         [totalPaid]="totalPaid"
         [orderInfo]="orderInfo"
         [orderStatus]="currentOrderStatus"
+        (newPaymentStatus)="onUpdatePaymentStatus($event)"
       ></app-ubs-admin-order-payment>
       <app-ubs-admin-export-details [exportDetailsDto]="getFormGroup('exportDetailsDto')" [exportInfo]="exportInfo">
       </app-ubs-admin-export-details>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -55,6 +55,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
   overpayment: number;
   isMinOrder = true;
   isSubmitted = false;
+  additionalPayment: string;
   private matSnackBar: MatSnackBarComponent;
   private orderService: OrderService;
   constructor(
@@ -245,6 +246,11 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
     this.currentOrderStatus = status;
     this.orderStatusInfo = this.getOrderStatusInfo(this.currentOrderStatus);
     this.notRequiredFieldsStatuses();
+  }
+
+  public onUpdatePaymentStatus(newPaymentStatus: string): void {
+    this.additionalPayment = newPaymentStatus;
+    this.orderForm.markAsDirty();
   }
 
   public changeOverpayment(sum: number): void {


### PR DESCRIPTION
UBS-Admin-Order -> "Save" button is active if the only change in order is additional payment
UBS-Admin-Order -> After pressing the "Зберегти" button the buttons "Зберегти" and "Скасувати" are disabled