### PR TITLE
Bugfix#4771/Displaying of extended tariff card

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
@@ -193,7 +193,7 @@
       <td>
         {{ card.tariff | tariffStatus }}
       </td>
-      <td class="last-col" *ngIf="card.tariff != 'Неактивно'" [matMenuTriggerFor]="crumbs">
+      <td class="last-col" *ngIf="card.tariff !== 'DEACTIVATED'" [matMenuTriggerFor]="crumbs">
         <img class="tariff-img mr-3" [src]="icons.crumbs" alt="crumbs" />
       </td>
       <mat-menu #crumbs="matMenu">
@@ -204,7 +204,7 @@
           <span class="menu-item">{{ 'ubs-tariffs.btn.deactivation' | translate }}</span>
         </button>
       </mat-menu>
-      <td class="last-col" *ngIf="card.tariff === 'Неактивно'" [matMenuTriggerFor]="restore">
+      <td class="last-col" *ngIf="card.tariff === 'DEACTIVATED'" [matMenuTriggerFor]="restore">
         <img class="tariff-img mr-3" [src]="icons.restore" alt="restore" />
       </td>
       <mat-menu #restore="matMenu">
@@ -237,7 +237,7 @@
       <td>
         {{ selectedCard.tariff | tariffStatus }}
       </td>
-      <td class="last-col" *ngIf="selectedCard.tariff != 'Неактивно'" [matMenuTriggerFor]="crumbs">
+      <td class="last-col" *ngIf="selectedCard.tariff !== 'DEACTIVATED'" [matMenuTriggerFor]="crumbs">
         <img class="tariff-img mr-3" [src]="icons.crumbs" alt="crumbs" />
       </td>
       <mat-menu #crumbs="matMenu">
@@ -248,7 +248,7 @@
           <span class="menu-item">{{ 'ubs-tariffs.btn.deactivation' | translate }}</span>
         </button>
       </mat-menu>
-      <td class="last-col" *ngIf="selectedCard.tariff === 'Неактивно'" [matMenuTriggerFor]="restore">
+      <td class="last-col" *ngIf="selectedCard.tariff === 'DEACTIVATED'" [matMenuTriggerFor]="restore">
         <img class="tariff-img mr-3" [src]="icons.restore" alt="restore" />
       </td>
       <mat-menu #restore="matMenu">

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
@@ -214,6 +214,50 @@
       </mat-menu>
     </tr>
   </tbody>
+  <tbody *ngIf="!showTitle">
+    <tr *ngFor="let card of selectedCard">
+      <td>
+        {{ card.region }}
+      </td>
+      <td>
+        <div *ngFor="let item of card.city">
+          {{ item }}
+        </div>
+      </td>
+      <td>
+        <div>
+          {{ card.courier }}
+        </div>
+      </td>
+      <td>
+        <div *ngFor="let item of card.station">
+          {{ item }}
+        </div>
+      </td>
+      <td>
+        {{ card.tariff | tariffStatus }}
+      </td>
+      <td class="last-col" *ngIf="card.tariff != 'Неактивно'" [matMenuTriggerFor]="crumbs">
+        <img class="tariff-img mr-3" [src]="icons.crumbs" alt="crumbs" />
+      </td>
+      <mat-menu #crumbs="matMenu">
+        <button mat-menu-item>
+          <span class="menu-item">{{ 'ubs-tariffs.btn.edit' | translate }}</span>
+        </button>
+        <button mat-menu-item (click)="openDeactivateLocation()">
+          <span class="menu-item">{{ 'ubs-tariffs.btn.deactivation' | translate }}</span>
+        </button>
+      </mat-menu>
+      <td class="last-col" *ngIf="card.tariff === 'Неактивно'" [matMenuTriggerFor]="restore">
+        <img class="tariff-img mr-3" [src]="icons.restore" alt="restore" />
+      </td>
+      <mat-menu #restore="matMenu">
+        <button mat-menu-item>
+          <span class="menu-item">{{ 'ubs-tariffs.btn.restore' | translate }}</span>
+        </button>
+      </mat-menu>
+    </tr>
+  </tbody>
 </table>
 <div *ngIf="isFieldFilled && !isCardExist" class="create-card-field">
   <span>{{ 'ubs-tariffs.card-not-found' | translate }}</span>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
@@ -171,12 +171,12 @@
     </tr>
   </thead>
   <tbody *ngIf="showAllTariff">
-    <tr *ngFor="let card of cards">
+    <tr *ngFor="let card of cards" class="cursor-pointer" (click)="page(card.cardId)">
       <td>
         {{ card.region }}
       </td>
       <td>
