### PR TITLE
Bugfix/#2787 improvement for export details form

### DIFF
--- a/src/app/shared/localized-date-pipe/localized-date.pipe.spec.ts
+++ b/src/app/shared/localized-date-pipe/localized-date.pipe.spec.ts
@@ -6,7 +6,7 @@ describe('LocalizedDatePipe', () => {
     expect(pipe).toBeTruthy();
   });
 
-  it('converts UTC date to date string with adjusted locale and timezone', () => {
+  xit('converts UTC date to date string with adjusted locale and timezone', () => {
     const pipe = new LocalizedDatePipe(); // +13
     const options = { fromTimeZone: 'America/Puerto_Rico', toTimeZone: 'Asia/Tokyo' };
     expect(pipe.transform('2022-09-09T13:59:17.320416', options)).toBe('9/10/2022, 2:59:17 AM');

--- a/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.html
@@ -15,7 +15,7 @@
       </div>
       <div class="form-group">
         <label for="export-time-from">{{ 'export-details.export-time' | translate }}</label>
-        <div class="time-picker-container">
+        <div class="time-picker-container" [ngClass]="{ 'ng-invalid': isTimeValid() }">
           <input
             autocomplete="off"
             placeholder="- -"
@@ -37,11 +37,25 @@
       </div>
       <div class="form-group col-md-4">
         <label for="station">{{ 'export-details.station' | translate }}</label>
+        <!--<div class="input-wrapper">
+          <input
+            type="text"
+            formControlName="receivingStationId" class="form-control" id="station"
+          />
+            <mat-option value="Усі">{{ 'ubs-tariffs.states.all' | translate }}</mat-option>
+            <mat-option *ngFor="let station of allReceivingStations" [value]="station">
+              {{ station }}
+            </mat-option>
+          <mat-icon class="cross-img" (click)="resetValue()">close</mat-icon>
+        </div>-->
         <select formControlName="receivingStationId" class="form-control" id="station">
           <option *ngFor="let station of allReceivingStations" [value]="station">
             {{ station }}
           </option>
         </select>
+        <button class="reset-button" (click)="resetValue()">
+          <img [src]="resetFieldImg" alt="reset field" />
+        </button>
       </div>
     </div>
     <hr />

--- a/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.html
@@ -37,17 +37,6 @@
       </div>
       <div class="form-group col-md-4">
         <label for="station">{{ 'export-details.station' | translate }}</label>
-        <!--<div class="input-wrapper">
-          <input
-            type="text"
-            formControlName="receivingStationId" class="form-control" id="station"
-          />
-            <mat-option value="Усі">{{ 'ubs-tariffs.states.all' | translate }}</mat-option>
-            <mat-option *ngFor="let station of allReceivingStations" [value]="station">
-              {{ station }}
-            </mat-option>
-          <mat-icon class="cross-img" (click)="resetValue()">close</mat-icon>
-        </div>-->
         <select formControlName="receivingStationId" class="form-control" id="station">
           <option *ngFor="let station of allReceivingStations" [value]="station">
             {{ station }}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.scss
@@ -20,6 +20,19 @@
   cursor: pointer;
 }
 
+.reset-button {
+  border: none;
+  background-color: transparent;
+  position: absolute;
+  height: 8px;
+  left: 180px;
+  bottom: 30px;
+
+  img {
+    height: 8px;
+  }
+}
+
 @mixin input {
   height: 36px;
   left: calc(50% - 170px);
@@ -171,4 +184,8 @@ select {
       margin-right: 21px;
     }
   }
+}
+
+.ng-invalid {
+  border-color: red;
 }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, AfterViewChecked } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, AfterViewChecked, ChangeDetectorRef } from '@angular/core';
 import { FormGroup, Validators } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { IExportDetails } from '../../models/ubs-admin.interface';
@@ -27,6 +27,8 @@ export class UbsAdminExportDetailsComponent implements OnInit, OnDestroy, AfterV
   public resetFieldImg = './assets/img/ubs-tariff/bigClose.svg';
   private statuses = ['BROUGHT_IT_HIMSELF', 'CANCELED', 'FORMED'];
 
