### PR TITLE
The slide bar is placed to high on the screen when screen resolution is 1400x1050 and higher/#4045

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -396,6 +396,9 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
   }
 
   onScroll() {
+    const table = document.getElementById('table');
+    const tableContainer = document.getElementById('table-container');
+    this.tableHeightService.setTableHeightToContainerHeight(table, tableContainer);
     if (!this.isUpdate && this.currentPage < this.totalPages) {
       this.currentPage++;
       this.updateTableData();


### PR DESCRIPTION
This bug was fixed.On scroll method recalculates table height.Also, i have to add,that this bug is not reproduceable in real life,as none enter the site and then change resolution,but we go to it with fixed resolution.So it was caused because of unexecuted lifecycle hook.