### PR TITLE
#4710: error message is displayed correctly

### DIFF
--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.spec.ts
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.spec.ts
@@ -69,9 +69,10 @@ describe('CreateEditEventsComponent', () => {
 
   const storeMock = jasmine.createSpyObj('store', ['select', 'dispatch']);
 
-  const localStorageServiceMock = jasmine.createSpyObj('localStorageService', ['getEventForEdit', 'getEditMode']);
+  const localStorageServiceMock = jasmine.createSpyObj('localStorageService', ['getEventForEdit', 'getEditMode', 'getUserId']);
   localStorageServiceMock.getEditMode = () => true;
   localStorageServiceMock.getEventForEdit = () => EditEventMock;
+  localStorageServiceMock.getUserId = () => 137;
 
   const EventsServiceMock = jasmine.createSpyObj('EventsService', ['createEvent', 'editEvent']);
   EventsServiceMock.createEvent = () => of(EditEventMock);

--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
@@ -266,7 +266,7 @@ export class CreateEditEventsComponent implements OnInit, OnDestroy {
   }
   private checkUserSigned(): boolean {
     this.getUserId();
-    return this.userId ? true : false;
+    return Boolean(this.userId);
   }
 
   private getUserId() {

--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
@@ -271,7 +271,6 @@ export class CreateEditEventsComponent implements OnInit, OnDestroy {
 
   private getUserId() {
     this.userId = this.localStorageService.getUserId();
-    console.log(this.userId);
   }
 
   private validateSpaces(control: AbstractControl): ValidationErrors {

--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
@@ -53,7 +53,7 @@ export class CreateEditEventsComponent implements OnInit, OnDestroy {
   private pipe = new DatePipe('en-US');
   private destroyed$: ReplaySubject<boolean> = new ReplaySubject<boolean>(1);
   private matSnackBar: MatSnackBarComponent;
-  private userId: number;
+  public userId: number;
 
   constructor(
     public router: Router,
@@ -264,13 +264,16 @@ export class CreateEditEventsComponent implements OnInit, OnDestroy {
       this.escapeFromCreateEvent();
     });
   }
-
-  checkUserSigned(): boolean {
+  private checkUserSigned(): boolean {
+    this.getUserId();
     return this.userId ? true : false;
   }
+
   private getUserId() {
     this.userId = this.localStorageService.getUserId();
+    console.log(this.userId);
   }
+
   private validateSpaces(control: AbstractControl): ValidationErrors {
     const value = control && control.value && control.value !== control.value.trim();
     return value ? { hasNoWhiteSpaces: 'false' } : null;


### PR DESCRIPTION
**Before**
When the user is logged in and clicks on create event page button, he receives the error message "You need to be authorized to edit an event".
**After** 
The error message "You need to be authorized to edit an event" isn't displayed when the user is authorized and is still displayed when the user didn't sign in.

https://user-images.githubusercontent.com/101433204/206746075-0301a6cd-4d1f-4af9-b8be-9beb372cbb14.mp4


