### PR TITLE
[User profile friends-list] at home page output only friend's first name

### DIFF
--- a/src/app/main/component/user/components/profile/users-friends/users-friends.component.html
+++ b/src/app/main/component/user/components/profile/users-friends/users-friends.component.html
@@ -23,7 +23,7 @@
           (click)="showFriendsInfo(friend)"
         >
         </app-user-profile-image>
-        <p class="friend-name">{{ friend.name }}</p>
+        <p class="friend-name">{{ friend.name | firststringword }}</p>
       </div>
     </div>
   </div>

--- a/src/app/main/component/user/user.module.ts
+++ b/src/app/main/component/user/user.module.ts
@@ -51,6 +51,7 @@ import { AlphabeticalPipePipe } from '../../pipe/alphabetical-pipe/alphabetical-
 import { SharedMainModule } from '../shared/shared-main.module';
 import { UserRoutingModule } from './user-routing.module';
 import { UserComponent } from './user.component';
+import { FirstStringWordPipe } from '@pipe/first-string-word/first-string-word.pipe';
 import { CalendarWeekComponent } from './components/profile/calendar/calendar-week/calendar-week.component';
 import { AllHabitsComponent } from './components/habit/all-habits/all-habits.component';
 import { HabitsListViewComponent } from './components/habit/all-habits/components/habits-list-view/habits-list-view.component';
@@ -110,6 +111,7 @@ import { SetCountComponent } from './components/profile/profile-dashboard/set-co
     ShowFirstNLettersPipe,
     ShowFirstNPipe,
     UncheckedFirstPipe,
+    FirstStringWordPipe,
     AlphabeticalPipePipe,
     ProfileWidgetComponent,
     ProfileHeaderComponent,

--- a/src/app/main/pipe/first-string-word/first-string-word.pipe.spec.ts
+++ b/src/app/main/pipe/first-string-word/first-string-word.pipe.spec.ts
@@ -1,18 +1,23 @@
 import { FirstStringWordPipe } from './first-string-word.pipe';
 
 describe('FirstStringWordPipe', () => {
-  let pipe: FirstStringWordPipe;
-
-  beforeEach(() => {
-    pipe = new FirstStringWordPipe();
-  });
+  const FirstLettersPipe = new FirstStringWordPipe();
 
   it('create an instance', () => {
-    expect(pipe).toBeTruthy();
+    const pipe = new FirstStringWordPipe();
+    expect(FirstLettersPipe).toBeTruthy();
+  });
+
+  it('should transform', () => {
+    expect(FirstLettersPipe.transform('FirstName Lastname')).toBe('FirstName');
+  });
+  it('should transform', () => {
+    expect(FirstLettersPipe.transform('Username Userlastname')).toBe('Username');
   });
 
   it('transforms "Firstname Lastname" to "Firstname"', () => {
     const name = 'Firstname Lastname';
+    const pipe = new FirstStringWordPipe();
     const result = pipe.transform(name);
     expect(result).toBe('Firstname');
   });

--- a/src/app/main/pipe/first-string-word/first-string-word.pipe.spec.ts
+++ b/src/app/main/pipe/first-string-word/first-string-word.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { FirstStringWordPipe } from './first-string-word.pipe';
+
+describe('FirstStringWordPipe', () => {
+  it('create an instance', () => {
+    const pipe = new FirstStringWordPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/main/pipe/first-string-word/first-string-word.pipe.spec.ts
+++ b/src/app/main/pipe/first-string-word/first-string-word.pipe.spec.ts
@@ -1,13 +1,17 @@
 import { FirstStringWordPipe } from './first-string-word.pipe';
 
 describe('FirstStringWordPipe', () => {
-  const pipe = new FirstStringWordPipe();
+  let pipe: FirstStringWordPipe;
+
+  beforeEach(() => {
+    pipe = new FirstStringWordPipe();
+  });
 
   it('create an instance', () => {
     expect(pipe).toBeTruthy();
   });
 
-  it('should display only first name in user name', () => {
+  it('transforms "Firstname Lastname" to "Firstname"', () => {
     const name = 'Firstname Lastname';
     const result = pipe.transform(name);
     expect(result).toBe('Firstname');

--- a/src/app/main/pipe/first-string-word/first-string-word.pipe.spec.ts
+++ b/src/app/main/pipe/first-string-word/first-string-word.pipe.spec.ts
@@ -15,6 +15,10 @@ describe('FirstStringWordPipe', () => {
     expect(FirstLettersPipe.transform('Username Userlastname')).toBe('Username');
   });
 
+  it('should transform empty line', () => {
+    expect(FirstLettersPipe.transform('')).toBe('');
+  });
+
   it('transforms "Firstname Lastname" to "Firstname"', () => {
     const name = 'Firstname Lastname';
     const pipe = new FirstStringWordPipe();

--- a/src/app/main/pipe/first-string-word/first-string-word.pipe.spec.ts
+++ b/src/app/main/pipe/first-string-word/first-string-word.pipe.spec.ts
@@ -1,8 +1,13 @@
 import { FirstStringWordPipe } from './first-string-word.pipe';
 
 describe('FirstStringWordPipe', () => {
+  const pipe = new FirstStringWordPipe();
+
   it('create an instance', () => {
-    const pipe = new FirstStringWordPipe();
     expect(pipe).toBeTruthy();
+  });
+
+  it('transforms "Firstname Lastname" to "Firstname"', () => {
+    expect(pipe.transform('Firstname Lastname')).toBe('Firstname');
   });
 });

--- a/src/app/main/pipe/first-string-word/first-string-word.pipe.spec.ts
+++ b/src/app/main/pipe/first-string-word/first-string-word.pipe.spec.ts
@@ -7,7 +7,9 @@ describe('FirstStringWordPipe', () => {
     expect(pipe).toBeTruthy();
   });
 
-  it('transforms "Firstname Lastname" to "Firstname"', () => {
-    expect(pipe.transform('Firstname Lastname')).toBe('Firstname');
+  it('should display only first name in user name', () => {
+    const name = 'Firstname Lastname';
+    const result = pipe.transform(name);
+    expect(result).toBe('Firstname');
   });
 });

--- a/src/app/main/pipe/first-string-word/first-string-word.pipe.ts
+++ b/src/app/main/pipe/first-string-word/first-string-word.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'firststringword'
+})
+export class FirstStringWordPipe implements PipeTransform {
+  transform(value: string): string {
+    if (!value) {
+      return '';
+    }
+    return value.split(' ')[0];
+  }
+}

--- a/src/app/main/pipe/first-string-word/first-string-word.pipe.ts
+++ b/src/app/main/pipe/first-string-word/first-string-word.pipe.ts
@@ -1,8 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({
-  name: 'firststringword'
-})
+@Pipe({ name: 'firststringword' })
 export class FirstStringWordPipe implements PipeTransform {
   transform(value: string): string {
     if (!value) {


### PR DESCRIPTION
Bug #3560 -  "My Friends" section, friends are displayed with first and last names below the avatar.
Expected result - Friends are displayed with first name below the avatar
Result - Friends are displayed with first name only. I created a pipe, which shows only first word os string 'firstname.name'.

![image](https://user-images.githubusercontent.com/55766529/190134469-0446787c-50c8-4787-8e3a-508c9487c9c7.png)