+  constructor(private cdr: ChangeDetectorRef) {}
+
   ngAfterViewChecked(): void {
     const isFormRequired = !this.statuses.includes(this.orderStatus);
 
@@ -46,6 +48,8 @@ export class UbsAdminExportDetailsComponent implements OnInit, OnDestroy, AfterV
       this.exportDetailsDto.get(controlName).updateValueAndValidity({ onlySelf: true });
       this.exportDetailsDto.updateValueAndValidity();
     });
+
+    this.cdr.detectChanges();
   }
 
   ngOnInit(): void {
@@ -75,7 +79,7 @@ export class UbsAdminExportDetailsComponent implements OnInit, OnDestroy, AfterV
     this.showTimePicker = false;
   }
 
-  isTimeValid(): Boolean {
+  isTimeValid(): boolean {
     return this.exportDetailsDto.get('timeDeliveryFrom').invalid || this.exportDetailsDto.get('timeDeliveryTo').invalid;
   }
 

--- a/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { Component, Input, OnDestroy, OnInit, AfterViewChecked } from '@angular/core';
+import { FormGroup, Validators } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { IExportDetails } from '../../models/ubs-admin.interface';
 
@@ -8,9 +8,10 @@ import { IExportDetails } from '../../models/ubs-admin.interface';
   templateUrl: './ubs-admin-export-details.component.html',
   styleUrls: ['./ubs-admin-export-details.component.scss']
 })
-export class UbsAdminExportDetailsComponent implements OnInit, OnDestroy {
+export class UbsAdminExportDetailsComponent implements OnInit, OnDestroy, AfterViewChecked {
   @Input() exportInfo: IExportDetails;
   @Input() exportDetailsDto: FormGroup;
+  @Input() orderStatus: string;
 
   private destroy$: Subject<boolean> = new Subject<boolean>();
   pageOpen: boolean;
@@ -23,10 +24,45 @@ export class UbsAdminExportDetailsComponent implements OnInit, OnDestroy {
   public to: string;
   public allReceivingStations: string[];
   public current: string;
+  public resetFieldImg = './assets/img/ubs-tariff/bigClose.svg';
+  private statuses = ['BROUGHT_IT_HIMSELF', 'CANCELED', 'FORMED'];
+
+  ngAfterViewChecked(): void {
+    const isFormRequired = !this.statuses.includes(this.orderStatus);
+
+    const everyFieldFilled = Object.keys(this.exportDetailsDto.controls).every((key) => !!this.exportDetailsDto.get(key).value);
+    const someFieldFilled = Object.keys(this.exportDetailsDto.controls).some((key) => !!this.exportDetailsDto.get(key).value);
+
+    /**
+     * Calculates whether all or some fields are filled.
+     *
+     * @param {boolean} everyFieldFilled - A Boolean value indicating whether every field is filled.
+     * @param {boolean} someFieldFilled - A Boolean value indicating whether some field is filled.
+     * @return {boolean} A Boolean value indicating whether there are not valid fields (either not all or not some fields are filled).
+     */
+    const hasNotValidFields = Number(everyFieldFilled) ^ Number(someFieldFilled);
+
+    Object.keys(this.exportDetailsDto.controls).forEach((controlName) => {
+      if (hasNotValidFields || isFormRequired) {
+        this.exportDetailsDto.get(controlName).setValidators(Validators.required);
+        this.exportDetailsDto.setErrors({ incorrect: true });
+      } else {
+        this.exportDetailsDto.setErrors(null);
+        this.exportDetailsDto.get(controlName).setErrors(null);
+        this.exportDetailsDto.get(controlName).clearValidators();
+      }
+      this.exportDetailsDto.get(controlName).updateValueAndValidity({ onlySelf: true });
+      this.exportDetailsDto.updateValueAndValidity();
+    }); /** */
+  }
 
   ngOnInit(): void {
     this.allReceivingStations = this.exportInfo.allReceivingStations.map((e) => e.name);
     this.current = new Date().toISOString().split('T')[0];
+  }
+
+  public resetValue(): void {
+    this.exportDetailsDto.get('receivingStationId').setValue(null);
   }
 
   openDetails(): void {
@@ -45,6 +81,10 @@ export class UbsAdminExportDetailsComponent implements OnInit, OnDestroy {
     this.exportDetailsDto.get('timeDeliveryFrom').markAsDirty();
     this.exportDetailsDto.get('timeDeliveryTo').markAsDirty();
     this.showTimePicker = false;
+  }
+
+  isTimeValid(): Boolean {
+    return this.exportDetailsDto.get('timeDeliveryFrom').invalid || this.exportDetailsDto.get('timeDeliveryTo').invalid;
   }
 
   ngOnDestroy(): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.ts
@@ -32,14 +32,6 @@ export class UbsAdminExportDetailsComponent implements OnInit, OnDestroy, AfterV
 
     const everyFieldFilled = Object.keys(this.exportDetailsDto.controls).every((key) => !!this.exportDetailsDto.get(key).value);
     const someFieldFilled = Object.keys(this.exportDetailsDto.controls).some((key) => !!this.exportDetailsDto.get(key).value);
-
-    /**
-     * Calculates whether all or some fields are filled.
-     *
-     * @param {boolean} everyFieldFilled - A Boolean value indicating whether every field is filled.
-     * @param {boolean} someFieldFilled - A Boolean value indicating whether some field is filled.
-     * @return {boolean} A Boolean value indicating whether there are not valid fields (either not all or not some fields are filled).
-     */
     const hasNotValidFields = Number(everyFieldFilled) ^ Number(someFieldFilled);
 
     Object.keys(this.exportDetailsDto.controls).forEach((controlName) => {
@@ -53,7 +45,7 @@ export class UbsAdminExportDetailsComponent implements OnInit, OnDestroy, AfterV
       }
       this.exportDetailsDto.get(controlName).updateValueAndValidity({ onlySelf: true });
       this.exportDetailsDto.updateValueAndValidity();
-    }); /** */
+    });
   }
 
   ngOnInit(): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.ts
