### PR TITLE
fixed display of payment status

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.spec.ts
@@ -112,6 +112,7 @@ describe('UbsAdminOrderStatusComponent', () => {
     GeneralInfoFake.orderStatusesDtos[0].ableActualChange = false;
     component.currentOrderPrice = 1;
     component.totalPaid = 0;
+    component.unPaidAmount = 1;
     component.setOrderPaymentStatus();
     expect(GeneralInfoFake.orderPaymentStatus).toBe('UNPAID');
   });
@@ -120,6 +121,7 @@ describe('UbsAdminOrderStatusComponent', () => {
     GeneralInfoFake.orderStatusesDtos[0].ableActualChange = false;
     component.currentOrderPrice = 2;
     component.totalPaid = 1;
+    component.unPaidAmount = 1;
     component.setOrderPaymentStatus();
     expect(GeneralInfoFake.orderPaymentStatus).toBe('HALF_PAID');
   });
@@ -128,6 +130,7 @@ describe('UbsAdminOrderStatusComponent', () => {
     GeneralInfoFake.orderStatusesDtos[0].ableActualChange = false;
     component.currentOrderPrice = 0;
     component.totalPaid = 1;
+    component.unPaidAmount = 0;
     component.setOrderPaymentStatus();
     expect(GeneralInfoFake.orderPaymentStatus).toBe('PAID');
   });
@@ -136,6 +139,7 @@ describe('UbsAdminOrderStatusComponent', () => {
     GeneralInfoFake.orderStatusesDtos[0].ableActualChange = true;
     component.currentOrderPrice = 0;
     component.totalPaid = 0;
+    component.unPaidAmount = 1;
     component.setOrderPaymentStatus();
     expect(GeneralInfoFake.orderPaymentStatus).toBe('UNPAID');
   });

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.spec.ts
@@ -118,6 +118,15 @@ describe('UbsAdminOrderStatusComponent', () => {
     expect(GeneralInfoFake.orderPaymentStatus).toBe('UNPAID');
   });
 
