### PR TITLE
Bugfix/#4233/[UBS-User-orders] Pagination colntrolls are displayed conditionally + interface added

### DIFF
--- a/src/app/ubs/ubs-user/services/user-orders.service.ts
+++ b/src/app/ubs/ubs-user/services/user-orders.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '@environment/environment.js';
+import { IUserOrdersInfo } from '../ubs-user-orders-list/models/UserOrder.interface';
 
 @Injectable({
   providedIn: 'root'
@@ -11,12 +12,12 @@ export class UserOrdersService {
 
   constructor(private http: HttpClient) {}
 
-  getAllUserOrders(page: number, itemsPerPage: number, table: string): Observable<any> {
+  getAllUserOrders(page: number, itemsPerPage: number, table: string): Observable<IUserOrdersInfo> {
     const ordersStatusesParams =
       table === 'current'
         ? 'ADJUSTMENT&status=BROUGHT_IT_HIMSELF&status=FORMED&status=CONFIRMED&status=ON_THE_ROUTE&status=NOT_TAKEN_OUT'
         : 'DONE&status=CANCELED';
-    return this.http.get<any[]>(`${this.url}/user-orders?page=${page}&size=${itemsPerPage}&status=${ordersStatusesParams}`);
+    return this.http.get<IUserOrdersInfo>(`${this.url}/user-orders?page=${page}&size=${itemsPerPage}&status=${ordersStatusesParams}`);
   }
   public deleteOrder(orderId: number): Observable<object> {
     return this.http.delete<object>(`${this.url}/delete-order/${orderId}`);

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/models/UserOrder.interface.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/models/UserOrder.interface.ts
@@ -66,3 +66,10 @@ export enum CheckOrderStatus {
   FORMED = 'Formed',
   ADJUSTMENT = 'Adjustment'
 }
+
+export interface IUserOrdersInfo {
+  currentPage: number;
+  page: IUserOrderInfo[];
+  totalElements: number;
+  totalPages: number;
+}

--- a/src/app/ubs/ubs-user/ubs-user-orders/ubs-user-orders.component.html
+++ b/src/app/ubs/ubs-user/ubs-user-orders/ubs-user-orders.component.html
@@ -41,7 +41,7 @@
         </div>
       </mat-tab>
     </mat-tab-group>
-    <div *ngIf="moreThenOnePage">
+    <div *ngIf="isMoreThenOnePage">
       <pagination-controls (pageChange)="onPageChange($event)" class="user-orders-pagination"></pagination-controls>
     </div>
     <div class="empty"></div>

--- a/src/app/ubs/ubs-user/ubs-user-orders/ubs-user-orders.component.html
+++ b/src/app/ubs/ubs-user/ubs-user-orders/ubs-user-orders.component.html
@@ -41,7 +41,9 @@
         </div>
       </mat-tab>
     </mat-tab-group>
-    <pagination-controls (pageChange)="onPageChange($event)" class="user-orders-pagination"></pagination-controls>
+    <div *ngIf="moreThenOnePage">
+      <pagination-controls (pageChange)="onPageChange($event)" class="user-orders-pagination"></pagination-controls>
+    </div>
     <div class="empty"></div>
   </div>
 

--- a/src/app/ubs/ubs-user/ubs-user-orders/ubs-user-orders.component.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders/ubs-user-orders.component.ts
@@ -27,6 +27,7 @@ export class UbsUserOrdersComponent implements OnInit, OnDestroy {
   numberOfHistoryOrders: number;
   currentOrdersOnPage = 10;
   historyOrdersOnPage = 10;
+  moreThenOnePage: boolean;
 
   constructor(
     private router: Router,
@@ -83,6 +84,10 @@ export class UbsUserOrdersComponent implements OnInit, OnDestroy {
         this.loadingOrders = true;
         this.currentOrders = table === 'current' ? this.orders : this.currentOrders;
         this.orderHistory = table === 'history' ? this.orders : this.orderHistory;
+
+        if (this.numberOfCurrentOrders && this.numberOfHistoryOrders) {
+          this.moreThenOnePage = this.numberOfCurrentOrders > 10 || this.numberOfHistoryOrders > 10;
+        }
       });
   }
 

--- a/src/app/ubs/ubs-user/ubs-user-orders/ubs-user-orders.component.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders/ubs-user-orders.component.ts
@@ -27,7 +27,7 @@ export class UbsUserOrdersComponent implements OnInit, OnDestroy {
   numberOfHistoryOrders: number;
   currentOrdersOnPage = 10;
   historyOrdersOnPage = 10;
-  moreThenOnePage: boolean;
+  isMoreThenOnePage: boolean;
 
   constructor(
     private router: Router,
@@ -86,7 +86,7 @@ export class UbsUserOrdersComponent implements OnInit, OnDestroy {
         this.orderHistory = table === 'history' ? this.orders : this.orderHistory;
 
         if (this.numberOfCurrentOrders && this.numberOfHistoryOrders) {
-          this.moreThenOnePage = this.numberOfCurrentOrders > 10 || this.numberOfHistoryOrders > 10;
+          this.isMoreThenOnePage = this.numberOfCurrentOrders > 10 || this.numberOfHistoryOrders > 10;
         }
       });
   }


### PR DESCRIPTION
pagination colntrolls are displayed conditionally only if user has more then 10 current or more then 10 orders in history;
Interface for getAllUserOrders() method in user-orders.service added