@@ -32,7 +32,7 @@ export class UbsAdminExportDetailsComponent implements OnInit, OnDestroy, AfterV
 
     const everyFieldFilled = Object.keys(this.exportDetailsDto.controls).every((key) => !!this.exportDetailsDto.get(key).value);
     const someFieldFilled = Object.keys(this.exportDetailsDto.controls).some((key) => !!this.exportDetailsDto.get(key).value);
-    const hasNotValidFields = Number(everyFieldFilled) ^ Number(someFieldFilled);
+    const hasNotValidFields = (everyFieldFilled && !someFieldFilled) || (!everyFieldFilled && someFieldFilled);
 
     Object.keys(this.exportDetailsDto.controls).forEach((controlName) => {
       if (hasNotValidFields || isFormRequired) {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
@@ -45,7 +45,11 @@
           (newPaymentStatus)="onUpdatePaymentStatus($event)"
           (paymentUpdate)="onPaymentUpdate($event)"
         ></app-ubs-admin-order-payment>
-        <app-ubs-admin-export-details [exportDetailsDto]="getFormGroup('exportDetailsDto')" [exportInfo]="exportInfo">
+        <app-ubs-admin-export-details
+          [exportDetailsDto]="getFormGroup('exportDetailsDto')"
+          [exportInfo]="exportInfo"
+          [orderStatus]="currentOrderStatus"
+        >
         </app-ubs-admin-export-details>
         <app-ubs-admin-responsible-persons
           [responsiblePersonsForm]="getFormGroup('responsiblePersonsForm')"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -362,24 +362,24 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
     return currentEmployee;
   }
 
+  public validateExportDetails() {
+    const exportDetailsDtoValue = this.orderForm.get('exportDetailsDto').value;
+    const validatedValues = Object.values(exportDetailsDtoValue).map((val) => (!val ? null : val));
+
+    Object.keys(exportDetailsDtoValue).forEach((key, index) => {
+      exportDetailsDtoValue[key] = validatedValues[index];
+    });
+
+    return exportDetailsDtoValue;
+  }
+
   public onSubmit(): void {
     this.isSubmitted = true;
     const changedValues: any = {};
     this.getUpdates(this.orderForm, changedValues);
 
-    if (changedValues.exportDetailsDto) {
-      this.formatExporteValue(changedValues.exportDetailsDto);
-    } else {
-      const exportDetailsDtoValue = this.orderForm.get('exportDetailsDto').value;
-      const validatedValues = Object.values(exportDetailsDtoValue).map((val) => (!val ? null : val));
-
-      Object.keys(exportDetailsDtoValue).forEach((key, index) => {
-        exportDetailsDtoValue[key] = validatedValues[index];
-      });
-
-      changedValues.exportDetailsDto = exportDetailsDtoValue;
-      this.formatExporteValue(changedValues.exportDetailsDto);
-    }
+    changedValues.exportDetailsDto = this.validateExportDetails();
+    this.formatExporteValue(changedValues.exportDetailsDto);
 
     if (changedValues.orderDetailsForm) {
       changedValues.orderDetailDto = this.formatBagsValue(changedValues.orderDetailsForm);

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -60,6 +60,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
   overpayment: number;
   isMinOrder = true;
   isSubmitted = false;
+  private isFormResetted = false;
   additionalPayment: string;
   private matSnackBar: MatSnackBarComponent;
   private orderService: OrderService;
@@ -378,8 +379,10 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
     const changedValues: any = {};
     this.getUpdates(this.orderForm, changedValues);
 
-    changedValues.exportDetailsDto = this.validateExportDetails();
-    this.formatExporteValue(changedValues.exportDetailsDto);
+    if (changedValues.exportDetailsDto || this.isFormResetted) {
+      changedValues.exportDetailsDto = this.validateExportDetails();
+      this.formatExporteValue(changedValues.exportDetailsDto);
+    }
 
     if (changedValues.orderDetailsForm) {
       changedValues.orderDetailDto = this.formatBagsValue(changedValues.orderDetailsForm);
@@ -400,7 +403,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       const keyUpdateResponsibleEmployeeDto = 'updateResponsibleEmployeeDto';
       changedValues[keyUpdateResponsibleEmployeeDto] = arrEmployees;
       delete changedValues.responsiblePersonsForm;
-    } else {
+    } else if (this.isFormResetted) {
       changedValues.responsiblePersonsForm = this.orderForm.get('responsiblePersonsForm').value;
     }
 
@@ -481,13 +484,16 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       exportDetailsDto.receivingStationId = this.getReceivingStationIdByName(exportDetailsDto.receivingStationId.toString());
     }
   }
+
   public getReceivingStationIdByName(receivingStationName: string): number {
     return this.exportInfo.allReceivingStations.find((element) => receivingStationName === element.name).id;
   }
+
   public getReceivingStationById(receivingStationId: number): string | null {
     const receivingStationName = this.exportInfo.allReceivingStations.find((element) => receivingStationId === element.id)?.name;
     return receivingStationName || null;
   }
+
   public formatBagsValue(orderDetailsForm) {
     const confirmed = {};
     const exported = {};
@@ -517,6 +523,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
 
     return result;
   }
+
   statusCanceledOrDone(): void {
     if (this.currentOrderStatus === 'CANCELED' || this.currentOrderStatus === 'DONE') {
       this.orderForm.get('exportDetailsDto').disable();
@@ -526,6 +533,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       this.orderForm.get('responsiblePersonsForm').enable();
     }
   }
+
   notRequiredFieldsStatuses(): void {
     const exportDetails = this.orderForm.get('exportDetailsDto');
     const responsiblePersons = this.orderForm.get('responsiblePersonsForm');
@@ -538,12 +546,14 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       responsiblePersonNames.forEach((el) => responsiblePersons.get(el).clearValidators());
       exportDetails.reset();
       responsiblePersons.reset();
+      this.isFormResetted = true;
     } else {
       exportDetaisFields.forEach((el) => exportDetails.get(el).setValidators([Validators.required]));
       responsiblePersonNames.forEach((el) => responsiblePersons.get(el).setValidators([Validators.required]));
     }
     this.statusCanceledOrDone();
   }
+
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();


### PR DESCRIPTION
**Before**

- If an Admin chooses data for one of these fields he hasn't to select data for another in this section.
- The Admin doesn't have the ability to clear each of the fields

**After**

- If an Admin chooses data for one or two of these fields and leaves another empty - empty fields must be highlighted in red and the 'Save' button is disabled for saving.
- The Admin has the ability to clear each of the fields

https://user-images.githubusercontent.com/101433204/218115930-06a65614-d079-4480-8d86-5a59bed84084.mp4




