### PR TITLE
limit the amount of certificates can be added to the order

### DIFF
--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.html
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.html
@@ -73,6 +73,7 @@
     type="button"
     *ngIf="addCert && finalSum > 0 && !failedCert"
     class="addCertificateBtn"
+    [hidden]="certificates.length > 4"
     [disabled]="!disableAddCertificate() || cancelCertBtn || certificateError || failedCert"
     (click)="addNewCertificate()"
   >


### PR DESCRIPTION
[[Personal Cabinet. Payment Step 1] The user can add more than 5 certificates to pay the order. #4288](https://github.com/ita-social-projects/GreenCity/issues/4288)