### PR TITLE
Fixed an error that arised when admin selects courier in create tariff card pop-up

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-card-pop-up/ubs-admin-tariffs-card-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-card-pop-up/ubs-admin-tariffs-card-pop-up.component.spec.ts
@@ -210,7 +210,7 @@ describe('UbsAdminTariffsCardPopUpComponent', () => {
 
   it('should set english courier name', () => {
     const mockEvent = {
-      value: ['фейкКурєр']
+      value: 'фейкКурєр'
     };
     component.onSelectCourier(mockEvent);
     expect(component.courierEnglishName).toEqual('fakeCourier');

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-card-pop-up/ubs-admin-tariffs-card-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-card-pop-up/ubs-admin-tariffs-card-pop-up.component.ts
@@ -165,7 +165,7 @@ export class UbsAdminTariffsCardPopUpComponent implements OnInit, OnDestroy {
   }
 
   public onSelectCourier(event): void {
-    const selectedValue = this.couriers.find((ob) => ob.nameUk === event.value[0]);
+    const selectedValue = this.couriers.find((ob) => ob.nameUk === event.value);
     this.courierEnglishName = selectedValue.nameEn;
     this.courierId = selectedValue.courierId;
   }


### PR DESCRIPTION
The error arises when admin selects courier. Impossible to create new tariff card

![image](https://user-images.githubusercontent.com/108685196/217643104-c76e3a52-a877-4205-9ea0-3611a493bccf.png)
