### PR TITLE
Bugfix#4662 / Changed condition for displaying text-message

### DIFF
--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.html
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.html
@@ -58,7 +58,7 @@
     <small class="text-message" *ngIf="certSize && certificateSum <= showTotal">
       {{ 'order-details.activated' | translate: { certificateSum: certificateSum, certDate: expirationDate[expirationDate.length - 1] } }}
     </small>
-    <small class="text-message" *ngIf="certSize && certificateSum >= showTotal">
+    <small class="text-message" *ngIf="certSize && certificateSum > showTotal">
       {{
         'order-details.activated-oversum'
           | translate

--- a/src/assets/i18n/ubs/en.json
+++ b/src/assets/i18n/ubs/en.json
@@ -67,7 +67,7 @@
     "failed-certificate": "Certificate not accepted, please try again",
     "not-found-certificate": "Certificate not found; check that the data is correct.",
     "activated-oversum": "A certificate for {{certificateSum}}.00 UAH is activated in excess of the amount of your order. The balance of {{certificateLeft}}.00 UAH does not return. The certificate is valid until {{ certDate}} ",
-    "activated": "Certificate for {{certificateSum}} UAH activated. Certificate validity period is up to {{certDate}}",
+    "activated": "The certificate for the amount of {{certificateSum}} UAH has been activated. The certificate is valid until {{certDate}}",
     "already-used": "Certificate has already been used {{certDate}}",
     "expired": "Certificate is invalid. Certificate validity is up to {{certDate}}",
     "add-certificate": "Add certificate",


### PR DESCRIPTION
**Expected result**
When the certificate with a discount is equals the order amount, should be displayed next message.
"The certificate for the amount of XXX UAH has been activated. The certificate is valid until YY.YY.YYYY" 

**Before**
<img width="911" alt="Знімок екрана 2022-11-04 о 22 52 28" src="https://user-images.githubusercontent.com/108685196/200072728-af93139f-4d28-49af-9a88-36972b904992.png">

**After**
<img width="901" alt="Знімок екрана 2022-11-04 о 22 51 17" src="https://user-images.githubusercontent.com/108685196/200072771-1f2f1742-3d99-4cfb-9870-ce8f1990b04d.png">
