### PR TITLE
bugfix/#4501 eco news tags saved in session storage

### DIFF
--- a/src/app/main/component/eco-news/components/news-list/news-list.component.spec.ts
+++ b/src/app/main/component/eco-news/components/news-list/news-list.component.spec.ts
@@ -124,10 +124,9 @@ describe('NewsListComponent', () => {
   });
 
   it('should filter data', () => {
-    component.filterPermission = true;
-    spyOn(component, 'dispatchStore');
-    component.getFilterData([]);
-    expect(component.dispatchStore).toHaveBeenCalledTimes(1);
+    spyOn(component, 'getFilterData');
+    component.getFilterData(['News']);
+    expect(component.getFilterData).toHaveBeenCalledWith(['News']);
   });
 
   it('should resize window and set view', () => {

--- a/src/app/main/component/eco-news/components/news-list/news-list.component.ts
+++ b/src/app/main/component/eco-news/components/news-list/news-list.component.ts
@@ -33,7 +33,6 @@ export class NewsListComponent implements OnInit, OnDestroy {
   private destroyed$: ReplaySubject<any> = new ReplaySubject<any>(1);
   public tags: Observable<Array<NewsTagInterface>>;
 
-  public filterPermission = false;
   public hasNext = true;
 
   econews$ = this.store.select((state: IAppState): IEcoNewsState => state.ecoNewsState);
@@ -96,7 +95,6 @@ export class NewsListComponent implements OnInit, OnDestroy {
   public onScroll(): void {
     this.scroll = true;
     this.dispatchStore(false);
-    this.filterPermission = true;
   }
 
   public changeView(event: boolean): void {
@@ -104,14 +102,12 @@ export class NewsListComponent implements OnInit, OnDestroy {
   }
 
   public getFilterData(value: Array<string>): void {
-    if (this.filterPermission) {
-      if (this.tagsList !== value) {
-        this.tagsList = value;
-      }
-      this.hasNext = true;
-      this.currentPage = 0;
-      this.dispatchStore(true);
+    if (this.tagsList !== value) {
+      this.tagsList = value;
     }
+    this.hasNext = true;
+    this.currentPage = 0;
+    this.dispatchStore(true);
   }
 
   public dispatchStore(res: boolean): void {

--- a/src/app/main/component/shared/components/tag-filter/tag-filter.component.spec.ts
+++ b/src/app/main/component/shared/components/tag-filter/tag-filter.component.spec.ts
@@ -37,6 +37,22 @@ describe('TagFilterComponent', () => {
   });
 
   describe('Test the basic functionality', () => {
+    it('should call methods OnInit', () => {
+      const spy = spyOn(component as any, 'getSessionStorageFilters');
+      const spy1 = spyOn(component, 'emitActiveFilters');
+
+      component.ngOnInit();
+      expect(spy).toHaveBeenCalled();
+      expect(spy1).toHaveBeenCalled();
+    });
+
+    it('should get filters OnInit', () => {
+      spyOn(component as any, 'getSessionStorageFilters').and.returnValue([]);
+
+      component.ngOnInit();
+      expect(component.filters).toEqual([]);
+    });
+
     it('Should call setTags method inside ngOnChanges', () => {
       // @ts-ignore
       const spy = spyOn(component, 'setTags');
@@ -66,10 +82,9 @@ describe('TagFilterComponent', () => {
     });
 
     it('Should return parsed data', () => {
-      spyOn(sessionStorage, 'getItem').and.returnValue('true');
-      // @ts-ignore
-      const val = component.getSessionStorageFilters();
-      expect(val).toEqual(true);
+      spyOn(sessionStorage, 'getItem').and.returnValue(null);
+      const val = (component as any).getSessionStorageFilters();
+      expect(val).toEqual([]);
     });
   });
 });

--- a/src/app/main/component/shared/components/tag-filter/tag-filter.component.ts
+++ b/src/app/main/component/shared/components/tag-filter/tag-filter.component.ts
@@ -16,8 +16,8 @@ export class TagFilterComponent implements OnInit, OnChanges {
   @Output() tagsList = new EventEmitter<Array<string>>();
   constructor(public localStorageService: LocalStorageService) {}
   ngOnInit() {
+    this.filters = this.getSessionStorageFilters();
     this.emitActiveFilters();
-    sessionStorage.removeItem(this.storageKey);
   }
 
   ngOnChanges(changes) {


### PR DESCRIPTION
Bugfix - [Eco news] When user clicks 'Back to news' button, marked tag is not desplayed on News page