### PR TITLE
bugfix/#4818 - UBS Admin - Tariffs - Add location pop up - region input suggestion

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.ts
@@ -47,7 +47,7 @@ export class UbsAdminTariffsLocationPopUpComponent implements OnInit, AfterViewC
   });
 
   regionOptions = {
-    types: ['(regions)'],
+    types: ['administrative_area_level_1'],
     componentRestrictions: { country: 'UA' }
   };
 


### PR DESCRIPTION
Fixed UBS admin > Tariffs > Add Location - region input have region in suggestion