### PR TITLE
#4664: check inputs in add certificate

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.html
@@ -10,16 +10,18 @@
       </div>
       <div class="monthCount-input">
         <label for="monthCount" class="form-label">Час дії</label>
-        <input type="text" formControlName="monthCount" id="monthCount" />
+        <input type="text" formControlName="monthCount" id="monthCount" (ngModelChange)="valueChangeMonthCount($event)" />
       </div>
       <div class="points-input">
         <label for="initialPointsValue" class="form-label">Знижка</label>
-        <input type="text" formControlName="initialPointsValue" id="initialPointsValue" />
+        <input type="text" formControlName="initialPointsValue" id="initialPointsValue" (ngModelChange)="valueChangePointsValue($event)" />
       </div>
     </div>
   </form>
   <mat-dialog-actions>
     <button class="btn btn-outline-success" mat-dialog-close>Назад</button>
-    <button class="btn btn-success" [disabled]="addCertificateForm.invalid" (click)="createCertificate()">Додати</button>
+    <button class="btn btn-success" [disabled]="addCertificateForm.invalid || pointsValid || monthCountValid" (click)="createCertificate()">
+      Додати
+    </button>
   </mat-dialog-actions>
 </div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.html
@@ -20,7 +20,11 @@
   </form>
   <mat-dialog-actions>
     <button class="btn btn-outline-success" mat-dialog-close>Назад</button>
-    <button class="btn btn-success" [disabled]="addCertificateForm.invalid || pointsValid || monthCountValid" (click)="createCertificate()">
+    <button
+      class="btn btn-success"
+      [disabled]="addCertificateForm.invalid || monthCountDisabled || pointsValueDisabled"
+      (click)="createCertificate()"
+    >
       Додати
     </button>
   </mat-dialog-actions>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.spec.ts
@@ -30,4 +30,20 @@ describe('UbsAdminCertificateAddCertificatePopUpComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should check if inputs contain only null', () => {
+    const newValue = '0';
+    component.valueChangeMonthCount(newValue);
+    component.valueChangePointsValue(newValue);
+    expect(component.monthCountDisabled).toBeTruthy();
+    expect(component.pointsValueDisabled).toBeTruthy();
+  });
+
+  it('should check if inputs contain not null', () => {
+    const newValue = '10';
+    component.valueChangeMonthCount(newValue);
+    component.valueChangePointsValue(newValue);
+    expect(component.monthCountDisabled).toBeFalsy();
+    expect(component.pointsValueDisabled).toBeFalsy();
+  });
 });

