### PR TITLE
Feature/#3851 deactivate card pop up

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.html
@@ -1,3 +1,29 @@
 <div class="w-100">
   <p class="deactivate-title">{{ 'ubs-tariffs-add-location-pop-up.deactivate' | translate }}</p>
 </div>
+<app-dialog-tariff [row]="form" [newDate]="newDate" [name]="name" [edit]="true"></app-dialog-tariff>
+<ng-template #form>
+  <form [formGroup]="DeactivateCardForm">
+    <div [ngClass]="selectedStation.length ? 'd-flex' : 'd-flex first-row'">
+      <div class="form-group">
+        <label>{{ 'ubs-tariffs.station' | translate }}</label>
+        <input
+          formControlName="station"
+          [ngClass]="{ 'form-control': true, onBlurSelectionPanel: blurOnOption }"
+          [placeholder]="stationPlaceholder"
+          [matAutocomplete]="autoStation"
+          #autocompleteTriggerStation="matAutocompleteTrigger"
+          (blur)="onBlur($event)"
+        />
+        <mat-autocomplete #autoStation="matAutocomplete" (optionSelected)="onSelectStation($event, autocompleteTriggerStation)">
+          <mat-option *ngFor="let option of filteredStations" class="option-state" [value]="option">
+            <mat-checkbox class="mr-1" [checked]="checkStation(option)"></mat-checkbox>
+            <span class="checkbox-text">{{ option }}</span>
+          </mat-option>
+        </mat-autocomplete>
+
+        <img [src]="icons.arrowDown" class="arrowDown-img" alt="arrowDown" (click)="openAuto($event, autocompleteTriggerStation, false)" />
+      </div>
+    </div>
+  </form>
+</ng-template>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.html
@@ -1,3 +1,3 @@
 <div class="w-100">
-  <p class="add-location-title">{{ 'ubs-tariffs-add-location-pop-up.deactivate' | translate }}</p>
+  <p class="deactivate-title">{{ 'ubs-tariffs-add-location-pop-up.deactivate' | translate }}</p>
 </div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.html
@@ -1,0 +1,3 @@
+<div class="w-100">
+  <p class="add-location-title">{{ 'ubs-tariffs-add-location-pop-up.deactivate' | translate }}</p>
+</div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.scss
@@ -1,0 +1,7 @@
+@import '../ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component';
+
+.deactivate-title {
+  font-weight: 700;
+  font-size: 18px;
+  color: #000;
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.spec.ts
@@ -1,0 +1,28 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatDialog, MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { UbsAdminTariffsDeactivatePopUpComponent } from './ubs-admin-tariffs-deactivate-pop-up.component';
+
+describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
+  let component: UbsAdminTariffsDeactivatePopUpComponent;
+  let fixture: ComponentFixture<UbsAdminTariffsDeactivatePopUpComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [UbsAdminTariffsDeactivatePopUpComponent],
+      imports: [MatDialogModule, TranslateModule.forRoot(), ReactiveFormsModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UbsAdminTariffsDeactivatePopUpComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.spec.ts
@@ -1,18 +1,61 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog, MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { TranslateModule } from '@ngx-translate/core';
+import { of, Subject } from 'rxjs';
 
 import { UbsAdminTariffsDeactivatePopUpComponent } from './ubs-admin-tariffs-deactivate-pop-up.component';
+import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
+import { TariffsService } from '../../../services/tariffs.service';
+import { Store } from '@ngrx/store';
 
 describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
   let component: UbsAdminTariffsDeactivatePopUpComponent;
   let fixture: ComponentFixture<UbsAdminTariffsDeactivatePopUpComponent>;
 
+  const stationItem = {
+    name: 'Фейк',
+    id: 0
+  };
+  const fakeStation = {
+    id: 1,
+    name: 'fake'
+  };
+  const eventMockStation = {
+    option: {
+      value: 'fake'
+    }
+  };
+
+  const matDialogMock = jasmine.createSpyObj('matDialog', ['open']);
+  matDialogMock.open.and.returnValue({ afterClosed: () => of(true) });
+  const fakeMatDialogRef = jasmine.createSpyObj(['close', 'afterClosed']);
+  fakeMatDialogRef.afterClosed.and.returnValue(of(true));
+
+  const tariffsServiceMock = jasmine.createSpyObj('tariffsServiceMock', ['getAllStations']);
+  tariffsServiceMock.getAllStations.and.returnValue(of([fakeStation]));
+  const localStorageServiceStub = () => ({
+    firstNameBehaviourSubject: { pipe: () => of('fakeName') }
+  });
+
+  const storeMock = jasmine.createSpyObj('store', ['select', 'dispatch']);
+  storeMock.select.and.returnValue(of());
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [UbsAdminTariffsDeactivatePopUpComponent],
-      imports: [MatDialogModule, TranslateModule.forRoot(), ReactiveFormsModule]
+      imports: [MatDialogModule, TranslateModule.forRoot(), ReactiveFormsModule],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: matDialogMock },
+        { provide: MatDialogRef, useValue: fakeMatDialogRef },
+        { provide: LocalStorageService, useFactory: localStorageServiceStub },
+        { provide: TariffsService, useValue: tariffsServiceMock },
+        { provide: Store, useValue: storeMock },
+        FormBuilder
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
   }));
 
