### PR TITLE
Bugfix/#4903-count-limit-big-bags

### DIFF
--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.html
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.html
@@ -10,16 +10,16 @@
           </button>
         </div>
       </div>
-      <div *ngIf="courierLimitBySum && displayMinOrderMes && (orderDetailsForm.touched || isOrderData)" class="validMes">
+      <div *ngIf="courierLimitBySum && displayMinOrderMes" class="validMes">
         <small class="text-danger">{{ 'order-details.min-sum' | translate: { minOrderValue: minOrderValue } }}</small>
       </div>
-      <div *ngIf="courierLimitBySum && displayMaxOrderMes && (orderDetailsForm.touched || isOrderData)" class="validMes">
+      <div *ngIf="courierLimitBySum && displayMaxOrderMes" class="validMes">
         <small class="text-danger">{{ 'order-details.max-sum' | translate: { maxOrderValue: maxOrderValue } }}</small>
       </div>
-      <div *ngIf="courierLimitByAmount && displayMinBigBagsMes && (orderDetailsForm.touched || isOrderData)" class="validMes">
+      <div *ngIf="courierLimitByAmount && displayMinBigBagsMes" class="validMes">
         <small class="text-danger">{{ 'order-details.min-big-bags' | translate: { minAmountOfBigBags: minAmountOfBigBags } }}</small>
       </div>
-      <div *ngIf="courierLimitByAmount && displayMaxBigBagsMes && (orderDetailsForm.touched || isOrderData)" class="validMes">
+      <div *ngIf="courierLimitByAmount && displayMaxBigBagsMes" class="validMes">
         <small class="text-danger">{{ 'order-details.max-big-bags' | translate: { maxAmountOfBigBags: maxAmountOfBigBags } }}</small>
       </div>
     </div>

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -87,7 +87,6 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
   public courierLimitByAmount: boolean;
   public courierLimitBySum: boolean;
   public courierLimitValidation: boolean;
-  public isOrderData: boolean;
 
   constructor(
     private fb: FormBuilder,
@@ -128,7 +127,6 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
     this.subscribeToLangChange();
     if (this.localStorageService.getUbsOrderData()) {
       this.calculateTotal();
-      this.isOrderData = true;
     }
   }
 
@@ -207,7 +205,7 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
       shop: new FormControl('no'),
       formArrayCertificates: this.fb.array([new FormControl('', [Validators.minLength(8), Validators.pattern(this.certificatePattern)])]),
       additionalOrders: this.fb.array(['']),
-      orderSum: new FormControl(0, [Validators.required, Validators.min(500)])
+      orderSum: new FormControl(0, [Validators.required])
     });
   }
 
@@ -235,11 +233,11 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
   }
 
   checkTotalBigBags() {
+    this.totalOfBigBags = 0;
     this.bags.forEach((bag) => {
-      if (bag.capacity === 120) {
-        const q1 = this.orderDetailsForm.controls.quantity1;
-        const q2 = this.orderDetailsForm.controls.quantity2;
-        this.totalOfBigBags = +q1.value + +q2.value;
+      if (bag.limitedIncluded) {
+        const quantity = this.orderDetailsForm.controls[`quantity${bag.id}`];
+        this.totalOfBigBags += +quantity.value;
       }
     });
     this.validateBags();

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-location-popup/ubs-order-location-popup.component.html
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-location-popup/ubs-order-location-popup.component.html
@@ -8,7 +8,7 @@
     <h5 class="title-text">{{ 'order-details.location.title' | translate }}</h5>
   </div>
   <form *ngIf="!isFetching; else spinner" class="form">
-    <mat-form-field>
+    <mat-form-field [style.width.%]="60">
       <input type="text" matInput [formControl]="myControl" [matAutocomplete]="auto" />
       <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn">
         <mat-option

--- a/src/app/ubs/ubs/models/ubs.interface.ts
+++ b/src/app/ubs/ubs/models/ubs.interface.ts
@@ -6,6 +6,7 @@ export interface Bag {
   price?: number;
   quantity?: number;
   code?: string;
+  limitedIncluded?: boolean;
 }
 
 export interface OrderBag {


### PR DESCRIPTION
**Before**

- Logic for counting bags was hardcoded only for Kyiv and was related to the capacity of the bag
- Content in the location field is cut on the pop-up "Вітаємо в УБС! Спочатку оберіть локацію вивезення відходів."
- The message "Зверніть, будь ласка, увагу на те, що мінімальне замовлення має містити не менше 2 пакетів по 120л" is not displayed on the block "Послуги' on the page 'Order' after choosing the location

**After**

- Counting of bags was changed according to the back-end and new logic is universal
- Content in the location field is fully displayed on the pop-up
- The message "Зверніть, будь ласка, увагу на те, що мінімальне замовлення має містити не менше 2 пакетів по 120л" is displayed on the block "Послуги' on the page 'Order' after choosing the location when a user doesn't choose the required number of packages