### PR TITLE
#4594 Fixed clearing of the uploaded image when the user goes to another page

### DIFF
--- a/src/app/main/component/shared/components/drag-and-drop/drag-and-drop.component.ts
+++ b/src/app/main/component/shared/components/drag-and-drop/drag-and-drop.component.ts
@@ -48,6 +48,9 @@ export class DragAndDropComponent implements OnInit {
       this.isCropper = false;
       this.files = [{ file: getPreviewImg.value.file, url: getPreviewImg.value.image }];
     }
+    if (!this.createEcoNewsService.isBackToEditing) {
+      this.cancelChanges();
+    }
   }
 
   public imageCropped(event: ImageCroppedEvent): void {


### PR DESCRIPTION
The uploaded image did not disappear when switching to another page and returning to the news creation page again.

Added clearing of information about the image, except when the user returns to editing the news.