### PR TITLE
Bugfix/#4214/Unchanged confirmed amount field isn't set to 0 after submit changes in another

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -112,7 +112,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
     this.setPreviousBagsIfEmpty(this.currentOrderStatus);
     const bagsObj = this.orderInfo.bags.map((bag) => {
       bag.planned = this.orderInfo.amountOfBagsOrdered[bag.id] || 0;
-      bag.confirmed = this.orderInfo.amountOfBagsConfirmed[bag.id] || 0;
+      bag.confirmed = this.orderInfo.amountOfBagsConfirmed[bag.id] || bag.planned;
       bag.actual = this.orderInfo.amountOfBagsExported[bag.id] || 0;
       return bag;
     });


### PR DESCRIPTION
if there is more then one bag type ordered in one order and Admin increases only one confirmed amount field and submits it another non 0 confirmed amounts isn't set to 0