### PR TITLE
bugfix/#4946 disabled order order status 'done' and 'cancel'

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
@@ -18,7 +18,6 @@
                 </label>
                 <select
                   *ngIf="isOrderStatusSelected"
-                  [disabled]="setDisabledSelect()"
                   class="form-control"
                   formControlName="orderStatus"
                   (change)="onChangedOrderStatus($event.target.value)"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
@@ -58,10 +58,6 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
     );
   }
 
-  public setDisabledSelect() {
-    return this.generalInfo.orderStatus === 'CANCELED' || this.generalInfo.orderStatus === 'DONE';
-  }
-
   private renderOrderStatus() {
     setTimeout(() => (this.isOrderStatusSelected = false));
     setTimeout(() => (this.isOrderStatusSelected = true));

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -162,11 +162,16 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
     const currentEmployees = this.responsiblePersonInfo.currentPositionEmployees;
     this.orderForm = this.fb.group({
       generalOrderInfo: this.fb.group({
-        orderStatus: this.generalInfo.orderStatus,
+        orderStatus: [
+          {
+            value: this.generalInfo.orderStatus,
+            disabled: this.generalInfo.orderStatus === 'CANCELED' || this.generalInfo.orderStatus === 'DONE'
+          }
+        ],
         paymentStatus: this.generalInfo.orderPaymentStatus,
         adminComment: [this.generalInfo.adminComment, Validators.maxLength(255)],
         cancellationComment: '', // TODO add this fields to controller
-        cancellationReason: '' // TODO
+        cancellationReason: '' // TODOthis.generalInfo.orderStatus === 'CANCELED' || this.generalInfo.orderStatus === 'DONE'
       }),
       userInfoDto: this.fb.group({
         recipientName: [

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -171,7 +171,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
         paymentStatus: this.generalInfo.orderPaymentStatus,
         adminComment: [this.generalInfo.adminComment, Validators.maxLength(255)],
         cancellationComment: '', // TODO add this fields to controller
-        cancellationReason: '' // TODOthis.generalInfo.orderStatus === 'CANCELED' || this.generalInfo.orderStatus === 'DONE'
+        cancellationReason: '' // TODO
       }),
       userInfoDto: this.fb.group({
         recipientName: [


### PR DESCRIPTION
**Before**
The final order statuses "Виконано"/"Скасовано" which were set in the field "Статус замовлення" aren't disabled after their saving 
**After**
The final order statuses "Виконано"/"Скасовано" which were set in the field "Статус замовлення" are disabled after their saving 
