### PR TITLE
Bugfix/#4459 new style edit button in violation pop up

### DIFF
--- a/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.html
+++ b/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.html
@@ -5,13 +5,13 @@
   <div *ngIf="!viewMode" class="row mb-4">
     <h3>{{ 'add-violation-modal.add-violation' | translate }}</h3>
   </div>
-  <div *ngIf="viewMode" class="row mb-4 view-header">
+  <div *ngIf="viewMode" class="row mb-3 view-header">
     <h3>{{ 'add-violation-modal.violation' | translate }}</h3>
     <span>{{ 'add-violation-modal.order' | translate }} №{{ orderId }}</span>
   </div>
   <div class="row justify-content-end edit-violation">
+    <mat-icon class="mat-icon">edit</mat-icon>
     <button *ngIf="viewMode" class="edit-violation-btn" [disabled]="editMode" (click)="editViolation()">
-      <mat-icon class="mat-icon">edit</mat-icon>
       {{ 'add-violation-modal.edit' | translate }}
     </button>
   </div>

--- a/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.html
+++ b/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.html
@@ -10,9 +10,9 @@
     <span>{{ 'add-violation-modal.order' | translate }} №{{ orderId }}</span>
   </div>
   <div class="row justify-content-end edit-violation">
-    <mat-icon class="mat-icon">edit</mat-icon>
     <button *ngIf="viewMode" class="edit-violation-btn" [disabled]="editMode" (click)="editViolation()">
-      {{ 'add-violation-modal.edit' | translate }}
+      <mat-icon class="mat-icon">edit</mat-icon>
+      <div class="edit-violation-btn-text">{{ 'add-violation-modal.edit' | translate }}</div>
     </button>
   </div>
   <div class="row mb-3">

--- a/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.scss
+++ b/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.scss
@@ -29,18 +29,26 @@ h6 {
 }
 
 .edit-violation {
-  margin: -30px 10px 0 0;
+  margin: 0 10px 40px 0;
 
   .mat-icon,
+  .edit-violation-btn {
+    font-size: 14px;
+    color: var(--ubs-electric-violet);
+    border: none;
+    background: transparent;
+  }
+
+  .mat-icon {
+    padding: 4px 0 0 6px;
+  }
+
   .edit-violation-btn {
     font-family: var(--ubs-quaternary-font);
     font-weight: 700;
     font-size: 14px;
     line-height: 20px;
     letter-spacing: 0.1px;
-    color: var(--ubs-electric-violet);
-    border: none;
-    background: transparent;
   }
 
   .edit-violation-btn:disabled,

--- a/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.scss
+++ b/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.scss
@@ -40,7 +40,14 @@ h6 {
   }
 
   .mat-icon {
-    padding: 4px 0 0 6px;
+    vertical-align: baseline;
+    padding-top: 2px;
+  }
+
+  .edit-violation-btn-text {
+    display: inline;
+    vertical-align: top;
+    margin-left: 3px;
   }
 
   .edit-violation-btn {
@@ -49,6 +56,7 @@ h6 {
     font-size: 14px;
     line-height: 20px;
     letter-spacing: 0.1px;
+    vertical-align: top;
   }
 
   .edit-violation-btn:disabled,

--- a/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.scss
+++ b/src/app/ubs/ubs-admin/components/add-violations/add-violations.component.scss
@@ -33,7 +33,11 @@ h6 {
 
   .mat-icon,
   .edit-violation-btn {
+    font-family: var(--ubs-quaternary-font);
+    font-weight: 700;
     font-size: 14px;
+    line-height: 20px;
+    letter-spacing: 0.1px;
     color: var(--ubs-electric-violet);
     border: none;
     background: transparent;


### PR DESCRIPTION
Small changes in the style of the "Edit" button in the "Add violation" window

Befor:
![image](https://user-images.githubusercontent.com/95560409/200668586-b103668a-9c23-42fc-b987-d0f777385f1b.png)

After:
![image](https://user-images.githubusercontent.com/95560409/200668654-662d5d8d-82ef-4566-ac1e-fe3bdfc70541.png)