-        <div *ngFor="let item of card.city" class="cursor-pointer" (click)="page(card.cardId)">
+        <div *ngFor="let item of card.city">
           {{ item }}
         </div>
       </td>
@@ -214,8 +214,8 @@
       </mat-menu>
     </tr>
   </tbody>
-  <tbody *ngIf="!showAllTariff">
-    <tr>
+  <tbody *ngIf="!showAllTariff && !isLoading">
+    <tr class="selected-card">
       <td>
         {{ selectedCard.region }}
       </td>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
@@ -1,6 +1,6 @@
 <div class="d-flex justify-content-between">
   <ng-template [ngTemplateOutlet]="textBack"></ng-template>
-  <p *ngIf="showTitle" class="h5 main-text">{{ 'ubs-tariffs.tariffs' | translate }}</p>
+  <p *ngIf="showAllTariff" class="h5 main-text">{{ 'ubs-tariffs.tariffs' | translate }}</p>
   <div class="mat-menu">
     <div class="setting-block" [matMenuTriggerFor]="menu">
       <img [src]="icons.setting" class="tariff-img" alt="settings" />
@@ -45,7 +45,7 @@
     </mat-menu>
   </div>
 </div>
-<form class="showing-block" *ngIf="showTitle" [formGroup]="searchForm" #form="ngForm">
+<form class="showing-block" *ngIf="showAllTariff" [formGroup]="searchForm" #form="ngForm">
   <div class="d-flex">
     <div class="col-item">
       <p class="col-text">{{ 'ubs-tariffs.region' | translate }}</p>
@@ -170,7 +170,7 @@
       <th id="action"></th>
     </tr>
   </thead>
-  <tbody *ngIf="showTitle">
+  <tbody *ngIf="showAllTariff">
     <tr *ngFor="let card of cards">
       <td>
         {{ card.region }}
@@ -214,30 +214,30 @@
       </mat-menu>
     </tr>
   </tbody>
-  <tbody *ngIf="!showTitle">
-    <tr *ngFor="let card of selectedCard">
+  <tbody *ngIf="!showAllTariff">
+    <tr>
       <td>
-        {{ card.region }}
+        {{ selectedCard.region }}
       </td>
       <td>
-        <div *ngFor="let item of card.city">
+        <div *ngFor="let item of selectedCard.city">
           {{ item }}
         </div>
       </td>
       <td>
         <div>
-          {{ card.courier }}
+          {{ selectedCard.courier }}
         </div>
       </td>
       <td>
-        <div *ngFor="let item of card.station">
+        <div *ngFor="let item of selectedCard.station">
           {{ item }}
         </div>
       </td>
       <td>
-        {{ card.tariff | tariffStatus }}
+        {{ selectedCard.tariff | tariffStatus }}
       </td>
-      <td class="last-col" *ngIf="card.tariff != 'Неактивно'" [matMenuTriggerFor]="crumbs">
+      <td class="last-col" *ngIf="selectedCard.tariff != 'Неактивно'" [matMenuTriggerFor]="crumbs">
         <img class="tariff-img mr-3" [src]="icons.crumbs" alt="crumbs" />
       </td>
       <mat-menu #crumbs="matMenu">
@@ -248,7 +248,7 @@
           <span class="menu-item">{{ 'ubs-tariffs.btn.deactivation' | translate }}</span>
         </button>
       </mat-menu>
-      <td class="last-col" *ngIf="card.tariff === 'Неактивно'" [matMenuTriggerFor]="restore">
+      <td class="last-col" *ngIf="selectedCard.tariff === 'Неактивно'" [matMenuTriggerFor]="restore">
         <img class="tariff-img mr-3" [src]="icons.restore" alt="restore" />
       </td>
       <mat-menu #restore="matMenu">

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
@@ -45,7 +45,7 @@
     </mat-menu>
   </div>
 </div>
-<form class="showing-block" [formGroup]="searchForm" #form="ngForm">
+<form class="showing-block" *ngIf="showTitle" [formGroup]="searchForm" #form="ngForm">
   <div class="d-flex">
     <div class="col-item">
       <p class="col-text">{{ 'ubs-tariffs.region' | translate }}</p>
@@ -170,7 +170,7 @@
       <th id="action"></th>
     </tr>
   </thead>
-  <tbody>
+  <tbody *ngIf="showTitle">
     <tr *ngFor="let card of cards">
       <td>
         {{ card.region }}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.scss
@@ -177,6 +177,11 @@ form {
   box-shadow: 0 2px 6px rgba(100, 114, 125, 0.15);
 }
 
