### PR TITLE
Fixed error with prediction street when user edits address

### DIFF
--- a/src/app/shared/ubs-add-address-pop-up/ubs-add-address-pop-up.component.ts
+++ b/src/app/shared/ubs-add-address-pop-up/ubs-add-address-pop-up.component.ts
@@ -118,8 +118,8 @@ export class UBSAddAddressPopUpComponent implements OnInit, OnDestroy, AfterView
       regionEn: [this.data.edit ? this.data.address.regionEn : this.bigRegionsList[1].regionName, Validators.required],
       city: [this.data.edit ? this.data.address.city : null, Validators.required],
       cityEn: [this.data.edit ? this.data.address.cityEn : null, Validators.required],
-      district: [this.data.edit ? this.data.address.district.split(' ')[0] : '', Validators.required],
-      districtEn: [this.data.edit ? this.data.address.districtEn.split(' ')[0] : '', Validators.required],
+      district: [this.data.edit ? this.data.address.district : '', Validators.required],
+      districtEn: [this.data.edit ? this.data.address.districtEn : '', Validators.required],
       street: [this.data.edit ? this.data.address.street : '', [Validators.required, Validators.minLength(3), Validators.maxLength(120)]],
       streetEn: [
         this.data.edit ? this.data.address.streetEn : '',
@@ -160,6 +160,7 @@ export class UBSAddAddressPopUpComponent implements OnInit, OnDestroy, AfterView
         this.cityPredictionList = null;
       });
 
+    this.isDistrict = this.city.value === 'Київ' ? true : false;
     this.regionsKyiv = this.listOflocations.getRegionsKyiv(this.currentLanguage);
     this.regions = this.listOflocations.getRegions(this.currentLanguage);
   }
@@ -241,7 +242,7 @@ export class UBSAddAddressPopUpComponent implements OnInit, OnDestroy, AfterView
     this.autocompleteService.getPlacePredictions(request, (streetPredictions) => {
       if (!this.isDistrict && streetPredictions) {
         this.streetPredictionList = streetPredictions.filter(
-          (el) => el.description.includes(this.region.value) || el.description.includes(this.regionEn.value)
+          (el) => el.description.includes(this.bigRegionsList[0].regionName) || el.description.includes(this.bigRegionsList[1].regionName)
         );
       } else {
         this.streetPredictionList = streetPredictions;


### PR DESCRIPTION
1. The system does not display the district (issue #5076)
<img width="1023" alt="Знімок екрана 2023-02-08 о 19 45 08" src="https://user-images.githubusercontent.com/108685196/217613176-3d3a8fb0-c883-4a5c-b82c-853b02bf6c89.png">

2. The system displays not correct "list of districts (issue #5078)
<img width="1063" alt="Знімок екрана 2023-02-08 о 19 45 39" src="https://user-images.githubusercontent.com/108685196/217613639-4cb265c4-ee65-4e1f-96a2-eaaa16101275.png">

3. The system does not show suggestions of streets based on the input (issue #5088)
<img width="999" alt="Знімок екрана 2023-02-08 о 19 46 24" src="https://user-images.githubusercontent.com/108685196/217614040-9ae36a29-fed0-4dbc-85bc-30923fa1de79.png">
