### PR TITLE
bugfix/#5220,#5184,#5225-Added changes of styles and texts at pop-ups

### DIFF
--- a/src/app/main/component/auth/components/sign-up/sign-up.component.scss
+++ b/src/app/main/component/auth/components/sign-up/sign-up.component.scss
@@ -42,14 +42,14 @@
 
   .content-label {
     margin: 20px 0 4px;
-    font-size: 12px;
+    font-size: 16px;
     font-family: var(--primary-font);
     line-height: 14px;
     color: var(--primary-dark-grey);
   }
 
   .under-error {
-    margin: 9px 0 4px;
+    margin: 20px 0 4px;
   }
 
   .main-data-input,

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.html
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.html
@@ -55,7 +55,7 @@
       <small class="text-danger" *ngIf="certificates.status[i] === 'EXPIRED' && certificates.failed[i]">
         {{ 'order-details.expired' | translate: { certDate: certificates.expirationDates[i] } }}
       </small>
-      <small class="text-message" *ngIf="showActivateCetificate([i])">
+      <small class="text-message" *ngIf="showActivateCetificate(i)">
         {{ 'order-details.activated' | translate: { certificateSum: certificates.points[i], certDate: certificates.expirationDates[i] } }}
       </small>
       <small class="text-message" *ngIf="certSize && certificateSum > showTotal && i === certificates.codes.length - 1">

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.html
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.html
@@ -55,7 +55,7 @@
       <small class="text-danger" *ngIf="certificates.status[i] === 'EXPIRED' && certificates.failed[i]">
         {{ 'order-details.expired' | translate: { certDate: certificates.expirationDates[i] } }}
       </small>
-      <small class="text-message" *ngIf="certificates.expirationDates[i] && certSize && !certificates.failed[i]">
+      <small class="text-message" *ngIf="showActivateCetificate([i])">
         {{ 'order-details.activated' | translate: { certificateSum: certificates.points[i], certDate: certificates.expirationDates[i] } }}
       </small>
       <small class="text-message" *ngIf="certSize && certificateSum > showTotal && i === certificates.codes.length - 1">

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -396,7 +396,7 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
       this.clickOnNo = false;
     }
   }
-  public showActivateCetificate([i]): boolean {
+  public showActivateCetificate(i: number): boolean {
     if (this.certificates.expirationDates[i] && this.certSize && !this.certificates.failed[i] && this.certificateSum < this.showTotal) {
       return true;
     }

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -397,10 +397,12 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
     }
   }
   public showActivateCetificate(i: number): boolean {
-    if (this.certificates.expirationDates[i] && this.certSize && !this.certificates.failed[i] && this.certificateSum < this.showTotal) {
-      return true;
-    }
-    return false;
+    const isCertificateExpired = !!this.certificates.expirationDates[i];
+    const isCertSize = !!this.certSize;
+    const isCertNotFailed = !this.certificates.failed[i];
+    const isShowTotal = this.certificateSum < this.showTotal;
+
+    return isCertificateExpired && isCertSize && isCertNotFailed && isShowTotal;
   }
 
   ngOnDestroy() {

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -396,6 +396,11 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
       this.clickOnNo = false;
     }
   }
+  public showActivateCetificate([i]) {
+    if (this.certificates.expirationDates[i] && this.certSize && !this.certificates.failed[i] && this.certificateSum < this.showTotal) {
+      return true;
+    }
+  }
 
   ngOnDestroy() {
     this.destroy.next();

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -396,10 +396,11 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
       this.clickOnNo = false;
     }
   }
-  public showActivateCetificate([i]) {
+  public showActivateCetificate([i]): boolean {
     if (this.certificates.expirationDates[i] && this.certSize && !this.certificates.failed[i] && this.certificateSum < this.showTotal) {
       return true;
     }
+    return false;
   }
 
   ngOnDestroy() {

--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -391,7 +391,7 @@
     "driver": "Driver"
   },
   "cancel-modal": {
-    "question": "If you will cancel this order it will be deleted. Do you really want to cancel this order?",
+    "question": "If you cancel the changes, they will be deleted. Are you sure you want to cancel the changes?",
     "disagree": "No",
     "agree": "Yes"
   },


### PR DESCRIPTION
Before:
#5220 - font-size of labels 12px.
#5184 -The message "Сертифікат на суму 1000 грн активовано. Строк дії сертифікату - до 03.05.2023 Сертифікат на суму 1000.00 грн активовано, що перевищує суму вашого замовлення. Залишок у розмірі 65.00 грн не повертається. Строк дії сертифікату - до 03.05.2023" is displayed when user activates certificate with discount is greater than order sum on the page 'Order form'.
#5225 - The pop-up contains incorrect text in En localization: " If you will cancel this order it will be deleted. Do you really want to cancel this order?"

After: 
#5220 - font-size of labels 16px.
#5184 -now message display "Сертифікат на суму 1000.00 грн активовано, що перевищує суму вашого замовлення. Залишок у розмірі 65.00 грн не повертається. Строк дії сертифікату - до 03.05.2023" should be displayed when user activates certificate with discount is greater than order sum on the page 'Order form'.
#5225 - now the pop-up contains correct text :“If you cancel the changes, they will be deleted. Are you sure you want to cancel the changes?”
