### PR TITLE
bugfix#4989 change automatically payment status

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.ts
@@ -177,6 +177,7 @@ export class UbsAdminOrderPaymentComponent implements OnInit, OnChanges, OnDestr
       .pipe(take(1))
       .subscribe((extraPayment: IPaymentInfoDto | number | null) => {
         if (typeof extraPayment === 'number') {
+          this.recountUnpaidAmount(extraPayment);
           this.paymentsArray = this.paymentsArray.filter((payment) => {
             if (payment.id === extraPayment) {
               this.totalPaid -= payment.amount;
@@ -188,17 +189,16 @@ export class UbsAdminOrderPaymentComponent implements OnInit, OnChanges, OnDestr
         if (extraPayment !== null && typeof extraPayment === 'object') {
           this.preconditionChangePaymentData(extraPayment);
           this.setOverpayment(this.totalPaid - this.actualPrice);
-
-          this.orderService
-            .getOrderInfo(this.orderId)
-            .pipe(takeUntil(this.destroy$))
-            .subscribe((data: IOrderInfo) => {
-              this.paymentUpdate.emit(data.paymentTableInfoDto.paidAmount);
-              const newValue = data.generalOrderInfo.orderPaymentStatus;
-              this.postDataItem(this.orderId, newValue);
-              this.newPaymentStatus.emit(newValue);
-            });
         }
+        this.orderService
+          .getOrderInfo(this.orderId)
+          .pipe(takeUntil(this.destroy$))
+          .subscribe((data: IOrderInfo) => {
+            this.paymentUpdate.emit(data.paymentTableInfoDto.paidAmount);
+            const newValue = data.generalOrderInfo.orderPaymentStatus;
+            this.postDataItem(this.orderId, newValue);
+            this.newPaymentStatus.emit(newValue);
+          });
       });
   }
 


### PR DESCRIPTION
**Before**
The field 'Статус оплати' is not changed automatically from "Оплачено" to "Не оплачено"/"Частково оплачено" after payment deleting in the order
**After**
The field 'Статус оплати' is changed automatically from "Оплачено" to "Не оплачено"/"Частково оплачено" after payment deleting in the order

https://user-images.githubusercontent.com/101433204/214540000-457871c1-45f1-4a58-a1f3-6a0235c21493.mp4