+.table-location tbody tr.selected-card {
+  background: none;
+  box-shadow: none;
+}
+
 .table-location {
   border-collapse: separate;
   border-spacing: 0 8px;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -28,6 +28,7 @@ import { LanguageService } from 'src/app/main/i18n/language.service';
 })
 export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterViewChecked, OnDestroy {
   @Input() showAllTariff = true;
+  @Input() isLoading;
   @Input() locationCard: Locations;
   @Input() textBack: TemplateRef<any>;
   @Input() selectedCard;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -53,6 +53,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
   stationPlaceholder: string;
   selectedStation = [];
   cards = [];
+  selectedCard = [];
   filterData = { status: '' };
   createCardObj: CreateCard;
   isFieldFilled = false;
@@ -123,6 +124,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
         });
         this.getCouriers();
       });
+    console.log(this.selectedCard);
   }
 
   ngAfterViewChecked(): void {
@@ -446,7 +448,10 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
   }
 
   page(cardID): void {
-    this.router.navigate([`ubs-admin/tariffs/location/${cardID}`]); //
+    const card = this.cards.find((item) => item.cardId === cardID);
+    this.selectedCard.push(card);
+    console.log(this.selectedCard);
+    this.router.navigate([`ubs-admin/tariffs/location/${cardID}`]);
   }
 
   getCouriers(): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -27,9 +27,10 @@ import { LanguageService } from 'src/app/main/i18n/language.service';
   styleUrls: ['./ubs-admin-tariffs-location-dashboard.component.scss']
 })
 export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterViewChecked, OnDestroy {
-  @Input() showTitle = true;
+  @Input() showAllTariff = true;
   @Input() locationCard: Locations;
   @Input() textBack: TemplateRef<any>;
+  @Input() selectedCard;
 
   locations: Locations[];
   regionEnglishName;
@@ -53,7 +54,6 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
   stationPlaceholder: string;
   selectedStation = [];
   cards = [];
-  selectedCard = [];
   filterData = { status: '' };
   createCardObj: CreateCard;
   isFieldFilled = false;
@@ -124,7 +124,6 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
         });
         this.getCouriers();
       });
-    console.log(this.selectedCard);
   }
 
   ngAfterViewChecked(): void {
@@ -447,10 +446,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
     return cityArray;
   }
 