--- a/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.spec.ts
@@ -31,19 +31,27 @@ describe('UbsAdminCertificateAddCertificatePopUpComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should check if inputs contain only null', () => {
+  it('should check if monthCount contains only null', () => {
     const newValue = '0';
     component.valueChangeMonthCount(newValue);
-    component.valueChangePointsValue(newValue);
     expect(component.monthCountDisabled).toBeTruthy();
+  });
+
+  it('should check if pointValue contains only null', () => {
+    const newValue = '0';
+    component.valueChangePointsValue(newValue);
     expect(component.pointsValueDisabled).toBeTruthy();
   });
 
-  it('should check if inputs contain not null', () => {
+  it('should check if monthCount contains not null', () => {
     const newValue = '10';
-    component.valueChangeMonthCount(newValue);
     component.valueChangePointsValue(newValue);
     expect(component.monthCountDisabled).toBeFalsy();
+  });
+
+  it('should check if pointValue contains not null', () => {
+    const newValue = '10';
+    component.valueChangePointsValue(newValue);
     expect(component.pointsValueDisabled).toBeFalsy();
   });
 });

--- a/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.spec.ts
@@ -31,6 +31,22 @@ describe('UbsAdminCertificateAddCertificatePopUpComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('valueChangeMonthCount should be call', () => {
+    spyOn(component, 'valueChangeMonthCount');
+    const newValue = '0';
+    component.valueChangeMonthCount(newValue);
+    expect(component.valueChangeMonthCount).toHaveBeenCalled();
+    expect(component.valueChangeMonthCount).toHaveBeenCalledWith(newValue);
+  });
+
+  it('valueChangePointsValue should be call', () => {
+    spyOn(component, 'valueChangePointsValue');
+    const newValue = '0';
+    component.valueChangePointsValue(newValue);
+    expect(component.valueChangePointsValue).toHaveBeenCalled();
+    expect(component.valueChangePointsValue).toHaveBeenCalledWith(newValue);
+  });
+
   it('should check if monthCount contains only null', () => {
     const newValue = '0';
     component.valueChangeMonthCount(newValue);
@@ -45,7 +61,7 @@ describe('UbsAdminCertificateAddCertificatePopUpComponent', () => {
 
   it('should check if monthCount contains not null', () => {
     const newValue = '10';
-    component.valueChangePointsValue(newValue);
+    component.valueChangeMonthCount(newValue);
     expect(component.monthCountDisabled).toBeFalsy();
   });
 

--- a/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.ts
@@ -17,8 +17,8 @@ export class UbsAdminCertificateAddCertificatePopUpComponent implements OnInit, 
   addCertificateForm: FormGroup;
   certificatePattern = Patterns.serteficatePattern;
   certificateMask = Masks.certificateMask;
-  monthCountValid: boolean;
-  pointsValid: boolean;
+  monthCountDisabled: boolean;
+  pointsValueDisabled: boolean;
 
   private destroy: Subject<boolean> = new Subject<boolean>();
 
@@ -42,18 +42,18 @@ export class UbsAdminCertificateAddCertificatePopUpComponent implements OnInit, 
   }
 
   valueChangeMonthCount(newValue: string) {
-    if (/^[0]+$/.test(newValue)) {
-      this.monthCountValid = true;
+    if (/^0+$/.test(newValue)) {
+      this.monthCountDisabled = true;
     } else {
-      this.monthCountValid = false;
+      this.monthCountDisabled = false;
     }
   }
 
   valueChangePointsValue(newValue: string) {
-    if (/^[0]+$/.test(newValue)) {
-      this.pointsValid = true;
+    if (/^0+$/.test(newValue)) {
+      this.pointsValueDisabled = true;
     } else {
-      this.pointsValid = false;
+      this.pointsValueDisabled = false;
     }
   }
 

--- a/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.ts
@@ -17,6 +17,9 @@ export class UbsAdminCertificateAddCertificatePopUpComponent implements OnInit, 
   addCertificateForm: FormGroup;
   certificatePattern = Patterns.serteficatePattern;
   certificateMask = Masks.certificateMask;
+  monthCountValid: boolean;
+  pointsValid: boolean;
+
   private destroy: Subject<boolean> = new Subject<boolean>();
 
   constructor(
@@ -36,6 +39,22 @@ export class UbsAdminCertificateAddCertificatePopUpComponent implements OnInit, 
       monthCount: new FormControl('', [Validators.required, Validators.pattern(Patterns.sertificateMonthCount)]),
       initialPointsValue: new FormControl('', [Validators.required, Validators.pattern(Patterns.sertificateInitialValue)])
     });
+  }
+
+  valueChangeMonthCount(newValue: string) {
+    if (/^[0]+$/.test(newValue)) {
+      this.monthCountValid = true;
+    } else {
+      this.monthCountValid = false;
+    }
+  }
+
+  valueChangePointsValue(newValue: string) {
+    if (/^[0]+$/.test(newValue)) {
+      this.pointsValid = true;
+    } else {
+      this.pointsValid = false;
+    }
   }
 
   createCertificate() {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.ts
@@ -42,19 +42,11 @@ export class UbsAdminCertificateAddCertificatePopUpComponent implements OnInit, 
   }
 
   valueChangeMonthCount(newValue: string) {
-    if (/^0+$/.test(newValue)) {
-      this.monthCountDisabled = true;
-    } else {
-      this.monthCountDisabled = false;
-    }
+    this.monthCountDisabled = /^0+$/.test(newValue);
   }
 
   valueChangePointsValue(newValue: string) {
-    if (/^0+$/.test(newValue)) {
-      this.pointsValueDisabled = true;
-    } else {
-      this.pointsValueDisabled = false;
-    }
+    this.pointsValueDisabled = /^0+$/.test(newValue);
   }
 
   createCertificate() {


### PR DESCRIPTION
**Before**
Users enter null to input fields and the button isn't disabled
![image](https://user-images.githubusercontent.com/101433204/200327383-82da3690-611c-4177-bd74-b925b0056bf3.png)
**After**
When users enter null, the button is disabled
![image](https://user-images.githubusercontent.com/101433204/200327770-aa77183a-68ef-4e17-a620-dc8a4d1c8e49.png)
![image](https://user-images.githubusercontent.com/101433204/200327811-d82a6de0-7fce-43ee-a749-d2d14b92a58f.png)