@@ -24,5 +67,82 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call methods in OnInit', () => {
+    const spy1 = spyOn(component, 'getReceivingStation');
+    const spy2 = spyOn(component, 'setStationPlaceholder');
+    component.ngOnInit();
+    expect(spy1).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+  });
+
+  it('should get all stations', () => {
+    component.getReceivingStation();
+    expect(component.stations).toEqual([fakeStation]);
+  });
+
+  it('should add new selected station if it does not exist in list', () => {
+    component.selectedStation = [{ name: 'station', id: 0 }];
+    component.onSelectStation(eventMockStation as any);
+    expect(component.selectedStation).toEqual([
+      { name: 'station', id: 0 },
+      { name: 'fake', id: 1 }
+    ]);
+  });
+
+  it('should remove selected station if it exists in list', () => {
+    component.selectedStation = [
+      { name: 'station', id: 0 },
+      { name: 'fake', id: 1 }
+    ];
+    component.onSelectStation(eventMockStation as any);
+    expect(component.selectedStation).toEqual([{ name: 'station', id: 0 }]);
+  });
+
+  it('should empty station value onSelectStation method', () => {
+    component.onSelectStation(eventMockStation as any);
+    expect(component.station.value).toEqual('');
+    expect(component.blurOnOption).toEqual(false);
+  });
+
+  it('should set station placeholder', () => {
+    component.selectedStation = [stationItem];
+    component.setStationPlaceholder();
+    expect(component.stationPlaceholder).toEqual('1 вибрано');
+  });
+
+  it('should set station placeholder', () => {
+    component.selectedStation = [];
+    component.setStationPlaceholder();
+    expect(component.stationPlaceholder).toEqual('ubs-tariffs.placeholder-choose-station');
+  });
+
+  it('should  change blurOnOption', () => {
+    const eventMock = {
+      relatedTarget: {
+        localName: 'mat-option'
+      }
+    };
+    component.onBlur(eventMock);
+    expect(component.blurOnOption).toEqual(true);
+  });
+
+  it('should not change blurOnOption', () => {
+    const eventMock = {
+      relatedTarget: {
+        localName: ''
+      }
+    };
+    component.onBlur(eventMock);
+    expect(component.blurOnOption).toEqual(false);
+  });
+
+  it('destroy Subject should be closed after ngOnDestroy()', () => {
+    const unsubscribe = 'unsubscribe';
+    component[unsubscribe] = new Subject<boolean>();
+    spyOn(component[unsubscribe], 'complete');
+    component.ngOnDestroy();
+    expect(component[unsubscribe].complete).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
@@ -1,13 +1,155 @@
 import { Component, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-
+import { TariffsService } from '../../../services/tariffs.service';
+import { FormBuilder, ValidatorFn, Validators } from '@angular/forms';
+import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
+import { Subject } from 'rxjs';
+import { map, startWith, takeUntil } from 'rxjs/operators';
+import { MatAutocompleteTrigger } from '@angular/material/autocomplete';
+import { DatePipe } from '@angular/common';
 @Component({
   selector: 'app-ubs-admin-tariffs-deactivate-pop-up',
   templateUrl: './ubs-admin-tariffs-deactivate-pop-up.component.html',
   styleUrls: ['./ubs-admin-tariffs-deactivate-pop-up.component.scss']
 })
-export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit {
-  constructor(private translate: TranslateService) {}
 
-  ngOnInit(): void {}
+//@ts-ignore
+export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit {
+  DeactivateCardForm = this.fb.group({
+    courier: ['', Validators.required],
+    station: ['', Validators.required],
+    region: ['', Validators.required],
+    city: [{ value: '', disabled: true }, [Validators.maxLength(40), Validators.required]]
+  });
+
+  public name: string;
+  public datePipe = new DatePipe('ua');
+  public newDate = this.datePipe.transform(new Date(), 'MMM dd, yyyy');
+
+  public selectedStation = [];
+  public blurOnOption = false;
+  public stationPlaceholder: string;
+  public stations;
+  public filteredStations;
+  unsubscribe: Subject<any> = new Subject();
+
+  public icons = {
+    arrowDown: '././assets/img/ubs-tariff/arrow-down.svg',
+    cross: '././assets/img/ubs/cross.svg'
+  };
+
+  get station() {
+    return this.DeactivateCardForm.get('station');
+  }
+  get courier() {
+    return this.DeactivateCardForm.get('courier');
+  }
+  get region() {
+    return this.DeactivateCardForm.get('region');
+  }
+  get city() {
+    return this.DeactivateCardForm.get('city');
+  }
+
+  constructor(
+    private fb: FormBuilder,
+    private translate: TranslateService,
+    private tariffsService: TariffsService,
+    private localeStorageService: LocalStorageService
+  ) {}
+
+  ngOnInit(): void {
+    this.localeStorageService.firstNameBehaviourSubject.pipe(takeUntil(this.unsubscribe)).subscribe((firstName) => {
+      this.name = firstName;
+    });
+    this.setStationPlaceholder();
+    this.getReceivingStation();
+  }
+
+  public onBlur(event): void {
+    if (event.relatedTarget.localName === 'mat-option') {
+      this.blurOnOption = true;
+    }
+  }
+
+  public checkStation(item): boolean {
+    return this.selectedStation.map((it) => it.name).includes(item);
+  }
+
+  openAuto(event: Event, trigger: MatAutocompleteTrigger, flag: boolean): void {
+    if (!flag) {
+      event.stopPropagation();
+      trigger.openPanel();
+    }
+  }
+
+  public setStationPlaceholder(): void {
+    if (this.selectedStation.length) {
+      this.stationPlaceholder = this.selectedStation.length + ' вибрано';
+    } else {
+      this.translate.get('ubs-tariffs.placeholder-choose-station').subscribe((data) => (this.stationPlaceholder = data));
+    }
+  }
+
+  public onSelectStation(event, trigger?: MatAutocompleteTrigger): void {
+    this.station.clearValidators();
+    this.station.updateValueAndValidity();
+    this.blurOnOption = false;
+    const selectedValue = this.stations.find((ob) => ob.name === event.option.value);
+    const tempItem = {
+      name: selectedValue.name,
+      id: selectedValue.id
+    };
+    const newValue = event.option.value;
+    if (this.selectedStation.map((it) => it.name).includes(newValue)) {
+      this.selectedStation = this.selectedStation.filter((item) => item.name !== newValue);
+    } else {
+      this.selectedStation.push(tempItem);
+    }
+    this.station.setValidators(this.stationValidator());
+    this.station.setValue('');
+    this.setStationPlaceholder();
+    if (trigger) {
+      requestAnimationFrame(() => {
+        trigger.openPanel();
+      });
+    }
+  }
+
+  public _filterOptions(name: string, items: any[]): any[] {
+    const filterValue = name.toLowerCase();
+    return items.filter((option) => option.toLowerCase().includes(filterValue));
+  }
+
+  public stationValidator(): ValidatorFn {
+    let error;
+    if (!this.selectedStation.length) {
+      error = this.station.setErrors({ emptySelectedStation: true });
+    }
+    return error;
+  }
+
+  public getReceivingStation(): void {
+    this.tariffsService
+      .getAllStations()
+      .pipe(takeUntil(this.unsubscribe))
+      .subscribe((res) => {
+        this.stations = res;
+        const stationsName = this.stations.map((it) => it.name);
+        this.station.valueChanges
+          .pipe(
+            startWith(''),
+            map((value: string) => this._filterOptions(value, stationsName))
+          )
+          .subscribe((data) => {
+            this.filteredStations = data;
+            this.station.setValidators(this.stationValidator());
+          });
+      });
+  }
+
+  public ngOnDestroy(): void {
+    this.unsubscribe.next();
+    this.unsubscribe.complete();
+  }
 }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { TariffsService } from '../../../services/tariffs.service';
 import { FormBuilder, ValidatorFn, Validators } from '@angular/forms';
@@ -13,8 +13,8 @@ import { DatePipe } from '@angular/common';
   styleUrls: ['./ubs-admin-tariffs-deactivate-pop-up.component.scss']
 })
 
-//@ts-ignore
-export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit {
+// @ts-ignore
+export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestroy {
   DeactivateCardForm = this.fb.group({
     courier: ['', Validators.required],
     station: ['', Validators.required],

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
@@ -1,0 +1,13 @@
+import { Component, OnInit } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-ubs-admin-tariffs-deactivate-pop-up',
+  templateUrl: './ubs-admin-tariffs-deactivate-pop-up.component.html',
+  styleUrls: ['./ubs-admin-tariffs-deactivate-pop-up.component.scss']
+})
+export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit {
+  constructor(private translate: TranslateService) {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.spec.ts
@@ -24,6 +24,7 @@ import { MockStore } from '@ngrx/store/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { UbsAdminTariffsCourierPopUpComponent } from './ubs-admin-tariffs-courier-pop-up/ubs-admin-tariffs-courier-pop-up.component';
 import { UbsAdminTariffsStationPopUpComponent } from './ubs-admin-tariffs-station-pop-up/ubs-admin-tariffs-station-pop-up.component';
+import { UbsAdminTariffsDeactivatePopUpComponent } from './ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component';
 import { UbsAdminTariffsLocationPopUpComponent } from './ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component';
 import { TariffStatusPipe } from '@pipe/tariff-status-pipe/tariff-status.pipe';
 
@@ -847,7 +848,7 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
 
   it('should call openDeactivateLocation', () => {
     component.openDeactivateLocation();
-    expect(matDialogMock.open).toHaveBeenCalledWith(UbsAdminTariffsLocationPopUpComponent, {
+    expect(matDialogMock.open).toHaveBeenCalledWith(UbsAdminTariffsDeactivatePopUpComponent, {
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -19,6 +19,7 @@ import { UbsAdminTariffsCardPopUpComponent } from './ubs-admin-tariffs-card-pop-
 import { TariffConfirmationPopUpComponent } from './../shared/components/tariff-confirmation-pop-up/tariff-confirmation-pop-up.component';
 import { TranslateService } from '@ngx-translate/core';
 import { Patterns } from 'src/assets/patterns/patterns';
+import { UbsAdminTariffsDeactivatePopUpComponent } from './ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component';
 
 @Component({
   selector: 'app-ubs-admin-tariffs-location-dashboard',
@@ -594,7 +595,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, OnDest
   }
 
   openDeactivateLocation(): void {
-    this.dialog.open(UbsAdminTariffsLocationPopUpComponent, {
+    this.dialog.open(UbsAdminTariffsDeactivatePopUpComponent, {
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {

--- a/src/app/ubs/ubs-admin/ubs-admin.module.ts
+++ b/src/app/ubs/ubs-admin/ubs-admin.module.ts
@@ -83,6 +83,7 @@ import { TariffConfirmationPopUpComponent } from './components/shared/components
 import { UbsAdminEmployeeRightsFormComponent } from './components/ubs-admin-employee/ubs-admin-employee-rights-form/ubs-admin-employee-rights-form.component';
 import { CdkAccordionModule } from '@angular/cdk/accordion';
 import { TariffStatusPipe } from '@pipe/tariff-status-pipe/tariff-status.pipe';
+import { UbsAdminTariffsDeactivatePopUpComponent } from './components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component';
 
 @NgModule({
   declarations: [
@@ -137,7 +138,8 @@ import { TariffStatusPipe } from '@pipe/tariff-status-pipe/tariff-status.pipe';
     UbsAdminTariffsCardPopUpComponent,
     TariffConfirmationPopUpComponent,
     UbsAdminEmployeeRightsFormComponent,
-    TariffStatusPipe
+    TariffStatusPipe,
+    UbsAdminTariffsDeactivatePopUpComponent
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
Feature of Deactivation the Tariffs card pop-up window + Unit Tests.

The window that includes inputs as "Select Region" was created. The information about deactivation actioner was added(username + date of deactivation). Input placeholders was set according to the inputs with it's translation.

The task is still in progress, inputs "Courier" and "City" will be added with confirmation buttons