### PR TITLE
#4610: fix position if search icon

### DIFF
--- a/src/app/shared/header/header.component.scss
+++ b/src/app/shared/header/header.component.scss
@@ -507,6 +507,12 @@ $ubs-header-height: 80px;
   background-color: $hr-color;
 }
 
+@media (min-width: 320px) and (max-width: 480px) {
+  .header_navigation-menu-right-list li {
+    padding: 10px 0;
+  }
+}
+
 @media (min-width: 576px) {
   .container {
     padding: 0;


### PR DESCRIPTION
**Before**
The search icon overlaps the logo at 320x658 screen resolution
![Untitled](https://user-images.githubusercontent.com/101433204/198053005-83453c3f-4cf0-4a6f-beae-7c26add02fa9.png)

**After**
The search icon does not cover the logo at 320x658 screen resolution
![image](https://user-images.githubusercontent.com/101433204/198052185-355430a7-6296-4607-bfc4-284e3d2e5fec.png)

