### PR TITLE
bugfix/#5156-Change pattern for adding certificate

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-certificate/ubs-admin-certificate-add-certificate-pop-up/ubs-admin-certificate-add-certificate-pop-up.component.ts
@@ -37,7 +37,12 @@ export class UbsAdminCertificateAddCertificatePopUpComponent implements OnInit, 
     this.addCertificateForm = this.fb.group({
       code: new FormControl('', [Validators.required, Validators.pattern(this.certificatePattern)]),
       monthCount: new FormControl('', [Validators.required, Validators.pattern(Patterns.sertificateMonthCount)]),
-      initialPointsValue: new FormControl('', [Validators.required, Validators.pattern(Patterns.sertificateInitialValue)])
+      initialPointsValue: new FormControl('', [
+        Validators.required,
+        Validators.pattern(Patterns.sertificateInitialValue),
+        Validators.min(0),
+        Validators.max(9999.99)
+      ])
     });
   }
 

--- a/src/assets/patterns/patterns.ts
+++ b/src/assets/patterns/patterns.ts
@@ -20,7 +20,7 @@ export const Patterns = {
 
   paymantAmountPattern: '^[0-9]+$',
   sertificateMonthCount: '^[0-9]{1,2}$',
-  sertificateInitialValue: '^[0-9]{2,4}$',
+  sertificateInitialValue: /^\d*[.,]?\d{1,2}$/,
 
   ubsPrice: '[0-9]{1,3}',
   ubsServicePrice: /^\d*[.,]?\d{0,2}$/,


### PR DESCRIPTION
Before:

In the Super Admin profile in the 'Certificates' item, after click on the 'Add certificate' bttn, fill up the third field 'Знижка' of the pop-up 'Додати сертифікат' with float data (e.g. 1000.00 or 1000,00), the field highlighted in red.

After:

The field 'Знижка' of the pop-up 'Додати сертифікат' accepts integer or float numbers.

https://user-images.githubusercontent.com/60553157/219054898-aa402e43-b8f4-4f36-bc81-a7afc3eb5568.mp4