-  page(cardID): void {
-    const card = this.cards.find((item) => item.cardId === cardID);
-    this.selectedCard.push(card);
-    console.log(this.selectedCard);
+  page(cardID: number): void {
     this.router.navigate([`ubs-admin/tariffs/location/${cardID}`]);
   }
 

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
@@ -3,6 +3,7 @@
   [locationCard]="thisLocation"
   [textBack]="back"
   [selectedCard]="selectedCard"
+  [isLoading]="isLoading"
 >
 </app-ubs-admin-tariffs-location-dashboard>
 <ng-template #back>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
@@ -1,4 +1,9 @@
-<app-ubs-admin-tariffs-location-dashboard [showTitle]="false" [locationCard]="thisLocation" [textBack]="back">
+<app-ubs-admin-tariffs-location-dashboard
+  [showAllTariff]="false"
+  [locationCard]="thisLocation"
+  [textBack]="back"
+  [selectedCard]="selectedCard"
+>
 </app-ubs-admin-tariffs-location-dashboard>
 <ng-template #back>
   <div class="ml-2 d-flex cursor-pointer align-items-center">

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.scss
@@ -258,7 +258,9 @@ button[disabled] {
 }
 
 .container {
-  padding: 35px 0;
+  padding: 0 25px 35px 0;
+  max-width: 100%;
+  margin: 0;
 }
 
 .secondary-global-button {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.spec.ts
@@ -103,7 +103,29 @@ describe('UbsAdminPricingPageComponent', () => {
     minAmountOfOrder: 'fake',
     maxPriceOfOrder: 'fake'
   };
-  const fakeCardId = { cardId: 3 };
+  const fakeCard = {
+    courierTranslationDtos: [{ name: 'Курʼєр', nameEng: 'Courier' }],
+    receivingStationDtos: [
+      {
+        id: 1,
+        name: 'Станція'
+      }
+    ],
+    regionDto: {
+      nameEn: 'Region',
+      nameUk: 'Область',
+      regionId: 1
+    },
+    locationInfoDtos: [
+      {
+        locationId: 2,
+        nameEn: 'City',
+        nameUk: 'Місто'
+      }
+    ],
+    tariffStatus: 'Active',
+    cardId: 3
+  };
   const dialogStub = {
     afterClosed() {
       return of(true);
@@ -128,7 +150,7 @@ describe('UbsAdminPricingPageComponent', () => {
   tariffsServiceMock.setLimitDescription.and.returnValue(of([fakeDescription]));
   tariffsServiceMock.setLimitsBySumOrder.and.returnValue(of([fakeSumInfo]));
   tariffsServiceMock.setLimitsByAmountOfBags.and.returnValue(of([fakeBagInfo]));
-  tariffsServiceMock.getCardInfo.and.returnValue(of([fakeCardId]));
+  tariffsServiceMock.getCardInfo.and.returnValue(of([fakeCard]));
 
   const matDialogMock = jasmine.createSpyObj('matDialogMock', ['open']);
   matDialogMock.open.and.returnValue(dialogStub);
@@ -199,9 +221,27 @@ describe('UbsAdminPricingPageComponent', () => {
   });
 
   it('should call all methods in ngOnInit', () => {
-    const spy = spyOn(component, 'routeParams');
+    const spy1 = spyOn(component, 'routeParams');
+    const spy2 = spyOn(component, 'getSelectedTariffCard');
     component.ngOnInit();
-    expect(spy).toHaveBeenCalled();
+    expect(spy1).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+  });
+
+  it('should get selected tariff card', () => {
+    component.selectedCardId = 3;
+    const result = {
+      courier: 'Курʼєр',
+      station: ['Станція'],
+      region: 'Область',
+      city: ['Місто'],
+      tariff: 'Active',
+      regionId: 1,
+      cardId: 3
+    };
+    component.getSelectedTariffCard();
+    expect(component.selectedCard).toEqual(result);
+    expect(component.isLoading).toEqual(false);
   });
 
   it('should fillFields correctly', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.ts
@@ -29,6 +29,7 @@ export class UbsAdminTariffsPricingPageComponent implements OnInit, OnDestroy {
   isLoadBar: boolean;
   selectedCardId;
   selectedCard;
+  isLoading: boolean = true;
   ourTariffs;
   amount;
   currentCourierId: number;
@@ -435,7 +436,7 @@ export class UbsAdminTariffsPricingPageComponent implements OnInit, OnDestroy {
           regionId: card.regionDto.regionId,
           cardId: card.cardId
         };
-        console.log(this.selectedCard);
+        this.isLoading = false;
       });
   }
 

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.ts
@@ -29,7 +29,7 @@ export class UbsAdminTariffsPricingPageComponent implements OnInit, OnDestroy {
   isLoadBar: boolean;
   selectedCardId;
   selectedCard;
-  isLoading: boolean = true;
+  isLoading = true;
   ourTariffs;
   amount;
   currentCourierId: number;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.ts
@@ -28,6 +28,7 @@ export class UbsAdminTariffsPricingPageComponent implements OnInit, OnDestroy {
   isLoadBar1: boolean;
   isLoadBar: boolean;
   selectedCardId;
+  selectedCard;
   ourTariffs;
   amount;
   currentCourierId: number;
@@ -85,6 +86,7 @@ export class UbsAdminTariffsPricingPageComponent implements OnInit, OnDestroy {
     this.getLocationId();
     this.getCourierId();
     this.setCourierId();
+    this.getSelectedTariffCard();
   }
 
   private initForm(): void {
@@ -415,6 +417,25 @@ export class UbsAdminTariffsPricingPageComponent implements OnInit, OnDestroy {
       .subscribe((res) => {
         this.couriers = res;
         this.fillFields();
+      });
+  }
+
+  public getSelectedTariffCard(): void {
+    this.tariffsService
+      .getCardInfo()
+      .pipe(takeUntil(this.destroy))
+      .subscribe((res) => {
+        const card = res.find((it) => it.cardId === this.selectedCardId);
+        this.selectedCard = {
+          courier: card.courierTranslationDtos.map((it) => it.name).join(),
+          station: card.receivingStationDtos.map((it) => it.name),
+          region: card.regionDto.nameUk,
+          city: card.locationInfoDtos.map((it) => it.nameUk),
+          tariff: card.tariffStatus,
+          regionId: card.regionDto.regionId,
+          cardId: card.cardId
+        };
+        console.log(this.selectedCard);
       });
   }
 


### PR DESCRIPTION
**Before**

When Super Admin clicks on tariff card, he is redirected to page with the extended tariff card (with details). On this page is displayed all tariff cards and searching form. The extended tariff card (with details) displayed in the bottom of current page.

https://www.loom.com/share/f5c2073a92cf4100b7b16a5817fd407f

**After**
The extended tariff card (with details) should be displayed under particular tariff card. All tariff cards and searching form should not be displayed.

https://www.loom.com/share/18dfd1dd6f3743aeba4f83c3300e53b2