### PR TITLE
Bugfix/#5061 field ubs courier for order details

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.html
@@ -108,17 +108,19 @@
           <li class="d-flex justify-content-between align-items-baseline py-2" *ngIf="doneAfterBroughtHimself">
             <span class="col-sm-2">{{ 'order-details.done-after-himself' | translate }}</span>
             <div class="col-sm-2 offset-sm-8 d-flex justify-content-center align-items-baseline form-group count">
-              <input
-                class="shadow-none form-control input p-2 ubs-courier"
-                type="number"
-                step="0.01"
-                min="0"
-                value="0.00"
-                (change)="changeWriteOffSum($event)"
-              />
-              <span>
-                {{ '' | localizedCurrency }}
-              </span>
+              <div class="d-flex align-items-baseline ubs-courier-container">
+                <input
+                  class="shadow-none form-control input p-2 ubs-courier"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value="0.00"
+                  (change)="changeWriteOffSum($event)"
+                />
+                <span>
+                  {{ '' | localizedCurrency }}
+                </span>
+              </div>
             </div>
           </li>
           <li class="d-flex justify-content-between align-items-baseline py-3">

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.html
@@ -91,17 +91,18 @@
             <span class="col-sm-2">{{ 'order-details.ubs-courier' | translate }}</span>
             <div class="col-sm-2 offset-sm-8 d-flex justify-content-center align-items-baseline form-group count">
               <span *ngIf="doneAfterBroughtHimself"> - </span>
-              <input
-                class="shadow-none form-control input p-2 ubs-courier"
-                type="number"
-                step="0.01"
-                min="0"
-                [value]="courierPrice | currency"
-                (change)="changeWriteOffSum($event)"
-              />
-              <span>
-                {{ '' | localizedCurrency }}
-              </span>
+              <div class="d-flex align-items-baseline ubs-courier-container">
+                <input
+                  class="shadow-none form-control input p-2 ubs-courier"
+                  type="number"
+                  min="0"
+                  [value]="courierPrice | currency"
+                  (change)="changeWriteOffSum($event)"
+                />
+                <span>
+                  {{ '' | localizedCurrency }}
+                </span>
+              </div>
             </div>
           </li>
           <li class="d-flex justify-content-between align-items-baseline py-2" *ngIf="doneAfterBroughtHimself">

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.scss
@@ -68,15 +68,30 @@
   padding-left: 72px;
 }
 
-.ubs-courier {
-  border: 1px solid var(--ubs-primary-light-grey);
-  box-sizing: border-box;
+.ubs-courier-container {
+  width: 100px;
+  margin-right: 25px;
   border-radius: 4px;
-  padding: 7px;
-  height: 36px;
-  width: 90px;
-  font-size: 16px;
-  text-align: center;
+  border: 1px solid var(--ubs-quintynary-light-grey);
+
+  .ubs-courier {
+    border: none;
+    box-sizing: border-box;
+    font-size: 16px;
+    text-align: center;
+
+    -moz-appearance: textfield;
+
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      display: none;
+      margin: 0;
+    }
+  }
+
+  span {
+    height: 26px;
+  }
 }
 
 .shop-numbers {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.scss
@@ -79,7 +79,6 @@
     box-sizing: border-box;
     font-size: 16px;
     text-align: center;
-
     -moz-appearance: textfield;
 
     &::-webkit-outer-spin-button,

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.ts
@@ -60,6 +60,11 @@ export class UbsAdminOrderDetailsFormComponent implements OnInit, OnChanges {
     } else {
       this.doneAfterBroughtHimself = false;
     }
+
+    if (changes.orderStatusInfo?.currentValue.key === 'NOT_TAKEN_OUT') {
+      this.isVisible = true;
+      this.showUbsCourier = true;
+    }
   }
 
   ngOnInit(): void {

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -193,7 +193,9 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
   }
 
   private setCurrentLocation(currentLanguage: string): void {
-    this.currentLocation = currentLanguage === 'en' ? this.locations?.regionDto.nameEn : this.locations?.regionDto.nameUk;
+    const currentLocationEn = `${this.locations?.locationsDtosList[0].nameEn}, ${this.locations?.regionDto.nameEn}`;
+    const currentLocationUk = `${this.locations?.locationsDtosList[0].nameUk}, ${this.locations?.regionDto.nameUk}`;
+    this.currentLocation = currentLanguage === 'en' ? currentLocationEn : currentLocationUk;
   }
 
   getFormValues(): boolean {

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -195,7 +195,7 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
   private setCurrentLocation(currentLanguage: string): void {
     const currentLocationEn = `${this.locations?.locationsDtosList[0].nameEn}, ${this.locations?.regionDto.nameEn}`;
     const currentLocationUk = `${this.locations?.locationsDtosList[0].nameUk}, ${this.locations?.regionDto.nameUk}`;
-    this.currentLocation = currentLanguage === 'en' ? currentLocationEn : currentLocationUk;
+    this.currentLocation = this.getLangValue(currentLocationUk, currentLocationEn);
   }
 
   getFormValues(): boolean {

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-location-popup/ubs-order-location-popup.component.html
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-location-popup/ubs-order-location-popup.component.html
@@ -29,7 +29,7 @@
     <app-spinner class="mx-auto"></app-spinner>
   </ng-template>
   <mat-dialog-actions class="footer-btns" align="end">
-    <button class="btn secondaryButton secondary-global-button" mat-dialog-close>
+    <button class="btn secondaryButton secondary-global-button" mat-dialog-close (click)="redirectToUbsPage()">
       {{ 'order-details.location.btn.back' | translate }}
     </button>
     <button


### PR DESCRIPTION
**Before**
The field 'UBS-courier' isn't displayed when the order status 'Cкасовано' of the page 'Order'

**After**
The field 'UBS-courier' is displayed when the order status 'Cкасовано' of the page 'Order'
![image](https://user-images.githubusercontent.com/101433204/218687669-7e41ea97-5fcc-4551-90c7-86805af2e8c6.png)
