### PR TITLE
changed placeholders name in UBS Admin

### DIFF
--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -223,7 +223,7 @@
       "tel-label": "Phone",
       "tel-placeholder": "+380 00 000 00 00",
       "email-label": "Email",
-      "email-placeholder": "mail@mail.com"
+      "email-placeholder": "example@mail.com"
     },
     "recipient": {
       "title": "Recipient",
@@ -234,7 +234,7 @@
       "tel-label": "Phone",
       "tel-placeholder": "+380 00 000 00 00",
       "email-label": "Email",
-      "email-placeholder": "mail@mail.com"
+      "email-placeholder": "example@mail.com"
     },
     "violation": {
       "title": "Customer violations",

--- a/src/assets/i18n/ubs-admin/ua.json
+++ b/src/assets/i18n/ubs-admin/ua.json
@@ -222,7 +222,7 @@
       "tel-label": "Телефон",
       "tel-placeholder": "+380 00 000 00 00",
       "email-label": "Email",
-      "email-placeholder": "mail@mail.com"
+      "email-placeholder": "example@mail.com"
     },
     "recipient": {
       "title": "Відправник",
@@ -233,7 +233,7 @@
       "tel-label": "Телефон",
       "tel-placeholder": "+380 00 000 00 00",
       "email-label": "Email",
-      "email-placeholder": "mail@mail.com"
+      "email-placeholder": "example@mail.com"
     },
     "violation": {
       "title": "Порушення клієнта",


### PR DESCRIPTION
Result before
The placeholder displays in gray colour '[mail@mail.com](mailto:mail@mail.com)'

Actual result
The placeholder displays in gray colour '[example@mail.com](mailto:example@mail.com)'