### PR TITLE
Add overflow scroll to Orders pop-up

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -59,7 +59,6 @@ body {
 
 .cdk-overlay-pane {
   overflow-y: auto;
-  
   &.extra-packages {
     overflow: auto;
     max-width: 100%;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -59,9 +59,7 @@ body {
 
 .cdk-overlay-pane {
   overflow-y: auto;
-}
 
-.cdk-overlay-pane {
   &.extra-packages {
     overflow: auto;
     max-width: 100%;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -58,6 +58,8 @@ body {
 }
 
 .cdk-overlay-pane {
+  overflow-y: auto;
+  
   &.extra-packages {
     overflow: auto;
     max-width: 100%;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -59,6 +59,9 @@ body {
 
 .cdk-overlay-pane {
   overflow-y: auto;
+}
+
+.cdk-overlay-pane {
   &.extra-packages {
     overflow: auto;
     max-width: 100%;


### PR DESCRIPTION
Add overflow scroll to Orders pop-up when we use 2 and more certificates for paying