+  it('setOrderPaymentStatus orderState shold be "confirmed" and should return orderPayment status UNPAID ', () => {
+    GeneralInfoFake.orderStatusesDtos[0].ableActualChange = false;
+    component.currentOrderPrice = 0;
+    component.totalPaid = 0;
+    component.unPaidAmount = 1;
+    component.setOrderPaymentStatus();
+    expect(GeneralInfoFake.orderPaymentStatus).toBe('UNPAID');
+  });
+
   it('setOrderPaymentStatus orderState shold be "confirmed" and should return orderPayment status HALF_PAID', () => {
     GeneralInfoFake.orderStatusesDtos[0].ableActualChange = false;
     component.currentOrderPrice = 2;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.spec.ts
@@ -136,6 +136,24 @@ describe('UbsAdminOrderStatusComponent', () => {
     expect(GeneralInfoFake.orderPaymentStatus).toBe('PAID');
   });
 
+  it('setOrderPaymentStatus orderState shold be "confirmed" and should return orderPayment status PAID', () => {
+    GeneralInfoFake.orderStatusesDtos[0].ableActualChange = false;
+    component.currentOrderPrice = 1;
+    component.totalPaid = 1;
+    component.unPaidAmount = 0;
+    component.setOrderPaymentStatus();
+    expect(GeneralInfoFake.orderPaymentStatus).toBe('PAID');
+  });
+
+  it('setOrderPaymentStatus orderState shold be "confirmed" and should return orderPayment status PAID', () => {
+    GeneralInfoFake.orderStatusesDtos[0].ableActualChange = false;
+    component.currentOrderPrice = 0;
+    component.totalPaid = 0;
+    component.unPaidAmount = 0;
+    component.setOrderPaymentStatus();
+    expect(GeneralInfoFake.orderPaymentStatus).toBe('PAID');
+  });
+
   it('setOrderPaymentStatus orderState shold be "actual" and should return orderPayment status UNPAID', () => {
     GeneralInfoFake.orderStatusesDtos[0].ableActualChange = true;
     component.currentOrderPrice = 0;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.spec.ts
@@ -1,12 +1,13 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatDialog } from '@angular/material/dialog';
-import { OrderService } from '../../services/order.service';
 import { FormGroup, FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { AddOrderCancellationReasonComponent } from '../add-order-cancellation-reason/add-order-cancellation-reason.component';
-
-import { UbsAdminOrderStatusComponent } from './ubs-admin-order-status.component';
 import { of, Subject } from 'rxjs';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { OrderService } from '../../services/order.service';
+import { AddOrderCancellationReasonComponent } from '../add-order-cancellation-reason/add-order-cancellation-reason.component';
+import { UbsAdminOrderStatusComponent } from './ubs-admin-order-status.component';
 
 describe('UbsAdminOrderStatusComponent', () => {
   let component: UbsAdminOrderStatusComponent;
@@ -50,7 +51,7 @@ describe('UbsAdminOrderStatusComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [UbsAdminOrderStatusComponent],
-      imports: [TranslateModule.forRoot(), FormsModule, ReactiveFormsModule],
+      imports: [TranslateModule.forRoot(), FormsModule, ReactiveFormsModule, NoopAnimationsModule],
       providers: [
         { provide: OrderService, useValue: OrderServiceFake },
         { provide: MatDialog, useValue: matDialogMock }
@@ -142,6 +143,15 @@ describe('UbsAdminOrderStatusComponent', () => {
     component.unPaidAmount = 1;
     component.setOrderPaymentStatus();
     expect(GeneralInfoFake.orderPaymentStatus).toBe('UNPAID');
+  });
+
+  it('setOrderPaymentStatus orderState shold be "actual" and should return orderPayment status PAID', () => {
+    GeneralInfoFake.orderStatusesDtos[0].ableActualChange = true;
+    component.currentOrderPrice = 0;
+    component.totalPaid = 1;
+    component.unPaidAmount = 0;
+    component.setOrderPaymentStatus();
+    expect(GeneralInfoFake.orderPaymentStatus).toBe('PAID');
   });
 
   it('destroy Subject should be closed after ngOnDestroy()', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
@@ -84,9 +84,9 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
 
     if (orderState === 'confirmed') {
       const confirmedPaidCondition1 =
-        this.currentOrderPrice > 0 && this.totalPaid > 0 && this.currentOrderPrice <= this.totalPaid && this.unPaidAmount === 0;
+        this.currentOrderPrice > 0 && this.totalPaid > 0 && this.currentOrderPrice <= this.totalPaid && !this.unPaidAmount;
       const confirmedPaidCondition2 =
-        this.currentOrderPrice === 0 && this.totalPaid >= 0 && this.currentOrderPrice <= this.totalPaid && this.unPaidAmount === 0;
+        this.currentOrderPrice === 0 && this.totalPaid >= 0 && this.currentOrderPrice <= this.totalPaid && !this.unPaidAmount;
       const confirmedPaidCondition = confirmedPaidCondition1 || confirmedPaidCondition2;
 
       const confirmedUnpaidCondition = this.currentOrderPrice > 0 && this.totalPaid === 0 && this.unPaidAmount > 0;
@@ -106,9 +106,9 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
       }
     } else if (orderState === 'actual') {
       const actualPaidCondition1 =
-        this.currentOrderPrice > 0 && this.totalPaid > 0 && this.currentOrderPrice <= this.totalPaid && this.unPaidAmount === 0;
+        this.currentOrderPrice > 0 && this.totalPaid > 0 && this.currentOrderPrice <= this.totalPaid && !this.unPaidAmount;
       const actualPaidCondition2 =
-        this.currentOrderPrice === 0 && this.totalPaid >= 0 && this.currentOrderPrice <= this.totalPaid && this.unPaidAmount === 0;
+        this.currentOrderPrice === 0 && this.totalPaid >= 0 && this.currentOrderPrice <= this.totalPaid && !this.unPaidAmount;
       const actualPaidCondition = actualPaidCondition1 || actualPaidCondition2;
 
       const actualUnpaidCondition = this.currentOrderPrice === 0 && this.totalPaid === 0 && this.unPaidAmount > 0;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, OnChanges, S
 import { FormGroup } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
+
 import { IGeneralOrderInfo } from '../../models/ubs-admin.interface';
 import { OrderService } from '../../services/order.service';
 import { MatDialog } from '@angular/material/dialog';
@@ -16,6 +17,7 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
   @Input() currentOrderPrice: number;
   @Input() generalOrderInfo: FormGroup;
   @Input() totalPaid: number;
+  @Input() unPaidAmount: number;
   @Input() generalInfo: IGeneralOrderInfo;
   @Input() currentLanguage: string;
   @Input() additionalPayment: string;
@@ -81,12 +83,15 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
     });
 
     if (orderState === 'confirmed') {
-      const confirmedPaidCondition1 = this.currentOrderPrice > 0 && this.totalPaid > 0 && this.currentOrderPrice <= this.totalPaid;
-      const confirmedPaidCondition2 = this.currentOrderPrice === 0 && this.totalPaid >= 0 && this.currentOrderPrice <= this.totalPaid;
+      const confirmedPaidCondition1 =
+        this.currentOrderPrice > 0 && this.totalPaid > 0 && this.currentOrderPrice <= this.totalPaid && this.unPaidAmount === 0;
+      const confirmedPaidCondition2 =
+        this.currentOrderPrice === 0 && this.totalPaid >= 0 && this.currentOrderPrice <= this.totalPaid && this.unPaidAmount === 0;
       const confirmedPaidCondition = confirmedPaidCondition1 || confirmedPaidCondition2;
 
-      const confirmedUnpaidCondition = this.currentOrderPrice > 0 && this.totalPaid === 0;
-      const confirmedHalfPaidCondition = this.currentOrderPrice > 0 && this.totalPaid > 0 && this.currentOrderPrice > this.totalPaid;
+      const confirmedUnpaidCondition = this.currentOrderPrice > 0 && this.totalPaid === 0 && this.unPaidAmount > 0;
+      const confirmedHalfPaidCondition =
+        this.unPaidAmount > 0 && this.unPaidAmount < this.currentOrderPrice && this.currentOrderPrice > this.totalPaid;
 
       if (confirmedPaidCondition) {
         this.generalInfo.orderPaymentStatus = 'PAID';
@@ -100,12 +105,15 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
         this.generalInfo.orderPaymentStatus = 'HALF_PAID';
       }
     } else if (orderState === 'actual') {
-      const actualPaidCondition1 = this.currentOrderPrice > 0 && this.totalPaid > 0 && this.currentOrderPrice <= this.totalPaid;
-      const actualPaidCondition2 = this.currentOrderPrice === 0 && this.totalPaid >= 0 && this.currentOrderPrice <= this.totalPaid;
+      const actualPaidCondition1 =
+        this.currentOrderPrice > 0 && this.totalPaid > 0 && this.currentOrderPrice <= this.totalPaid && this.unPaidAmount === 0;
+      const actualPaidCondition2 =
+        this.currentOrderPrice === 0 && this.totalPaid >= 0 && this.currentOrderPrice <= this.totalPaid && this.unPaidAmount === 0;
       const actualPaidCondition = actualPaidCondition1 || actualPaidCondition2;
 
-      const actualUnpaidCondition = this.currentOrderPrice === 0 && this.totalPaid === 0;
-      const actualHalfPaidCondition = this.currentOrderPrice > 0 && this.totalPaid >= 0 && this.currentOrderPrice > this.totalPaid;
+      const actualUnpaidCondition = this.currentOrderPrice === 0 && this.totalPaid === 0 && this.unPaidAmount > 0;
+      const actualHalfPaidCondition =
+        this.unPaidAmount > 0 && this.unPaidAmount < this.currentOrderPrice && this.currentOrderPrice > this.totalPaid;
 
       if (actualPaidCondition) {
         this.generalInfo.orderPaymentStatus = 'PAID';

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
@@ -89,7 +89,7 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
         this.currentOrderPrice === 0 && this.totalPaid >= 0 && this.currentOrderPrice <= this.totalPaid && !this.unPaidAmount;
       const confirmedPaidCondition = confirmedPaidCondition1 || confirmedPaidCondition2;
 
-      const confirmedUnpaidCondition = this.currentOrderPrice > 0 && this.totalPaid === 0 && this.unPaidAmount > 0;
+      const confirmedUnpaidCondition = this.currentOrderPrice >= 0 && this.totalPaid === 0 && this.unPaidAmount > 0;
       const confirmedHalfPaidCondition =
         this.unPaidAmount > 0 && this.unPaidAmount < this.currentOrderPrice && this.currentOrderPrice > this.totalPaid;
 

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
@@ -12,6 +12,7 @@
           [generalOrderInfo]="getFormGroup('generalOrderInfo')"
           [generalInfo]="generalInfo"
           [totalPaid]="totalPaid"
+          [unPaidAmount]="unPaidAmount"
           [currentLanguage]="currentLanguage"
           [additionalPayment]="additionalPayment"
           (changedOrderStatus)="onChangedOrderStatus($event)"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -1,14 +1,18 @@
 import { Component, OnInit, OnDestroy, AfterContentChecked, ChangeDetectorRef, Injector, ViewChild } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
+import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Params, Router } from '@angular/router';
+import { formatDate } from '@angular/common';
+import { MatDialog } from '@angular/material/dialog';
+import { Subject } from 'rxjs';
+import { take, takeUntil } from 'rxjs/operators';
+import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
+import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
+
 import { UbsAdminCancelModalComponent } from '../ubs-admin-cancel-modal/ubs-admin-cancel-modal.component';
 import { UbsAdminGoBackModalComponent } from '../ubs-admin-go-back-modal/ubs-admin-go-back-modal.component';
-import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
-import { take, takeUntil } from 'rxjs/operators';
 import { OrderService } from '../../services/order.service';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
-import { Subject } from 'rxjs';
 import {
   IAddressExportDetails,
   IEmployee,
@@ -23,10 +27,7 @@ import {
   IUserInfo,
   ResponsibleEmployee
 } from '../../models/ubs-admin.interface';
-import { formatDate } from '@angular/common';
-import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
 import { IAppState } from 'src/app/store/state/app.state';
-import { Store } from '@ngrx/store';
 import { ChangingOrderData } from 'src/app/store/actions/bigOrderTable.actions';
 import { UbsAdminOrderPaymentComponent } from '../ubs-admin-order-payment/ubs-admin-order-payment.component';
 import { Patterns } from 'src/assets/patterns/patterns';
@@ -48,6 +49,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
   addressInfo: IAddressExportDetails;
   paymentInfo: IPaymentInfo;
   totalPaid: number;
+  unPaidAmount: number;
   exportInfo: IExportDetails;
   responsiblePersonInfo: IResponsiblePersons;
   orderDetails: IOrderDetails;
@@ -106,6 +108,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
         this.exportInfo = data.exportDetailsDto;
         this.responsiblePersonInfo = data.employeePositionDtoRequest;
         this.totalPaid = data.paymentTableInfoDto.paidAmount;
+        this.unPaidAmount = data.paymentTableInfoDto.unPaidAmount;
         this.overpayment = data.paymentTableInfoDto.overpayment;
         this.currentOrderPrice = data.orderFullPrice;
         this.setOrderDetails();


### PR DESCRIPTION
The error appeared when the order was partially paid only with bonuses.

For example, order 1453 has only partial payment by bonuses.
![image](https://user-images.githubusercontent.com/95560409/194758922-7271a350-2cd4-4f3f-9bc1-1939fe475081.png)
![image](https://user-images.githubusercontent.com/95560409/194758992-eb913f56-0cf8-4841-a4fa-8191a32531a0.png)

Changed the logic of setting the payment status. 
To do this, passed additional data to the component - unPaidAmount.

Now the status is displayed correctly:
![image](https://user-images.githubusercontent.com/95560409/194759334-cec636df-e452-46f7-94cb-83d10f22d33b.png)

