### PR TITLE
Bugfix/#43524356/[UBS-User-order cancellation] Cancel button displaying logic fixed

### DIFF
--- a/src/app/ubs/ubs-user/ubs-user-orders-list/models/UserOrder.interface.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/models/UserOrder.interface.ts
@@ -67,7 +67,9 @@ export enum CheckOrderStatus {
   CANCELED = 'Canceled',
   CONFIRMED = 'Confirmed',
   FORMED = 'Formed',
-  ADJUSTMENT = 'Adjusted'
+  ADJUSTMENT = 'Adjustment',
+  BROUGHT_IT_HIMSELF = 'Brought by himself',
+  NOT_TAKEN_OUT = 'Not taken out'
 }
 
 export interface IUserOrdersInfo {

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.html
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.html
@@ -39,7 +39,7 @@
         <div class="btn-space">
           <div *ngIf="isOrderPaymentAccess(order)" class="btns_group">
             <div class="btn_grid_cancel">
-              <div *ngIf="!isOrderHalfPaid(order)" class="btn_grid_cancel">
+              <div *ngIf="canOrderBeCancel(order)" class="btn_grid_cancel">
                 <button class="btn_cancel" (click)="openOrderCancelDialog(order)">
                   {{ 'user-orders.btn.cancel' | translate }}
                 </button>

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.spec.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.spec.ts
@@ -33,6 +33,15 @@ describe('UbsUserOrdersListComponent', () => {
       orderFullPrice: -55,
       amountBeforePayment: 55,
       extend: false
+    },
+    {
+      id: 12,
+      dateForm: 15,
+      orderStatusEng: 'Adjustment',
+      paymentStatusEng: 'Unpaid',
+      orderFullPrice: 55,
+      amountBeforePayment: 55,
+      extend: false
     }
   ];
   const fakePoints = 111;
@@ -120,6 +129,18 @@ describe('UbsUserOrdersListComponent', () => {
       const isOrderPaymentAccessRes = component.isOrderPaymentAccess(fakeIputOrderData[2] as any);
       expect(isOrderPaymentAccessRes).toBeFalsy();
     });
+
+    it('canOrderBeCancel return false', () => {
+      spyOn(component, 'canOrderBeCancel').and.returnValue(false);
+      const canOrderBeCancel = component.canOrderBeCancel(fakeIputOrderData[3] as any);
+      expect(canOrderBeCancel).toBeFalsy();
+    });
+
+    it('canOrderBeCancel return true', () => {
+      spyOn(component, 'canOrderBeCancel').and.returnValue(true);
+      const canOrderBeCancel = component.canOrderBeCancel(fakeIputOrderData[1] as any);
+      expect(canOrderBeCancel).toBeTruthy();
+    });
   });
 
   describe('changeCard', () => {
@@ -171,6 +192,15 @@ describe('UbsUserOrdersListComponent', () => {
           orderFullPrice: 55,
           amountBeforePayment: 55,
           extend: true
+        },
+        {
+          id: 12,
+          dateForm: 15,
+          orderStatusEng: 'Adjustment',
+          paymentStatusEng: 'Unpaid',
+          orderFullPrice: 55,
+          amountBeforePayment: 55,
+          extend: false
         },
         {
           id: 1,

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.ts
@@ -54,6 +54,16 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
     return this.isOrderPriceGreaterThenZero(order) && (this.isOrderUnpaid(order) || this.isOrderHalfPaid(order));
   }
 
+  public canOrderBeCancel(order: IUserOrderInfo): boolean {
+    return (
+      order.paymentStatusEng !== CheckPaymentStatus.HALFPAID &&
+      order.orderStatusEng !== CheckOrderStatus.ADJUSTMENT &&
+      order.orderStatusEng !== CheckOrderStatus.BROUGHT_IT_HIMSELF &&
+      order.orderStatusEng !== CheckOrderStatus.NOT_TAKEN_OUT &&
+      order.orderStatusEng !== CheckOrderStatus.CANCELED
+    );
+  }
+
   public changeCard(id: number): void {
     this.orders.forEach((order) => (order.extend = order.id === id ? !order.extend : false));
   }


### PR DESCRIPTION
[UBS-User. Order cancellation] 
Cancel button is not displayed for orders with statuses "adjustment", "not taken out", "brought by himself" and "canceled"
