### PR TITLE
bugfix/#4819 UBS admin - Tariffs - Add Location - input autocomplite translation in Ua

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -51,7 +51,7 @@
     crossorigin="anonymous"
   ></script>
   <script
-    src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB3xs7Kczo46LFcQRFKPMdrE0lU4qsR_S4&libraries=places&language=en"
+    src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB3xs7Kczo46LFcQRFKPMdrE0lU4qsR_S4&libraries=places&language=ua"
     id="googleMaps"
   ></script>
 </html>


### PR DESCRIPTION
Fixed UBS admin - Tariffs - Add Location - region input remain in Ua after click to autocomplete list