### PR TITLE
Bugfix/#5059 column exported amount should has value according to status

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -370,11 +370,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       this.formatExporteValue(changedValues.exportDetailsDto);
     } else {
       const exportDetailsDtoValue = this.orderForm.get('exportDetailsDto').value;
-      const validatedValues = Object.values(exportDetailsDtoValue).map((val) => {
-        if (val === ' ') {
-          val = null;
-        }
-      });
+      const validatedValues = Object.values(exportDetailsDtoValue).map((val) => (!val ? null : val));
 
       Object.keys(exportDetailsDtoValue).forEach((key, index) => {
         exportDetailsDtoValue[key] = validatedValues[index];

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Params, Router } from '@angular/router';
 import { formatDate } from '@angular/common';
 import { MatDialog } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
-import { take, takeUntil, map } from 'rxjs/operators';
+import { take, takeUntil } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -371,7 +371,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
     } else {
       const exportDetailsDtoValue = this.orderForm.get('exportDetailsDto').value;
       const validatedValues = Object.values(exportDetailsDtoValue).map((val) => {
-        if (val == ' ') {
+        if (val === ' ') {
           val = null;
         }
       });


### PR DESCRIPTION
**Before**

- The column "Вивезена кількість" doesn't have the value '0' by default when the order status 'Скасовано' on the page "Order"
- When the user changes some value and doesn't change time without value, the request with an empty string is sending

**After**

- The column "Вивезена кількість" has a value '0' by default when the order status 'Скасовано' on the page "Order"
- When the user changes some value and doesn't change time without value, the request with empty object is sending