### PR TITLE
Bugfix/#4946 disabled select with canceled or done

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
@@ -18,7 +18,7 @@
                 </label>
                 <select
                   *ngIf="isOrderStatusSelected"
-                  [attr.disabled]="setDisabledSelect()"
+                  [disabled]="setDisabledSelect()"
                   class="form-control"
                   formControlName="orderStatus"
                   (change)="onChangedOrderStatus($event.target.value)"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
@@ -18,6 +18,7 @@
                 </label>
                 <select
                   *ngIf="isOrderStatusSelected"
+                  [attr.disabled]="setDisabledSelect()"
                   class="form-control"
                   formControlName="orderStatus"
                   (change)="onChangedOrderStatus($event.target.value)"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
@@ -58,6 +58,10 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
     );
   }
 
+  public setDisabledSelect() {
+    return this.availableOrderStatuses[0].key === 'CANCELED' || this.availableOrderStatuses[0].key === 'DONE' ? true : null;
+  }
+
   private renderOrderStatus() {
     setTimeout(() => (this.isOrderStatusSelected = false));
     setTimeout(() => (this.isOrderStatusSelected = true));

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
@@ -59,7 +59,7 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
   }
 
   public setDisabledSelect() {
-    return this.availableOrderStatuses[0].key === 'CANCELED' || this.availableOrderStatuses[0].key === 'DONE' ? true : null;
+    return this.generalInfo.orderStatus === 'CANCELED' || this.generalInfo.orderStatus === 'DONE';
   }
 
   private renderOrderStatus() {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
@@ -66,7 +66,7 @@
           </button>
           <button type="submit" class="save-button" [disabled]="orderForm.pristine || !orderForm.valid || !isMinOrder" (click)="onSubmit()">
             {{ 'order-edit.btn.save' | translate }}
-            <span class="inform-window">
+            <span class="inform-window" *ngIf="!orderForm.valid">
               {{ 'information-window.message' | translate }}
               <ul>
                 <li>{{ 'export-details.export-date' | translate }}</li>


### PR DESCRIPTION
**Before**

- The final order statuses "Виконано"/"Скасовано" which were set in the field "Статус замовлення" isn't disabled after their saving 
- The message "Fill up, please, all the necessary fields" is appeared in orders with filled these fields

**After**

- The final order statuses "Виконано"/"Скасовано" which were set in the field "Статус замовлення" isn't disabled after their saving 
- The message "Fill up, please, all the necessary fields" doesn't appear in orders with filled these fields