### PR TITLE
Bugfix#4748 Couriers are shown in tariffs table

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.spec.ts
@@ -90,12 +90,8 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
     courierLimit: 'fake',
     courierTranslationDtos: [
       {
-        languageCode: 'en',
-        name: 'fake'
-      },
-      {
-        languageCode: 'ua',
-        name: 'фейк'
+        name: 'фейк',
+        nameEng: 'fake'
       }
     ],
     createdAt: 'date',

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -481,10 +481,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
       .subscribe((card) => {
         card.forEach((el) => {
           const cardObj = {
-            courier: el.courierTranslationDtos
-              .filter((ob) => ob.languageCode === 'ua')
-              .map((it) => it.name)
-              .join(),
+            courier: el.courierTranslationDtos.map((it) => it.name).join(),
             station: el.receivingStationDtos.map((it) => it.name),
             region: el.regionDto.nameUk,
             city: el.locationInfoDtos.map((it) => it.nameUk),


### PR DESCRIPTION
**Before**
Tariffs table doesn't show couriers
<img width="1104" alt="Знімок екрана 2022-11-17 о 19 30 11" src="https://user-images.githubusercontent.com/108685196/202647748-c42b412e-4a62-4326-b8c2-1027f0839e5d.png">

**After**
Tariffs table shows couriers
<img width="1432" alt="Знімок екрана 2022-11-18 о 09 40 38" src="https://user-images.githubusercontent.com/108685196/202647922-8d6ba43f-995c-4d5d-98c3-b749de0373ae.png">
