### PR TITLE
#4663: add logic after reloading page

### DIFF
--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
@@ -18,6 +18,7 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
   orderResponseError = false;
   orderStatusDone: boolean;
   isSpinner = true;
+  pageReloaded = false;
   private destroy$: Subject<boolean> = new Subject<boolean>();
 
   constructor(
@@ -41,10 +42,14 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.ubsOrderFormService.orderId.pipe(takeUntil(this.destroy$)).subscribe((oderID) => {
+      if (!oderID && this.localStorageService.getUbsOrderId()) {
+        oderID = this.localStorageService.getUbsOrderId();
+        this.pageReloaded = true;
+      }
       if (oderID) {
         this.orderId = oderID;
-        this.orderResponseError = this.ubsOrderFormService.getOrderResponseErrorStatus();
-        this.orderStatusDone = this.ubsOrderFormService.getOrderStatus();
+        this.orderResponseError = !this.pageReloaded ? this.ubsOrderFormService.getOrderResponseErrorStatus() : !this.pageReloaded;
+        this.orderStatusDone = !this.pageReloaded ? this.ubsOrderFormService.getOrderStatus() : this.pageReloaded;
         this.renderView();
       } else {
         this.orderService
@@ -68,7 +73,7 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
   }
 
   public isUserPageOrderPayment(): boolean {
-    return this.localStorageService.getUserPagePayment() === 'true';
+    return this.localStorageService.getUserPagePayment() === 'true' || this.pageReloaded;
   }
 
   renderView(): void {

--- a/src/app/ubs/ubs/components/ubs-submit-order/ubs-submit-order.component.ts
+++ b/src/app/ubs/ubs/components/ubs-submit-order/ubs-submit-order.component.ts
@@ -235,6 +235,7 @@ export class UBSSubmitOrderComponent extends FormBaseComponent implements OnInit
             this.ubsOrderFormService.transferOrderId(orderId);
             this.ubsOrderFormService.setOrderResponseErrorStatus(false);
             this.ubsOrderFormService.setOrderStatus(true);
+            this.localStorageService.setUbsOrderId(orderId);
           } else {
             this.shareFormService.orderUrl = link.toString();
             this.localStorageService.setUbsFondyOrderId(orderId);


### PR DESCRIPTION
**Before**
The message "Oops, something went wrong..." appears after the user pays for the order in full with a certificate and refreshes the page

**After**
The message "Oops, something went wrong..." doesn't appear and the appropriate page is displayed

https://user-images.githubusercontent.com/101433204/206665660-22039ac4-8b4a-4d79-b972-8c15f058f0ca.mp4

