### PR TITLE
Bugfix/#4110#4122#4117#4123#4158#4159/UBS Users-orders: adding missing data + updating to mockups

### DIFF
--- a/src/app/main/service/jwt/jwt.service.ts
+++ b/src/app/main/service/jwt/jwt.service.ts
@@ -37,7 +37,7 @@ export class JwtService {
     if (accessToken != null) {
       const payload = accessToken.split('.')[1];
       const decodedPayload = window.atob(payload);
-      return JSON.parse(decodedPayload).authorities[0];
+      return JSON.parse(decodedPayload).role[0];
     } else {
       return null;
     }

--- a/src/app/ubs/ubs-user/ubs-user-order-details/ubs-user-order-details.component.html
+++ b/src/app/ubs/ubs-user/ubs-user-order-details/ubs-user-order-details.component.html
@@ -60,11 +60,10 @@
       <li>
         <span *ngIf="currentLanguage === 'ua'">{{ order.address.addressStreet }} </span>
         <span *ngIf="currentLanguage === 'en'">{{ order.address.addressStreetEng }} </span>
-
-        <span>, {{ 'user-orders.details.block-number' | translate }}unreceived</span>
-
+        <span>, {{ order.address.houseNumber }}</span>
+        <span>, {{ 'user-orders.details.block-number' | translate }} {{ order.address.houseCorpus || '-' }}</span>
         <span>
-          <span>, {{ 'user-orders.details.entrance' | translate }}unreceived</span>
+          <span> , {{ 'user-orders.details.entrance' | translate }} {{ order.address.entranceNumber || '-' }}</span>
         </span>
       </li>
     </ol>

--- a/src/app/ubs/ubs-user/ubs-user-order-details/ubs-user-order-details.component.html
+++ b/src/app/ubs/ubs-user/ubs-user-order-details/ubs-user-order-details.component.html
@@ -13,7 +13,7 @@
         <td *ngIf="currentLanguage === 'ua'">{{ bag.service }}</td>
         <td *ngIf="currentLanguage === 'en'">{{ bag.serviceEng }}</td>
         <td>{{ bag.capacity }} {{ 'user-orders.details.litr' | translate }}</td>
-        <td>{{ bag.price }} {{ 'user-orders.details.currency' | translate }}</td>
+        <td>{{ bag.fullPrice }} {{ 'user-orders.details.currency' | translate }}</td>
         <td>{{ bag.count }} {{ 'user-orders.details.pieces' | translate }}</td>
         <td>{{ bag.totalPrice | currency | localizedCurrency }}</td>
       </tr>

--- a/src/app/ubs/ubs-user/ubs-user-order-details/ubs-user-order-details.component.html
+++ b/src/app/ubs/ubs-user/ubs-user-order-details/ubs-user-order-details.component.html
@@ -42,41 +42,43 @@
       <td>{{ order.amountBeforePayment | currency | localizedCurrency }}</td>
     </tr>
   </table>
-</div>
-<div class="order_details">
-  <ol class="recipient">
-    <h6 class="bold_text">{{ 'user-orders.details.recipient' | translate }}</h6>
-    <li>
-      <span>{{ order.sender.senderName }}</span
-      ><span>{{ order.sender.senderSurname }}</span>
-    </li>
-    <li>{{ order.sender.senderPhone }}</li>
-    <li>{{ order.sender.senderEmail }}</li>
-  </ol>
-  <ol class="recipient">
-    <h6 class="bold_text">{{ 'user-orders.details.export-address' | translate }}</h6>
-    <li *ngIf="currentLanguage === 'ua'">{{ order.address.addressCity }}</li>
-    <li *ngIf="currentLanguage === 'en'">{{ order.address.addressCityEng }}</li>
-    <li>
-      <span *ngIf="currentLanguage === 'ua'">{{ order.address.addressStreet }} </span>
-      <span *ngIf="currentLanguage === 'en'">{{ order.address.addressStreetEng }} </span>
 
-      <span>, {{ 'user-orders.details.block-number' | translate }}unreceived</span>
+  <div class="order_details">
+    <ol class="recipient">
+      <h6 class="bold_text">{{ 'user-orders.details.recipient' | translate }}</h6>
+      <li>
+        <span>{{ order.sender.senderName }}</span
+        ><span>{{ order.sender.senderSurname }}</span>
+      </li>
+      <li>{{ order.sender.senderPhone }}</li>
+      <li>{{ order.sender.senderEmail }}</li>
+    </ol>
+    <ol class="recipient">
+      <h6 class="bold_text">{{ 'user-orders.details.export-address' | translate }}</h6>
+      <li *ngIf="currentLanguage === 'ua'">{{ order.address.addressCity }}</li>
+      <li *ngIf="currentLanguage === 'en'">{{ order.address.addressCityEng }}</li>
+      <li>
+        <span *ngIf="currentLanguage === 'ua'">{{ order.address.addressStreet }} </span>
+        <span *ngIf="currentLanguage === 'en'">{{ order.address.addressStreetEng }} </span>
 
-      <span>
-        <span>, {{ 'user-orders.details.entrance' | translate }}unreceived</span>
-      </span>
-    </li>
-  </ol>
-  <ol class="recipient" *ngIf="order.address.addressComment !== ''">
-    <h6 class="bold_text">{{ 'user-orders.details.comment-address' | translate }}</h6>
-    <li>{{ order.address.addressComment }}</li>
-  </ol>
-  <ol class="recipient" *ngIf="order.orderComment !== ''">
-    <h6 class="bold_text">{{ 'user-orders.details.comment-order' | translate }}</h6>
-    <li>{{ order.orderComment }}</li>
-  </ol>
+        <span>, {{ 'user-orders.details.block-number' | translate }}unreceived</span>
+
+        <span>
+          <span>, {{ 'user-orders.details.entrance' | translate }}unreceived</span>
+        </span>
+      </li>
+    </ol>
+    <ol class="recipient" *ngIf="order.address.addressComment !== ''">
+      <h6 class="bold_text">{{ 'user-orders.details.comment-address' | translate }}</h6>
+      <li>{{ order.address.addressComment }}</li>
+    </ol>
+    <ol class="recipient" *ngIf="order.orderComment !== ''">
+      <h6 class="bold_text">{{ 'user-orders.details.comment-order' | translate }}</h6>
+      <li>{{ order.orderComment }}</li>
+    </ol>
+  </div>
 </div>
+
 <div class="download">
   <div class="arrow">
     <mat-icon [ngStyle]="{ fontSize: '16px' }">arrow_downward</mat-icon>

--- a/src/app/ubs/ubs-user/ubs-user-order-details/ubs-user-order-details.component.scss
+++ b/src/app/ubs/ubs-user/ubs-user-order-details/ubs-user-order-details.component.scss
@@ -1,8 +1,8 @@
 .full_card {
   display: grid;
   grid-template-rows: 28px auto;
-  grid-template-columns: 670px;
-  margin-left: 56px;
+  grid-template-columns: 850px auto;
+  margin-left: 30px;
   color: var(--ubs-secondary-grey);
 
   .header_details {
@@ -12,12 +12,17 @@
     letter-spacing: 0.002em;
     color: var(--ubs-primary-black);
     font-family: var(--primary-font);
+    grid-column-start: 1;
+    grid-column-end: -1;
   }
 }
 
 .table_of_details {
+  width: 780px;
   margin-top: 15px;
   font-family: var(--primary-font);
+  grid-column: 1;
+  grid-row: 2;
 
   .header_table {
     height: 34px;
@@ -75,7 +80,7 @@
 }
 
 .data_table td:nth-child(4) {
-  padding-left: 40px;
+  padding-left: 20px;
 }
 
 .data_table td:nth-child(5) {
@@ -100,13 +105,18 @@
 }
 
 .order_details {
-  width: 450px;
+  width: 200px;
+  padding: 0;
   margin-left: 16px;
   color: var(--ubs-primary-grey);
   font-family: var(--primary-font);
+  grid-column: 2;
+  grid-row: 2;
+  border-left: 1px solid var(--ubs-primary-light-grey);
 
   .recipient {
     margin: 32px 0;
+    padding: 0 0 0 15px;
   }
 
   .bold_text {
@@ -125,7 +135,7 @@
   grid-template-columns: 16px auto;
   grid-template-rows: 17px auto;
   justify-content: end;
-  margin: 0 18px 33px 0;
+  margin: 30px 18px 33px 0;
   color: var(--primary-green);
 }
 

--- a/src/app/ubs/ubs-user/ubs-user-order-details/ubs-user-order-details.component.scss
+++ b/src/app/ubs/ubs-user/ubs-user-order-details/ubs-user-order-details.component.scss
@@ -3,7 +3,7 @@
   grid-template-rows: 28px auto;
   grid-template-columns: 850px auto;
   margin-left: 30px;
-  color: var(--ubs-secondary-grey);
+  color: var(--ubs-primary-black);
 
   .header_details {
     font-size: 20px;
@@ -48,7 +48,7 @@
 }
 
 .data_table {
-  color: var(--ubs-quaternary-dark-grey);
+  color: var(--ubs-primary-black);
 
   td {
     text-align: left;
@@ -85,17 +85,17 @@
 
 .data_table td:nth-child(5) {
   text-align: right;
-  color: var(--ubs-primary-grey);
+  color: var(--ubs-primary-black);
   font-weight: bold;
 }
 
 .sum_of_order td:nth-child(2) {
-  color: var(--ubs-primary-grey);
+  color: var(--ubs-primary-black);
   font-weight: bold;
 }
 
 .sum_to_pay td:nth-child(2) {
-  color: var(--ubs-primary-grey);
+  color: var(--ubs-primary-black);
   font-weight: bold;
 }
 
@@ -108,7 +108,7 @@
   width: 200px;
   padding: 0;
   margin-left: 16px;
-  color: var(--ubs-primary-grey);
+  color: var(--ubs-primary-black);
   font-family: var(--primary-font);
   grid-column: 2;
   grid-row: 2;
@@ -161,7 +161,7 @@
     flex-direction: column;
     max-width: 670px;
     margin: 0;
-    color: var(--ubs-secondary-grey);
+    color: var(--ubs-primary-black);
 
     .header_details {
       font-size: 20px;
@@ -188,7 +188,7 @@
   .order_details {
     margin: 0;
     width: auto;
-    color: var(--ubs-primary-grey);
+    color: var(--ubs-primary-black);
     font-family: var(--primary-font);
 
     .recipient {

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/models/UserOrder.interface.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/models/UserOrder.interface.ts
@@ -36,6 +36,9 @@ export interface IAddressExportDetails {
   addressRegionEng: string;
   addressStreet: string;
   addressStreetEng: string;
+  entranceNumber: string;
+  houseCorpus: string;
+  houseNumber: string;
 }
 
 export interface IBags {

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.html
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.html
@@ -14,25 +14,25 @@
     <mat-expansion-panel (click)="changeCard(order.id)">
       <mat-expansion-panel-header>
         <div class="mat-content-wrapper">
-          <mat-panel-title class="order_list-num">
+          <mat-panel-title class="order_list-num table-data">
             {{ order.id }}
           </mat-panel-title>
-          <mat-panel-description class="order_list-date">
+          <mat-panel-description class="order_list-date table-data">
             {{ order.dateForm | date: 'dd.MM.y' }}
           </mat-panel-description>
-          <mat-panel-description class="order_list-paymentDate">
+          <mat-panel-description class="order_list-paymentDate table-data">
             {{ order.datePaid | date: 'dd.MM.y' }}
           </mat-panel-description>
-          <mat-panel-description class="order_list-status">
+          <mat-panel-description class="order_list-status table-data">
             {{ currentLanguage === 'ua' ? order.orderStatus : order.orderStatusEng }}
           </mat-panel-description>
-          <mat-panel-description class="order_list-paymentStatus">
+          <mat-panel-description class="order_list-paymentStatus table-data">
             {{ currentLanguage === 'ua' ? order.paymentStatus : order.paymentStatusEng }}
           </mat-panel-description>
-          <mat-panel-description class="order_list-paymentAmount">
+          <mat-panel-description class="order_list-paymentAmount table-data">
             {{ order.orderFullPrice | currency | localizedCurrency }}
           </mat-panel-description>
-          <mat-panel-description class="order_list-paymentAmountDue">
+          <mat-panel-description class="order_list-paymentAmountDue table-data">
             {{ order.amountBeforePayment | currency | localizedCurrency }}
           </mat-panel-description>
         </div>

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.html
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.html
@@ -1,10 +1,12 @@
 <div *ngIf="orders.length !== 0" class="header_list">
-  <div class="header_list-num">{{ 'user-orders.order-number' | translate }}</div>
-  <div class="header_list-date">{{ 'user-orders.order-date' | translate }}</div>
-  <div class="header_list-paymentDate">{{ 'add-payment.payment-date' | translate }}</div>
-  <div class="header_list-status">{{ 'user-orders.order-status' | translate }}</div>
-  <div class="header_list-paymentStatus">{{ 'user-orders.order-payment-status' | translate }}</div>
-  <div class="header_list-paymentAmount">{{ 'user-orders.payment-amount' | translate }}</div>
+  <div class="header header_list-num">{{ 'user-orders.order-number' | translate }}</div>
+  <div class="header header_list-date">{{ 'user-orders.order-date' | translate }}</div>
+  <div class="header header_list-paymentDate">{{ 'add-payment.payment-date' | translate }}</div>
+  <div class="header header_list-status">{{ 'user-orders.order-status' | translate }}</div>
+  <div class="header header_list-paymentStatus">{{ 'user-orders.order-payment-status' | translate }}</div>
+  <div class="header header_list-paymentAmount">{{ 'user-orders.payment-amount' | translate }}</div>
+  <div class="header header_list-paymentAmountDue">{{ 'user-orders.amount-due' | translate }}</div>
+
   <div class="empty-div"></div>
 </div>
 <mat-accordion multi="false">
@@ -29,6 +31,9 @@
           </mat-panel-description>
           <mat-panel-description class="order_list-paymentAmount">
             {{ order.orderFullPrice | currency | localizedCurrency }}
+          </mat-panel-description>
+          <mat-panel-description class="order_list-paymentAmountDue">
+            {{ calculateAmountDue(order) | currency | localizedCurrency }}
           </mat-panel-description>
         </div>
         <div class="btn-space">

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.html
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.html
@@ -33,7 +33,7 @@
             {{ order.orderFullPrice | currency | localizedCurrency }}
           </mat-panel-description>
           <mat-panel-description class="order_list-paymentAmountDue">
-            {{ calculateAmountDue(order) | currency | localizedCurrency }}
+            {{ order.amountBeforePayment | currency | localizedCurrency }}
           </mat-panel-description>
         </div>
         <div class="btn-space">

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.scss
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.scss
@@ -22,6 +22,10 @@
   padding: 0 17px;
 }
 
+.table-data {
+  color: var(--ubs-primary-black);
+}
+
 .header_list {
   display: grid;
   grid-template-columns: repeat(7, 109px);

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.scss
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.scss
@@ -24,20 +24,15 @@
 
 .header_list {
   display: grid;
-  grid-template-columns: repeat(6, 109px);
-  column-gap: 1.7vw;
+  grid-template-columns: repeat(7, 109px);
+  column-gap: 1.4vw;
   align-items: center;
   font-size: 14px;
   font-weight: 500;
   line-height: 20px;
   margin-left: 17px;
 
-  .header_list-num,
-  .header_list-paymentStatus,
-  .header_list-paymentAmount,
-  .header_list-status,
-  .header_list-paymentDate,
-  .header_list-date {
+  .header {
     line-height: 20px;
     font-style: normal;
   }
@@ -66,8 +61,8 @@
 
 .mat-content-wrapper {
   display: grid;
-  grid-template-columns: repeat(6, 109px);
-  column-gap: 1.57vw;
+  grid-template-columns: repeat(7, 109px);
+  column-gap: 1.4vw;
 }
 
 .btn-space {

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.ts
@@ -34,10 +34,6 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
-  public calculateAmountDue(order: IUserOrderInfo): number {
-    return order.paidAmount === 0 ? order.orderFullPrice : order.orderFullPrice - order.paidAmount;
-  }
-
   public isOrderUnpaid(order: IUserOrderInfo): boolean {
     return order.paymentStatusEng === CheckPaymentStatus.UNPAID;
   }

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.ts
@@ -34,6 +34,10 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
+  public calculateAmountDue(order: IUserOrderInfo): number {
+    return order.paidAmount === 0 ? order.orderFullPrice : order.orderFullPrice - order.paidAmount;
+  }
+
   public isOrderUnpaid(order: IUserOrderInfo): boolean {
     return order.paymentStatusEng === CheckPaymentStatus.UNPAID;
   }

--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -385,6 +385,7 @@
     "payment-amount": "Payment amount",
     "order-date": "Order date",
     "order-payment-status": "Payment status",
+    "amount-due": "Amount-due",
     "btn": {
       "cancel": "Cancel",
       "pay": "Pay",

--- a/src/assets/i18n/ubs-admin/ua.json
+++ b/src/assets/i18n/ubs-admin/ua.json
@@ -384,6 +384,7 @@
     "order-date": "Дата замовлення",
     "order-payment-status": "Статус оплати",
     "payment-amount": "Сума замовлення",
+    "amount-due": "Сума до оплати",
     "btn": {
       "cancel": "Скасувати",
       "pay": "Оплатити",


### PR DESCRIPTION
UBS Users orders table:
Table on "Поточні замовлення" tab includes all columns according mockup;
In order details part "Доставка" is placed according mockup;
Text in order details matches the mockup;
Values are now displayed in column "Вартість" in order details. 
In order details address block number or entrance number are displayed (if they were provided, if not "-" is displayed) 