### PR TITLE
Changed styles, added translation to en to deactivate pop-up, fixed bug with red frame

### DIFF
--- a/src/app/ubs/ubs-admin/components/shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component.html
@@ -1,5 +1,5 @@
 <div class="w-100">
-  <p class="title">{{ 'ubs-tariffs-add-location-pop-up.deactivate' | translate }}</p>
+  <p class="title">{{ 'ubs-tariffs-add-location-pop-up.deactivate-confirm' | translate }}</p>
 </div>
 <app-dialog-tariff [row]="form" [newDate]="newDate" [name]="adminName" [edit]="true"></app-dialog-tariff>
 <ng-template #form>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.scss
@@ -67,6 +67,7 @@ input {
 
 .itemList {
   width: auto;
+  overflow: hidden;
 }
 
 .dis-none {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.spec.ts
@@ -8,6 +8,7 @@ import { UbsAdminTariffsDeactivatePopUpComponent } from './ubs-admin-tariffs-dea
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { TariffsService } from '../../../services/tariffs.service';
 import { ModalTextComponent } from '../../shared/components/modal-text/modal-text.component';
+import { LanguageService } from 'src/app/main/i18n/language.service';
 
 describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
   let component: UbsAdminTariffsDeactivatePopUpComponent;
@@ -382,6 +383,9 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
   tariffsServiceMock.getActiveLocations.and.returnValue(of([fakeLocation]));
   tariffsServiceMock.getCardInfo.and.returnValue(of([fakeTariffCard]));
 
+  const languageServiceMock = jasmine.createSpyObj('languageServiceMock', ['getCurrentLanguage']);
+  languageServiceMock.getCurrentLanguage.and.returnValue('ua');
+
   const localStorageServiceStub = () => ({
     firstNameBehaviourSubject: { pipe: () => of('fakeName') }
   });
@@ -396,6 +400,7 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
         { provide: MatDialogRef, useValue: fakeMatDialogRef },
         { provide: LocalStorageService, useFactory: localStorageServiceStub },
         { provide: TariffsService, useValue: tariffsServiceMock },
+        { provide: LanguageService, useValue: languageServiceMock },
         FormBuilder
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
@@ -52,6 +52,7 @@
       <div class="input-wrapper">
         <input
           type="text"
+          class="region"
           placeholder="{{ 'ubs-tariffs.placeholder-region' | translate }}"
           matInput
           #autocompleteTriggerRegion="matAutocompleteTrigger"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.scss
@@ -55,7 +55,7 @@ form {
 }
 
 .input-wrapper input {
-  padding-left: 15px;
+  padding: 0 34px 0 15px;
   margin: 0;
   width: 100%;
   height: 100%;
@@ -65,12 +65,16 @@ form {
   color: var(--ubs-primary-light-grey);
 }
 
+.input-wrapper input.region {
+  padding: 0 56px 0 15px;
+}
+
 .courier-select {
-  padding: 5px 0 0 15px;
+  padding: 5px 34px 0 15px;
 }
 
 .state-select {
-  padding: 5px 0 0 15px;
+  padding: 5px 34px 0 15px;
 }
 
 .col-item {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.scss
@@ -57,7 +57,7 @@ select {
 .form-control {
   height: 2.25rem;
   font-size: 0.9rem;
-  padding: 8px;
+  padding: 8px 35px 8px 8px;
   color: var(--ubs-quaternary-dark-grey);
   width: 228px;
   display: block;

--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -672,6 +672,7 @@
     "title": "Add location",
     "edit-title": "Edit location",
     "deactivate": "Deactivate",
+    "deactivate-confirm": "Confirm deactivation",
     "region": "Region",
     "locality": "City",
     "english-hint": "Enter the following data in ENGLISH",

--- a/src/assets/i18n/ubs-admin/ua.json
+++ b/src/assets/i18n/ubs-admin/ua.json
@@ -666,6 +666,7 @@
     "title": "Додати локацію",
     "edit-title": "Редагувати локацію",
     "deactivate": "Деактивувати",
+    "deactivate-confirm": "Підтвердити деактивацію",
     "region": "Область",
     "locality": "Місто",
     "courier": "Кур'єр",


### PR DESCRIPTION
**Before**
1. Date is not translated into EN language in the pop-up window "Деактивувати" (#4827) 
2. Text overlaps the pictogram of the item list on the pop window"Деактивувати" (#4828)
3. The title of the window "Підтвердити деактивацію" does not correspond to the mock up (#4829)
4. Uneven location of the pictogram 'x' (deleting item) of choosen items under the field "Станція приймання" (#4830)
5. The field "Courier" is highlighted when the user deleted chosen name of the courier and choosed and deleted the name of the region on the pop-up window "Деактивувати" (#4839)
6. Regions are not translated into EN language in the pop-up window "Деактивувати" (#4834)
7. UI elements overlap each other when the user zoom 'Tariffs' page on 150% and 175% (#4814)

**After**
1. Date is translated into EN language in the pop-up window "Деактивувати" (#4827) 
2. Text doesn`t overlaps the pictogram of the item list on the pop window"Деактивувати" (#4828)
3. The title of the window "Підтвердити деактивацію" corresponds to the mock up (#4829)
4. Fixed location of the pictogram 'x' (deleting item) of choosen items under the field "Станція приймання" (#4830)
5. The field "Courier" is not highlighted when the user deleted chosen name of the courier and choosed and deleted the name of the region on the pop-up window "Деактивувати" (#4839)
6. Regions are translated into EN language in the pop-up window "Деактивувати" (#4834)
7. UI elements don`t overlap each other when the user zoom 'Tariffs' page on 150% and 175% (#4814)