### PR TITLE
bugfix/#5250 - registration dialog - added trim method for inputs values

### DIFF
--- a/src/app/main/component/auth/components/sign-up/sign-up.component.html
+++ b/src/app/main/component/auth/components/sign-up/sign-up.component.html
@@ -15,6 +15,7 @@
     name="email"
     required
     formControlName="email"
+    (focusout)="trimValue(emailControl)"
     (input)="setEmailBackendErr()"
     [ngClass]="emailClassCheck()"
     tabindex="0"
@@ -35,6 +36,7 @@
     name="firstName"
     required
     formControlName="firstName"
+    (focusout)="trimValue(firstNameControl)"
     (input)="setEmailBackendErr()"
     [ngClass]="firstNameClassCheck()"
     tabindex="0"
@@ -58,6 +60,7 @@
       formControlName="password"
       id="password"
       name="form-control password"
+      (focusout)="trimValue(passwordControl)"
       (input)="setEmailBackendErr()"
       tabindex="0"
     />
@@ -93,6 +96,7 @@
       formControlName="repeatPassword"
       id="repeatPassword"
       name="form-control password-confirm"
+      (focusout)="trimValue(passwordControlConfirm)"
       (input)="setEmailBackendErr()"
       tabindex="0"
     />

--- a/src/app/main/component/auth/components/sign-up/sign-up.component.spec.ts
+++ b/src/app/main/component/auth/components/sign-up/sign-up.component.spec.ts
@@ -234,6 +234,13 @@ describe('SignUpComponent', () => {
 
     validPassword.forEach((el) => controlsValidator(el, 'password', 'valid'));
 
+    it('should trim value', () => {
+      const emailControl = component.signUpForm.get('email');
+      emailControl.setValue('    1qQ@');
+      component.trimValue(emailControl);
+      expect(emailControl.value).toBe('1qQ@');
+    });
+
     it('form should be invalid passwords not matching', () => {
       const passwordControl = component.signUpForm.get('password');
       passwordControl.setValue('123456qQ@');

--- a/src/app/main/component/auth/components/sign-up/sign-up.component.ts
+++ b/src/app/main/component/auth/components/sign-up/sign-up.component.ts
@@ -158,6 +158,10 @@ export class SignUpComponent implements OnInit, OnDestroy, OnChanges {
     this.passwordControlConfirm = this.signUpForm.get('repeatPassword');
   }
 
+  public trimValue(control: AbstractControl): void {
+    control.setValue(control.value.trim());
+  }
+
   private setNullAllMessage(): void {
     this.firstNameErrorMessageBackEnd = null;
     this.emailErrorMessageBackEnd = null;


### PR DESCRIPTION
Sign up - Added method that will remove whitespaces from start and the end of the words after unfocus input