### PR TITLE
bugfix/#4930 - pricing page - Add Location - active cities en translate

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.html
@@ -80,7 +80,7 @@
         </mat-panel-title>
       </mat-expansion-panel-header>
 
-      <div *ngFor="let item of cities" class="itemList">
+      <div *ngFor="let item of activeCities" class="itemList">
         {{ item }}
       </div>
     </mat-expansion-panel>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.ts
@@ -181,7 +181,7 @@ export class UbsAdminTariffsLocationPopUpComponent implements OnInit, AfterViewC
         )
       )
       .flat(2);
-    this.currentLang === 'ua' ? (this.activeCities = this.cities) : (this.activeCities = this.enCities);
+    this.activeCities = this.currentLang === 'ua' ? this.cities : this.enCities;
   }
 
   translate(sourceText: string, input: any): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.ts
@@ -81,6 +81,7 @@ export class UbsAdminTariffsLocationPopUpComponent implements OnInit, AfterViewC
   cityExist = false;
   editedCityExist = false;
   cities = [];
+  activeCities = [];
   filteredRegions;
   filteredCities = [];
   editLocationId;
@@ -180,6 +181,7 @@ export class UbsAdminTariffsLocationPopUpComponent implements OnInit, AfterViewC
         )
       )
       .flat(2);
+    this.currentLang === 'ua' ? (this.activeCities = this.cities) : (this.activeCities = this.enCities);
   }
 
   translate(sourceText: string, input: any): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.ts
@@ -138,7 +138,7 @@ export class UbsAdminTariffsLocationPopUpComponent implements OnInit, AfterViewC
     });
     this.location.valueChanges.subscribe((item) => {
       this.cityInvalid = !this.citySelected && item.length > 3;
-      this.cityExist = this.checkCityExist(item, this.cities);
+      this.cityExist = this.checkCityExist(item, this.activeCities);
     });
     this.localeStorageService.languageBehaviourSubject.pipe(takeUntil(this.unsubscribe)).subscribe((lang: string) => {
       this.currentLang = lang;


### PR DESCRIPTION
- UBS Admin - Pricing page - Add Location pop up - added translation for active cities.
- Fixed error message logic for en city input - if city is active