### PR TITLE
Bugfix/#4996 reset inputs in order details blocks

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -360,7 +360,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
 
       changedValues.exportDetailsDto = exportDetail1s;
       this.formatExporteValue(changedValues.exportDetailsDto);
-    } /** */
+    }
 
     if (changedValues.orderDetailsForm) {
       changedValues.orderDetailDto = this.formatBagsValue(changedValues.orderDetailsForm);

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -382,6 +382,8 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       const keyUpdateResponsibleEmployeeDto = 'updateResponsibleEmployeeDto';
       changedValues[keyUpdateResponsibleEmployeeDto] = arrEmployees;
       delete changedValues.responsiblePersonsForm;
+    } else {
+      changedValues.responsiblePersonsForm = this.orderForm.get('responsiblePersonsForm').value;
     }
 
     this.addIdForUserAndAdress(changedValues);
@@ -396,6 +398,8 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
         if (response.ok) {
           this.getOrderInfo(this.orderId, true);
           Object.keys(changedValues?.generalOrderInfo).forEach((key: string) => {
+            console.log('key', changedValues.generalOrderInfo[key]);
+
             if (changedValues.generalOrderInfo[key]) {
               this.postDataItem([this.orderId], key, changedValues.generalOrderInfo[key]);
             }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -109,7 +109,6 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
         this.addressInfo = data.addressExportDetailsDto;
         this.paymentInfo = data.paymentTableInfoDto;
         this.exportInfo = data.exportDetailsDto;
-        console.log('exportInfo', this.exportInfo);
         this.responsiblePersonInfo = data.employeePositionDtoRequest;
         this.totalPaid = data.paymentTableInfoDto.paidAmount;
         this.unPaidAmount = data.paymentTableInfoDto.unPaidAmount;
@@ -388,8 +387,6 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
 
     this.addIdForUserAndAdress(changedValues);
 
-    console.log('chbupd', changedValues);
-
     this.orderService
       .updateOrderInfo(this.orderId, this.currentLanguage, changedValues)
       .pipe(takeUntil(this.destroy$))
@@ -398,8 +395,6 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
         if (response.ok) {
           this.getOrderInfo(this.orderId, true);
           Object.keys(changedValues?.generalOrderInfo).forEach((key: string) => {
-            console.log('key', changedValues.generalOrderInfo[key]);
-
             if (changedValues.generalOrderInfo[key]) {
               this.postDataItem([this.orderId], key, changedValues.generalOrderInfo[key]);
             }
@@ -420,10 +415,6 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       if (name && formItem.dirty) {
         changedValues[name] = formItem.value;
       }
-
-      /*if (name?.includes('dateExport')) {
-        console.log(name, ' : ', formItem.value, formItem.dirty, formItem.pristine, formItem.touched);
-      }/** */
     } else {
       for (const formControlName in formItem.controls) {
         if (formItem.controls.hasOwnProperty(formControlName)) {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -109,6 +109,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
         this.addressInfo = data.addressExportDetailsDto;
         this.paymentInfo = data.paymentTableInfoDto;
         this.exportInfo = data.exportDetailsDto;
+        console.log('exportInfo', this.exportInfo);
         this.responsiblePersonInfo = data.employeePositionDtoRequest;
         this.totalPaid = data.paymentTableInfoDto.paidAmount;
         this.unPaidAmount = data.paymentTableInfoDto.unPaidAmount;
@@ -355,7 +356,12 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
 
     if (changedValues.exportDetailsDto) {
       this.formatExporteValue(changedValues.exportDetailsDto);
-    }
+    } else {
+      const exportDetail1s = this.orderForm.get('exportDetailsDto').value;
+
+      changedValues.exportDetailsDto = exportDetail1s;
+      this.formatExporteValue(changedValues.exportDetailsDto);
+    } /** */
 
     if (changedValues.orderDetailsForm) {
       changedValues.orderDetailDto = this.formatBagsValue(changedValues.orderDetailsForm);
@@ -379,6 +385,8 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
     }
 
     this.addIdForUserAndAdress(changedValues);
+
+    console.log('chbupd', changedValues);
 
     this.orderService
       .updateOrderInfo(this.orderId, this.currentLanguage, changedValues)
@@ -408,6 +416,10 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       if (name && formItem.dirty) {
         changedValues[name] = formItem.value;
       }
+
+      /*if (name?.includes('dateExport')) {
+        console.log(name, ' : ', formItem.value, formItem.dirty, formItem.pristine, formItem.touched);
+      }/** */
     } else {
       for (const formControlName in formItem.controls) {
         if (formItem.controls.hasOwnProperty(formControlName)) {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -356,9 +356,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
     if (changedValues.exportDetailsDto) {
       this.formatExporteValue(changedValues.exportDetailsDto);
     } else {
-      const exportDetail1s = this.orderForm.get('exportDetailsDto').value;
-
-      changedValues.exportDetailsDto = exportDetail1s;
+      changedValues.exportDetailsDto = this.orderForm.get('exportDetailsDto').value;
       this.formatExporteValue(changedValues.exportDetailsDto);
     }
 

--- a/src/app/ubs/ubs-admin/services/order.service.ts
+++ b/src/app/ubs/ubs-admin/services/order.service.ts
@@ -74,8 +74,6 @@ export class OrderService {
   }
 
   public updateOrderInfo(orderId: number, lang: string, data: {}) {
-    console.log('data', data);
-
     return this.http.patch(`${this.backend}/management/update-order-page-admin-info/${orderId}?lang=${lang}`, data, {
       observe: 'response'
     });

--- a/src/app/ubs/ubs-admin/services/order.service.ts
+++ b/src/app/ubs/ubs-admin/services/order.service.ts
@@ -74,6 +74,8 @@ export class OrderService {
   }
 
   public updateOrderInfo(orderId: number, lang: string, data: {}) {
+    console.log('data', data);
+
     return this.http.patch(`${this.backend}/management/update-order-page-admin-info/${orderId}?lang=${lang}`, data, {
       observe: 'response'
     });


### PR DESCRIPTION
**Before**
When a user clicks on the dropdown list "Статус замовлення" and chooses order status "Formed", "Canceled" and "Done", the forms "Responsible Persons" and "Export details" aren't reset and  fields exportDetailsDto, responsiblePersonsForm in request don't contain null

**After**
When a user clicks on the dropdown list "Статус замовлення" and chooses order status "Formed", "Canceled" and "Done", the forms "Responsible Persons" and "Export details" are reset and  fields exportDetailsDto, responsiblePersonsForm in request contain null