### PR TITLE
changed patterns for name, surname and email

### DIFF
--- a/src/app/ubs/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
+++ b/src/app/ubs/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
@@ -30,7 +30,7 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
   order: Order;
   addresses: Address[] = [];
   maxAddressLength = 4;
-  namePattern = Patterns.NamePattern;
+  namePattern = Patterns.ubsNameAndSernamePattern;
   emailPattern = Patterns.ubsMailPattern;
   phoneMask = Masks.phoneMask;
   firstOrder = true;

--- a/src/assets/patterns/patterns.ts
+++ b/src/assets/patterns/patterns.ts
@@ -17,7 +17,7 @@ export const Patterns = {
   ubsCommentPattern: /[\S\s]{0,255}/,
   ordersPattern: /^\d{10}$/,
 
-  ubsMailPattern: /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/,
+  ubsMailPattern: /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/,
 
   paymantAmountPattern: '^[0-9]+$',
   sertificateMonthCount: '^[0-9]{1,2}$',


### PR DESCRIPTION
**Before**

- The error message does not appear when the user enters invalid values ​​in the fields 'Name' and 'Surname' for the Personal details and  in the block "The recipient is another person" 
- Error message does not appear when the user enters incorrect Email​​ in Personal details or into block "The recipient is another person" the field "Email"

**After**
- The error message appears when the user enters invalid values ​​in the fields 'Name' and 'Surname' for the Personal details and  in the block "The recipient is another person" 
![image](https://user-images.githubusercontent.com/101433204/210587589-59a82df1-fd89-48a9-8473-d032fa2435e1.png)
- Error message appears when the user enters incorrect Email​​ in Personal details or into block "The recipient is another person" the field "Email"
![image](https://user-images.githubusercontent.com/101433204/210587901-ade3aa16-7fed-40da-bde4-790e526e6238.png)
