### PR TITLE
Bugfix#5049/Removed diplication in filtered cards

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -463,8 +463,6 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
   }
 
   public getExistingCard(filterData) {
-    this.cardsUk.length = 0;
-    this.cardsEn.length = 0;
     this.tariffsService
       .getFilteredCard(filterData)
       .pipe(takeUntil(this.destroy))

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -463,6 +463,8 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
   }
 
   public getExistingCard(filterData) {
+    this.cardsUk.length = 0;
+    this.cardsEn.length = 0;
     this.tariffsService
       .getFilteredCard(filterData)
       .pipe(takeUntil(this.destroy))


### PR DESCRIPTION
1. The filter is not applied for cards filtering after using items "Активно"/"Неактивно"/"Незаповнена" in filter "Стан"
![image](https://user-images.githubusercontent.com/108685196/217642862-06fae730-cd4f-408d-ae9d-ae124b964ca1.png)
