### PR TITLE
Bugfix/#5151 saving order without payment

### DIFF
--- a/src/app/main/component/shared/components/form-base/form-base.component.ts
+++ b/src/app/main/component/shared/components/form-base/form-base.component.ts
@@ -80,6 +80,7 @@ export class FormBaseComponent implements ComponentCanDeactivate {
             this.areChangesSaved = true;
           }
           if (confirm && isUbsOrderSubmit) {
+            this.orderService.saveOrderData();
             this.router.navigate(['ubs', 'confirm']);
           }
           if (confirm && !isUbsOrderSubmit && isUBS) {

--- a/src/app/main/component/shared/components/warning-pop-up/warning-pop-up.component.spec.ts
+++ b/src/app/main/component/shared/components/warning-pop-up/warning-pop-up.component.spec.ts
@@ -93,7 +93,7 @@ describe('WarningPopUpComponent', () => {
       const spyTransferOrderId = spyOn(component.ubsOrderFormService, 'transferOrderId');
       const spySetOrderResponseErrorStatus = spyOn(component.ubsOrderFormService, 'setOrderResponseErrorStatus');
       const localStorageService = 'localStorageService';
-      const removeUbsOrderIdMock = spyOn(component[localStorageService], 'removeUbsOrderId');
+      const removeUbsOrderIdMock = spyOn(component[localStorageService], 'removeUbsLiqPayOrderId');
       const removeUbsFondyOrderIdMock = spyOn(component[localStorageService], 'removeUbsFondyOrderId');
       component.userReply(true);
       expect(spyChangeShouldBePaid).toHaveBeenCalled();

--- a/src/app/main/component/shared/components/warning-pop-up/warning-pop-up.component.ts
+++ b/src/app/main/component/shared/components/warning-pop-up/warning-pop-up.component.ts
@@ -69,7 +69,7 @@ export class WarningPopUpComponent implements OnInit, OnDestroy {
             this.ubsOrderFormService.transferOrderId(orderId);
             this.ubsOrderFormService.setOrderResponseErrorStatus(orderId ? false : true);
             this.localStorageService.removeUbsFondyOrderId();
-            this.localStorageService.removeUbsOrderId();
+            this.localStorageService.removeUbsLiqPayOrderId();
             this.matDialogRef.close(reply);
             this.isLoading = false;
           },

--- a/src/app/main/service/localstorage/local-storage.service.spec.ts
+++ b/src/app/main/service/localstorage/local-storage.service.spec.ts
@@ -4,7 +4,7 @@ import { LocalStorageService } from './local-storage.service';
 import { Subject } from 'rxjs';
 import { EventPageResponceDto } from '../../component/events/models/events.interface';
 
-fdescribe('LocalStorageService', () => {
+describe('LocalStorageService', () => {
   let service: LocalStorageService;
   const ACCESS_TOKEN = 'accessToken';
 

--- a/src/app/main/service/localstorage/local-storage.service.spec.ts
+++ b/src/app/main/service/localstorage/local-storage.service.spec.ts
@@ -1,12 +1,610 @@
 import { TestBed } from '@angular/core/testing';
-
+import { TranslateModule } from '@ngx-translate/core';
 import { LocalStorageService } from './local-storage.service';
+import { Subject } from 'rxjs';
+import { EventPageResponceDto } from '../../component/events/models/events.interface';
 
-describe('LocalStorageService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+fdescribe('LocalStorageService', () => {
+  let service: LocalStorageService;
+  const ACCESS_TOKEN = 'accessToken';
+
+  const mockEvent: EventPageResponceDto = {
+    additionalImages: ['image1.jpg', 'image2.jpg'],
+    dates: [
+      {
+        coordinates: {
+          addressEn: 'address',
+          addressUa: 'адреса',
+          latitude: 0,
+          longitude: 0
+        },
+        event: 'event',
+        finishDate: 'finishDate',
+        id: 3,
+        onlineLink: 'link',
+        startDate: '2022-02-01T00:00:00Z'
+      }
+    ],
+    description: 'Test event description',
+    id: 123,
+    open: true,
+    organizer: {
+      id: 456,
+      name: 'Test organizer',
+      organizerRating: 4.5
+    },
+    tags: [{ id: 789, nameUa: 'Test tag UA', nameEn: 'Test tag EN' }],
+    title: 'Test event title',
+    titleImage: 'testImage.jpg',
+    isSubscribed: true
+  };
+
+  const fakeLanguageSubject: Subject<string> = new Subject<string>();
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()]
+    });
+    service = TestBed.inject(LocalStorageService);
+    service.languageSubject = fakeLanguageSubject;
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
 
   it('should be created', () => {
-    const service: LocalStorageService = TestBed.inject(LocalStorageService);
     expect(service).toBeTruthy();
+  });
+
+  describe('setUbsOrderId and getUbsOrderId', () => {
+    it('should set the orderId to localStorage', () => {
+      const orderId = '12345';
+      service.setUbsOrderId(orderId);
+      expect(localStorage.getItem('UbsOrderId')).toEqual(JSON.stringify(orderId));
+    });
+
+    it('should accept a number as an argument', () => {
+      const orderId = 12345;
+      service.setUbsOrderId(orderId);
+      expect(localStorage.getItem('UbsOrderId')).toEqual(JSON.stringify(orderId));
+    });
+
+    it('should return false if UbsOrderId is undefined', () => {
+      localStorage.removeItem('UbsOrderId');
+      expect(service.getUbsOrderId()).toBeFalsy();
+    });
+
+    it('should return the stored value if UbsOrderId is defined', () => {
+      const orderId = '12345';
+      localStorage.setItem('UbsOrderId', JSON.stringify(orderId));
+      expect(service.getUbsOrderId()).toEqual(JSON.parse(localStorage.getItem('UbsOrderId')));
+    });
+  });
+
+  it('should set and get habits gallery view', () => {
+    service.setHabitsGalleryView(true);
+    expect(service.getHabitsGalleryView()).toBeTruthy();
+
+    service.setHabitsGalleryView(false);
+    expect(service.getHabitsGalleryView()).toBeFalsy();
+  });
+
+  it('should get access token', () => {
+    const token = '12345';
+    localStorage.setItem(ACCESS_TOKEN, token);
+    expect(service.getAccessToken()).toEqual(token);
+  });
+
+  describe('setEditMode and getEditMode', () => {
+    it('should set and get edit mode', () => {
+      const key = 'testKey';
+      service.setEditMode(key, true);
+      expect(localStorage.getItem(key)).toEqual('true');
+      service.setEditMode(key, false);
+      expect(localStorage.getItem(key)).toEqual('false');
+      localStorage.removeItem(key);
+      expect(service.getEditMode()).toBeFalsy();
+    });
+  });
+
+  describe('setCurentPage', () => {
+    it('should set the current page in localStorage', () => {
+      const key = 'CURRENT_PAGE';
+      const pageName = 'about';
+      service.setCurentPage(key, pageName);
+      expect(localStorage.getItem(key)).toBe(pageName);
+    });
+  });
+
+  describe('setAccessToken', () => {
+    it('should set access token in localStorage and remove UBS registration', () => {
+      const accessTokenKey = 'ACCESS_TOKEN';
+      const accessTokenValue = 'abc123';
+      const ubsRegistrationKey = 'UBS_REGISTRATION';
+      localStorage.setItem(accessTokenKey, accessTokenValue);
+      service.setAccessToken(accessTokenValue);
+      expect(localStorage.getItem(accessTokenKey)).toBe(accessTokenValue);
+      expect(localStorage.getItem(ubsRegistrationKey)).toBeNull();
+    });
+  });
+
+  describe('setRefreshToken', () => {
+    it('should set the refresh token in local storage', () => {
+      const refreshToken = '12345';
+      const localStorageSpy = spyOn(localStorage, 'setItem');
+      service.setRefreshToken(refreshToken);
+      expect(localStorageSpy).toHaveBeenCalledWith('refreshToken', refreshToken);
+    });
+  });
+
+  describe('setUserId', () => {
+    it('should set the user id in local storage and update the behaviour subject', () => {
+      const userId = 1;
+      const localStorageSpy = spyOn(localStorage, 'setItem');
+      service.setUserId(userId);
+      expect(localStorageSpy).toHaveBeenCalledWith('userId', String(userId));
+    });
+  });
+
+  describe('setFirstName', () => {
+    it('should set the first name in local storage and update the behaviour subject', () => {
+      const name = 'John';
+      const localStorageSpy = spyOn(localStorage, 'setItem');
+      service.setFirstName(name);
+      expect(localStorageSpy).toHaveBeenCalledWith('name', name);
+    });
+  });
+
+  describe('setFirstSignIn/unsetFirstSignIn', () => {
+    it('should set firstSignIn in local storage to true', () => {
+      service.setFirstSignIn();
+      expect(localStorage.getItem('firstSignIn')).toEqual('true');
+    });
+
+    it('should unset firstSignIn in local storage to false', () => {
+      localStorage.setItem('firstSignIn', 'true');
+      service.unsetFirstSignIn();
+      expect(localStorage.getItem('firstSignIn')).toEqual('false');
+    });
+  });
+
+  it('should get first sign in', () => {
+    localStorage.setItem('firstSignIn', 'true');
+    expect(service.getFirstSighIn()).toBeTruthy();
+  });
+
+  it('should clear local storage and reset subjects', () => {
+    localStorage.setItem('language', 'ua');
+    service.clear();
+    expect(service.firstNameBehaviourSubject.value).toBeNull();
+    expect(service.userIdBehaviourSubject.value).toBeNull();
+  });
+
+  it('should set UBS registration value to true if no user id is present in local storage', () => {
+    service.setUbsRegistration(true);
+    expect(service.ubsRegBehaviourSubject.value).toBeTruthy();
+    expect(localStorage.getItem('callUbsRegWindow')).toBeTruthy();
+  });
+
+  describe('UBS Registration', () => {
+    it('should return true if callUbsRegWindow is true', () => {
+      localStorage.setItem('callUbsRegWindow', 'true');
+      expect(service.getUbsRegistration()).toBe(true);
+    });
+
+    it('should remove callUbsRegWindow from localStorage', () => {
+      localStorage.setItem('callUbsRegWindow', 'true');
+      service.removeUbsRegistration();
+      expect(localStorage.getItem('callUbsRegWindow')).toBeNull();
+    });
+
+    it('should set UBSpersonalData and UBSorderData in localStorage', () => {
+      const personalData = 'John Doe';
+      const orderData = 'Order 123';
+      service.setUbsOrderData(personalData, orderData);
+      expect(localStorage.getItem('UBSpersonalData')).toBe(personalData);
+      expect(localStorage.getItem('UBSorderData')).toBe(orderData);
+    });
+  });
+
+  describe('removeanotherClientData', () => {
+    it('should remove anotherClient from localStorage', () => {
+      localStorage.setItem('anotherClient', 'test');
+      service.removeanotherClientData();
+      expect(localStorage.getItem('anotherClient')).toBeNull();
+    });
+  });
+
+  describe('setLocationId', () => {
+    it('should set currentLocationId in localStorage', () => {
+      const currentLocationId = 1;
+      service.setLocationId(currentLocationId);
+      expect(JSON.parse(localStorage.getItem('currentLocationId'))).toEqual(currentLocationId);
+    });
+
+    it('should set locations in localStorage', () => {
+      const locations = [
+        { id: 1, name: 'location1' },
+        { id: 2, name: 'location2' }
+      ];
+      service.setLocations(locations);
+      expect(JSON.parse(localStorage.getItem('locations'))).toEqual(locations);
+    });
+  });
+
+  describe('setOrderWithoutPayment', () => {
+    it('should set saveOrderWithoutPayment in localStorage as true when value is true', () => {
+      service.setOrderWithoutPayment(true);
+      expect(JSON.parse(localStorage.getItem('saveOrderWithoutPayment'))).toBeTruthy();
+    });
+
+    it('should set saveOrderWithoutPayment in localStorage as false when value is false', () => {
+      service.setOrderWithoutPayment(false);
+      expect(JSON.parse(localStorage.getItem('saveOrderWithoutPayment'))).toBeFalsy();
+    });
+  });
+
+  describe('getOrderWithoutPayment', () => {
+    it('should parse and return the saveOrderWithoutPayment item from local storage', () => {
+      const saveOrderWithoutPayment = { id: 1, name: 'Test Order' };
+      localStorage.setItem('saveOrderWithoutPayment', JSON.stringify(saveOrderWithoutPayment));
+      const result = service.getOrderWithoutPayment();
+      expect(result).toEqual(saveOrderWithoutPayment);
+    });
+  });
+
+  describe('UbsLiqPayOrderId and UbsFondyOrderId', () => {
+    it('should set and get the UbsLiqPayOrderId from local storage', () => {
+      const orderId = 123;
+      service.setUbsLiqPayOrderId(orderId);
+      const result = service.getUbsLiqPayOrderId();
+      expect(result).toEqual(orderId);
+    });
+
+    it('should remove the UbsLiqPayOrderId from local storage', () => {
+      const orderId = 123;
+      service.setUbsLiqPayOrderId(orderId);
+      service.removeUbsLiqPayOrderId();
+      const result = service.getUbsLiqPayOrderId();
+      expect(result).toBeFalsy();
+    });
+
+    it('should set the UbsFondyOrderId in local storage', () => {
+      const orderId = '123';
+      service.setUbsFondyOrderId(orderId);
+      expect(localStorage.getItem('UbsFondyOrderId')).toEqual(JSON.stringify(orderId));
+    });
+
+    it('should get the UbsFondyOrderId from local storage', () => {
+      const orderId = '123';
+      localStorage.setItem('UbsFondyOrderId', JSON.stringify(orderId));
+      expect(service.getUbsFondyOrderId()).toEqual(orderId);
+    });
+
+    it('should remove the UbsFondyOrderId from local storage', () => {
+      localStorage.setItem('UbsFondyOrderId', JSON.stringify('123'));
+      service.removeUbsFondyOrderId();
+      expect(localStorage.getItem('UbsFondyOrderId')).toBeNull();
+    });
+  });
+
+  it('should remove the saveOrderWithoutPayment from local storage', () => {
+    const order = { id: 1, name: 'Test Order' };
+    localStorage.setItem('saveOrderWithoutPayment', JSON.stringify(order));
+    service.removeOrderWithoutPayment();
+    const result = localStorage.getItem('saveOrderWithoutPayment');
+    expect(result).toBeFalsy();
+  });
+
+  it('should remove UBSExistingOrderId', () => {
+    localStorage.setItem('UBSExistingOrderId', '123');
+    service.removeUBSExistingOrderId();
+    expect(localStorage.getItem('UBSExistingOrderId')).toBeNull();
+  });
+
+  describe('IsUserPagePayment', () => {
+    it('should set IsUserPagePayment in local storage', () => {
+      service.setUserPagePayment(true);
+      expect(localStorage.getItem('IsUserPagePayment')).toEqual('true');
+    });
+
+    it('should get IsUserPagePayment from local storage', () => {
+      localStorage.setItem('IsUserPagePayment', JSON.stringify(true));
+      expect(service.getUserPagePayment()).toEqual('true');
+    });
+
+    it('should remove the IsUserPagePayment key from localStorage', () => {
+      localStorage.setItem('IsUserPagePayment', 'true');
+      service.removeUserPagePayment();
+      expect(localStorage.getItem('IsUserPagePayment')).toBeNull();
+    });
+  });
+
+  it('should clear payment info', () => {
+    localStorage.setItem('UbsLiqPayOrderId', '123');
+    localStorage.setItem('UbsFondyOrderId', '456');
+    localStorage.setItem('IsUserPagePayment', 'true');
+    service.clearPaymentInfo();
+    expect(localStorage.getItem('UbsLiqPayOrderId')).toBeNull();
+    expect(localStorage.getItem('UbsFondyOrderId')).toBeNull();
+    expect(localStorage.getItem('IsUserPagePayment')).toBeNull();
+  });
+
+  it('should remove UBS order data', () => {
+    localStorage.setItem('UBSpersonalData', 'personalData');
+    localStorage.setItem('UBSorderData', 'orderData');
+    localStorage.setItem('currentLocationId', '123');
+    localStorage.setItem('locations', 'locations');
+    localStorage.setItem('addressId', '456');
+    localStorage.setItem('anotherClient', 'anotherClient');
+    service.removeUbsOrderData();
+    expect(localStorage.getItem('UBSpersonalData')).toBeNull();
+    expect(localStorage.getItem('UBSorderData')).toBeNull();
+    expect(localStorage.getItem('currentLocationId')).toBeNull();
+    expect(localStorage.getItem('locations')).toBeNull();
+    expect(localStorage.getItem('addressId')).toBeNull();
+    expect(localStorage.getItem('anotherClient')).toBeNull();
+  });
+
+  it('should set the value of firstSignIn in local storage', () => {
+    service.setFirstSignIn();
+    expect(localStorage.getItem('firstSignIn')).toEqual('true');
+  });
+
+  it('should unset the value of firstSignIn in local storage', () => {
+    service.unsetFirstSignIn();
+    expect(localStorage.getItem('firstSignIn')).toEqual('false');
+  });
+
+  it('should remove the UbsOrderId from local storage', () => {
+    localStorage.setItem('UbsOrderId', '123');
+    service.removeUbsOrderId();
+    expect(localStorage.getItem('UbsOrderId')).toBeNull();
+  });
+
+  it('should remove the saveOrderWithoutPayment from local storage', () => {
+    localStorage.setItem('saveOrderWithoutPayment', JSON.stringify('order'));
+    service.removeOrderWithoutPayment();
+    expect(localStorage.getItem('saveOrderWithoutPayment')).toBeNull();
+  });
+
+  it('should remove the UBSExistingOrderId from local storage', () => {
+    localStorage.setItem('UBSExistingOrderId', '123');
+    service.removeUBSExistingOrderId();
+    expect(localStorage.getItem('UBSExistingOrderId')).toBeNull();
+  });
+
+  it('should set firstSignIn to true in localStorage', () => {
+    service.setFirstSignIn();
+    expect(localStorage.getItem('firstSignIn')).toEqual('true');
+  });
+
+  it('should set firstSignIn to false in localStorage', () => {
+    service.unsetFirstSignIn();
+    expect(localStorage.getItem('firstSignIn')).toEqual('false');
+  });
+
+  it('should remove saveOrderWithoutPayment from localStorage', () => {
+    localStorage.setItem('saveOrderWithoutPayment', 'test');
+    service.removeOrderWithoutPayment();
+    expect(localStorage.getItem('saveOrderWithoutPayment')).toBeFalsy();
+  });
+
+  it('should remove UBSExistingOrderId from localStorage', () => {
+    localStorage.setItem('UBSExistingOrderId', 'test');
+    service.removeUBSExistingOrderId();
+    expect(localStorage.getItem('UBSExistingOrderId')).toBeFalsy();
+  });
+
+  it('should clear payment info from localStorage', () => {
+    service.setUbsLiqPayOrderId(123);
+    service.setUbsFondyOrderId('abc');
+    service.setUserPagePayment(true);
+    service.clearPaymentInfo();
+    expect(service.getUbsLiqPayOrderId()).toBeFalsy();
+    expect(service.getUbsFondyOrderId()).toBeFalsy();
+    expect(service.getUserPagePayment()).toBeFalsy();
+  });
+
+  it('should remove Ubs order and personal data', () => {
+    localStorage.setItem('UBSpersonalData', JSON.stringify({ name: 'John', age: 30 }));
+    localStorage.setItem('UBSorderData', JSON.stringify({ orderId: 123 }));
+    service.removeUbsOrderAndPersonalData();
+    expect(localStorage.getItem('UBSpersonalData')).toBeNull();
+    expect(localStorage.getItem('UBSorderData')).toBeNull();
+  });
+
+  it('should remove UBSpersonalData and UBSorderData', () => {
+    localStorage.setItem('UBSpersonalData', JSON.stringify({}));
+    localStorage.setItem('UBSorderData', JSON.stringify({}));
+    service.removeUbsOrderAndPersonalData();
+    expect(localStorage.getItem('UBSpersonalData')).toBeNull();
+    expect(localStorage.getItem('UBSorderData')).toBeNull();
+  });
+
+  it('should get UBS personal data', () => {
+    localStorage.setItem('UBSpersonalData', JSON.stringify({ name: 'John Doe' }));
+    const personalData = service.getUbsPersonalData();
+    expect(personalData).toEqual({ name: 'John Doe' });
+  });
+
+  it('should get UBS order data', () => {
+    localStorage.setItem('UBSorderData', JSON.stringify({ orderId: 123 }));
+    const orderData = service.getUbsOrderData();
+    expect(orderData).toEqual({ orderId: 123 });
+  });
+
+  it('should get current location id', () => {
+    localStorage.setItem('currentLocationId', '1');
+    const locationId = service.getLocationId();
+    expect(locationId).toBe(1);
+  });
+
+  describe('getExistingOrderId()', () => {
+    it('should return the existing order id from local storage', () => {
+      localStorage.setItem('UBSExistingOrderId', '12345');
+      expect(service.getExistingOrderId()).toBe('12345');
+    });
+
+    it('should return null if the existing order id does not exist in local storage', () => {
+      expect(service.getExistingOrderId()).toBeNull();
+    });
+  });
+
+  describe('getLocations()', () => {
+    it('should return a valid JSON object from local storage', () => {
+      const locations = { location1: 'New York', location2: 'London' };
+      localStorage.setItem('locations', JSON.stringify(locations));
+      expect(service.getLocations()).toEqual(locations);
+    });
+
+    it('should return null if the locations does not exist in local storage', () => {
+      expect(service.getLocations()).toBeNull();
+    });
+  });
+
+  describe('setCustomer/getCustomer()', () => {
+    it('should set and get a customer object to/from local storage correctly', () => {
+      const customer = { name: 'John Doe' };
+      service.setCustomer(customer);
+      expect(service.getCustomer()).toEqual(customer);
+    });
+
+    it('should return null if no customer exists in local storage', () => {
+      expect(service.getCustomer()).toBeNull();
+    });
+
+    it('should remove current customer from local storage', () => {
+      localStorage.setItem('currentCustomer', JSON.stringify({ id: 1, name: 'John Doe' }));
+      service.removeCurrentCustomer();
+      expect(localStorage.getItem('currentCustomer')).toBeNull();
+    });
+  });
+
+  describe('UBSAdminOrdersTableColumnsWidthPreference', () => {
+    it('should set UBSAdminOrdersTableColumnsWidthPreference in local storage', () => {
+      const preference = new Map<string, number>([
+        ['column1', 100],
+        ['column2', 200]
+      ]);
+      service.setUbsAdminOrdersTableColumnsWidthPreference(preference);
+      expect(JSON.parse(localStorage.getItem('UBSAdminOrdersTableColumnsWidthPreference'))).toEqual({ column1: 100, column2: 200 });
+    });
+
+    it('should get UBSAdminOrdersTableColumnsWidthPreference from local storage', () => {
+      const preference = new Map<string, number>([
+        ['column1', 100],
+        ['column2', 200]
+      ]);
+      localStorage.setItem('UBSAdminOrdersTableColumnsWidthPreference', JSON.stringify({ column1: 100, column2: 200 }));
+      expect(service.getUbsAdminOrdersTableColumnsWidthPreference()).toEqual(preference);
+    });
+
+    it('should return an empty Map if UBSAdminOrdersTableColumnsWidthPreference is not in local storage', () => {
+      expect(service.getUbsAdminOrdersTableColumnsWidthPreference().size).toEqual(0);
+    });
+  });
+
+  describe('setOrderIdToRedirect and getOrderIdToRedirect', () => {
+    it('should set order id to redirect in local storage and emit event', () => {
+      spyOn(service.ubsRedirectionBehaviourSubject, 'next').and.callThrough();
+      service.setOrderIdToRedirect(123);
+      expect(service.ubsRedirectionBehaviourSubject.next).toHaveBeenCalledWith(123);
+    });
+
+    it('should return NaN if order id to redirect is not in local storage', () => {
+      expect(service.getOrderIdToRedirect()).toBeNaN();
+    });
+  });
+
+  describe('getAdminOrdersDateFilter', () => {
+    it('should return null if the filter is not set', () => {
+      localStorage.removeItem('UbsAdminOrdersDateFilters');
+      const filter = service.getAdminOrdersDateFilter();
+      expect(filter).toBeNull();
+    });
+
+    it('should remove UbsAdminOrdersDateFilters from local storage', () => {
+      localStorage.setItem(
+        'UbsAdminOrdersDateFilters',
+        JSON.stringify({ startDate: new Date(2022, 1, 1), endDate: new Date(2022, 1, 31) })
+      );
+      service.removeAdminOrderDateFilters();
+      expect(localStorage.getItem('UbsAdminOrdersDateFilters')).toBeNull();
+    });
+
+    it('should set UbsAdminOrdersTableTitleColumnFilters in local storage', () => {
+      const filters = [
+        { column: 'column1', value: 'value1' },
+        { column: 'column2', value: 'value2' }
+      ];
+      service.setUbsAdminOrdersTableTitleColumnFilter(filters);
+      expect(JSON.parse(localStorage.getItem('UbsAdminOrdersTableTitleColumnFilters'))).toEqual([
+        { column: 'column1', value: 'value1' },
+        { column: 'column2', value: 'value2' }
+      ]);
+    });
+
+    it('should remove UbsAdminOrdersTableTitleColumnFilters from local storage', () => {
+      localStorage.setItem('UbsAdminOrdersTableTitleColumnFilters', JSON.stringify([{ column: 'column1', value: 'value1' }]));
+      service.removeAdminOrderFilters();
+      expect(localStorage.getItem('UbsAdminOrdersTableTitleColumnFilters')).toBeNull();
+    });
+
+    it('should get UbsAdminOrdersTableTitleColumnFilters from local storage', () => {
+      const filters = [
+        { column: 'column1', value: 'value1' },
+        { column: 'column2', value: 'value2' }
+      ];
+      localStorage.setItem('UbsAdminOrdersTableTitleColumnFilters', JSON.stringify(filters));
+      expect(service.getUbsAdminOrdersTableTitleColumnFilter()).toEqual(filters);
+    });
+
+    it('should return an empty array if UbsAdminOrdersTableTitleColumnFilters is not in local storage', () => {
+      expect(service.getUbsAdminOrdersTableTitleColumnFilter().length).toEqual(0);
+    });
+
+    it('should set UbsAdminOrdersDateFilters in local storage', () => {
+      const filters = { startDate: new Date(2022, 1, 1), endDate: new Date(2022, 1, 31) };
+      service.setAdminOrdersDateFilter(filters);
+      expect(JSON.parse(localStorage.getItem('UbsAdminOrdersDateFilters'))).toEqual({
+        startDate: filters.startDate.toJSON(),
+        endDate: filters.endDate.toJSON()
+      });
+    });
+
+    it('should return the parsed filter if it is set', () => {
+      const filter = { startDate: '2022-01-01', endDate: '2022-01-31' };
+      localStorage.setItem('UbsAdminOrdersDateFilters', JSON.stringify(filter));
+      const result = service.getAdminOrdersDateFilter();
+      expect(result).toEqual(filter);
+    });
+
+    it('should return null if UbsAdminOrdersDateFilters is not in local storage', () => {
+      expect(service.getAdminOrdersDateFilter()).toBeNull();
+    });
+  });
+
+  describe('finalSumOfOrder', () => {
+    it('should set final sum of order in local storage', () => {
+      service.setFinalSumOfOrder(123.45);
+      expect(JSON.parse(localStorage.getItem('finalSumOfOrder'))).toEqual(123.45);
+    });
+
+    it('should get final sum of order from local storage', () => {
+      localStorage.setItem('finalSumOfOrder', JSON.stringify(123.45));
+      expect(service.getFinalSumOfOrder()).toEqual(123.45);
+    });
+
+    it('should return null if final sum of order is not in local storage', () => {
+      expect(service.getFinalSumOfOrder()).toBeNull();
+    });
+  });
+
+  it('should set the event in local storage with the given key', () => {
+    const key = 'testKey';
+    service.setEventForEdit(key, mockEvent);
+    expect(localStorage.getItem(key)).toEqual(JSON.stringify(mockEvent));
   });
 });

--- a/src/app/main/service/localstorage/local-storage.service.ts
+++ b/src/app/main/service/localstorage/local-storage.service.ts
@@ -163,13 +163,21 @@ export class LocalStorageService {
   }
 
   public setOrderWithoutPayment(SaveOrderWithoutPayment: boolean) {
-    localStorage.setItem('SaveOrderWithoutPayment', JSON.stringify(orderId));
+    localStorage.setItem('SaveOrderWithoutPayment', JSON.stringify(SaveOrderWithoutPayment));
   }
 
   public getOrderWithoutPayment(): any {
     return localStorage.getItem('SaveOrderWithoutPayment') === 'undefined'
       ? false
       : JSON.parse(localStorage.getItem('SaveOrderWithoutPayment'));
+  }
+
+  public setUbsOrderId(orderId: string | number) {
+    localStorage.setItem('UbsOrderId', JSON.stringify(orderId));
+  }
+
+  public getUbsOrderId(): any {
+    return localStorage.getItem('UbsOrderId') === 'undefined' ? false : JSON.parse(localStorage.getItem('UbsOrderId'));
   }
 
   public setUbsLiqPayOrderId(orderId: string | number) {
@@ -182,6 +190,10 @@ export class LocalStorageService {
 
   public removeUbsLiqPayOrderId() {
     localStorage.removeItem('UbsLiqPayOrderId');
+  }
+
+  public removeUbsOrderId() {
+    localStorage.removeItem('UbsOrderId');
   }
 
   public setUbsFondyOrderId(orderId: string | number) {

--- a/src/app/main/service/localstorage/local-storage.service.ts
+++ b/src/app/main/service/localstorage/local-storage.service.ts
@@ -162,17 +162,17 @@ export class LocalStorageService {
     localStorage.setItem('locations', JSON.stringify(locations));
   }
 
-  public setOrderWithoutPayment(SaveOrderWithoutPayment: boolean) {
-    localStorage.setItem('SaveOrderWithoutPayment', JSON.stringify(SaveOrderWithoutPayment));
+  public setOrderWithoutPayment(value: boolean): void {
+    localStorage.setItem('saveOrderWithoutPayment', JSON.stringify(value));
   }
 
   public getOrderWithoutPayment(): any {
-    return localStorage.getItem('SaveOrderWithoutPayment') === 'undefined'
+    return localStorage.getItem('saveOrderWithoutPayment') === 'undefined'
       ? false
-      : JSON.parse(localStorage.getItem('SaveOrderWithoutPayment'));
+      : JSON.parse(localStorage.getItem('saveOrderWithoutPayment'));
   }
 
-  public setUbsOrderId(orderId: string | number) {
+  public setUbsOrderId(orderId: string | number): void {
     localStorage.setItem('UbsOrderId', JSON.stringify(orderId));
   }
 
@@ -180,7 +180,7 @@ export class LocalStorageService {
     return localStorage.getItem('UbsOrderId') === 'undefined' ? false : JSON.parse(localStorage.getItem('UbsOrderId'));
   }
 
-  public setUbsLiqPayOrderId(orderId: string | number) {
+  public setUbsLiqPayOrderId(orderId: string | number): void {
     localStorage.setItem('UbsLiqPayOrderId', JSON.stringify(orderId));
   }
 
@@ -208,8 +208,8 @@ export class LocalStorageService {
     localStorage.removeItem('UbsFondyOrderId');
   }
 
-  public removeOrderWithoutPayment() {
-    localStorage.removeItem('SaveOrderWithoutPayment');
+  public removeOrderWithoutPayment(): void {
+    localStorage.removeItem('saveOrderWithoutPayment');
   }
 
   public removeUBSExistingOrderId() {

--- a/src/app/main/service/localstorage/local-storage.service.ts
+++ b/src/app/main/service/localstorage/local-storage.service.ts
@@ -162,15 +162,25 @@ export class LocalStorageService {
     localStorage.setItem('locations', JSON.stringify(locations));
   }
 
-  public setUbsOrderId(orderId: string | number) {
+  public setOrderWithoutPayment(SaveOrderWithoutPayment: boolean) {
+    localStorage.setItem('SaveOrderWithoutPayment', JSON.stringify(orderId));
+  }
+
+  public getOrderWithoutPayment(): any {
+    return localStorage.getItem('SaveOrderWithoutPayment') === 'undefined'
+      ? false
+      : JSON.parse(localStorage.getItem('SaveOrderWithoutPayment'));
+  }
+
+  public setUbsLiqPayOrderId(orderId: string | number) {
     localStorage.setItem('UbsLiqPayOrderId', JSON.stringify(orderId));
   }
 
-  public getUbsOrderId(): any {
+  public getUbsLiqPayOrderId(): any {
     return localStorage.getItem('UbsLiqPayOrderId') === 'undefined' ? false : JSON.parse(localStorage.getItem('UbsLiqPayOrderId'));
   }
 
-  public removeUbsOrderId() {
+  public removeUbsLiqPayOrderId() {
     localStorage.removeItem('UbsLiqPayOrderId');
   }
 
@@ -184,6 +194,10 @@ export class LocalStorageService {
 
   public removeUbsFondyOrderId() {
     localStorage.removeItem('UbsFondyOrderId');
+  }
+
+  public removeOrderWithoutPayment() {
+    localStorage.removeItem('SaveOrderWithoutPayment');
   }
 
   public removeUBSExistingOrderId() {
@@ -203,7 +217,7 @@ export class LocalStorageService {
   }
 
   public clearPaymentInfo(): void {
-    this.removeUbsOrderId();
+    this.removeUbsLiqPayOrderId();
     this.removeUbsFondyOrderId();
     this.removeUserPagePayment();
   }

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-order-payment-pop-up/ubs-user-order-payment-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-order-payment-pop-up/ubs-user-order-payment-pop-up.component.spec.ts
@@ -62,7 +62,7 @@ describe('UbsUserOrderPaymentPopUpComponent', () => {
     'processOrderLiqPayFromUserOrderList'
   ]);
   const localStorageServiceMock = jasmine.createSpyObj('localStorageService', [
-    'setUbsOrderId',
+    'setUbsLiqPayOrderId',
     'setUbsFondyOrderId',
     'clearPaymentInfo',
     'setUserPagePayment'

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-order-payment-pop-up/ubs-user-order-payment-pop-up.component.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-order-payment-pop-up/ubs-user-order-payment-pop-up.component.ts
@@ -297,7 +297,7 @@ export class UbsUserOrderPaymentPopUpComponent implements OnInit {
             this.liqPayButtonForm = this.sanitizer.bypassSecurityTrustHtml(response.liqPayButton);
             setTimeout(() => {
               this.liqPayButton = document.getElementsByName('btn_text');
-              this.localStorageService.setUbsOrderId(this.orderClientDto.orderId);
+              this.localStorageService.setUbsLiqPayOrderId(this.orderClientDto.orderId);
               this.liqPayButton[0].click();
             }, 0);
           }

--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
@@ -98,7 +98,7 @@ describe('UbsConfirmPageComponent', () => {
     expect(saveDataOnLocalStorageMock).toHaveBeenCalled();
   });
 
-  it('in saveDataOnLocalStorage should removeUbsOrderId and saveDataOnLocalStorage be called', () => {
+  it('in saveDataOnLocalStorage should removeUbsLiqPayOrderId and saveDataOnLocalStorage be called', () => {
     component.saveDataOnLocalStorage();
     expect(fakeUBSOrderFormService.saveDataOnLocalStorage).toHaveBeenCalled();
   });

--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
@@ -21,7 +21,14 @@ describe('UbsConfirmPageComponent', () => {
     'getOrderStatus',
     'saveDataOnLocalStorage'
   ]);
-  const fakeLocalStorageService = jasmine.createSpyObj('localStorageService', ['getFinalSumOfOrder', 'clearPaymentInfo']);
+  const fakeLocalStorageService = jasmine.createSpyObj('localStorageService', [
+    'getFinalSumOfOrder',
+    'clearPaymentInfo',
+    'getUbsOrderId',
+    'setUbsOrderId',
+    'getOrderWithoutPayment',
+    'removeOrderWithoutPayment'
+  ]);
   const fakeJwtService = jasmine.createSpyObj('fakeJwtService', ['']);
 
   beforeEach(async(() => {
@@ -55,6 +62,7 @@ describe('UbsConfirmPageComponent', () => {
     fakeUBSOrderFormService.getOrderResponseErrorStatus.and.returnValue(false);
     fakeUBSOrderFormService.getOrderStatus.and.returnValue(of({ result: 'success', order_id: '123_456' }));
     const renderViewMock = spyOn(component, 'renderView');
+    fakeLocalStorageService.getOrderWithoutPayment.and.returnValue(of(false));
     const checkPaymentStatusMock = spyOn(component, 'checkPaymentStatus');
     component.ngOnInit();
     expect(renderViewMock).toHaveBeenCalled();

--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
@@ -1,6 +1,6 @@
 import { of } from 'rxjs';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import { Router, NavigationEnd } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { JwtService } from '@global-service/jwt/jwt.service';
@@ -27,7 +27,8 @@ describe('UbsConfirmPageComponent', () => {
     'getUbsOrderId',
     'setUbsOrderId',
     'getOrderWithoutPayment',
-    'removeOrderWithoutPayment'
+    'removeOrderWithoutPayment',
+    'removeUbsOrderId'
   ]);
   const fakeJwtService = jasmine.createSpyObj('fakeJwtService', ['']);
 
@@ -56,6 +57,25 @@ describe('UbsConfirmPageComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should remove order without payment and UBS order id from local storage on NavigationEnd event', () => {
+    fakeLocalStorageService.removeOrderWithoutPayment();
+    fakeLocalStorageService.removeUbsOrderId();
+    const event = new NavigationEnd(1, '/ubs/confirm', '/ubs/confirm');
+    component.removeOrderFromLocalStorage();
+
+    expect(component.localStorageService.removeOrderWithoutPayment).toHaveBeenCalled();
+    expect(component.localStorageService.removeUbsOrderId).toHaveBeenCalled();
+  });
+
+  it('shouldn`t remove order without payment and UBS order id from local storage on NavigationEnd event if url is /ubs/confirm', () => {
+    fakeLocalStorageService.removeOrderWithoutPayment();
+    fakeLocalStorageService.removeUbsOrderId();
+    const event = new NavigationEnd(1, '/ubs/confirm', '/ubs');
+    component.removeOrderFromLocalStorage();
+
+    expect(component.localStorageService.removeOrderWithoutPayment).toHaveBeenCalled();
   });
 
   xit('ngOnInit should call renderView with oderID', () => {

--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
@@ -3,11 +3,10 @@ import { Router, NavigationEnd } from '@angular/router';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
 import { JwtService } from '@global-service/jwt/jwt.service';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
-import { Subject } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { OrderService } from '../../services/order.service';
 import { UBSOrderFormService } from '../../services/ubs-order-form.service';
-import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-ubs-confirm-page',

--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnDestroy, OnInit, HostListener } from '@angular/core';
-import { Router, NavigationStart, NavigationEnd, ActivatedRoute } from '@angular/router';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
 import { JwtService } from '@global-service/jwt/jwt.service';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
@@ -30,10 +30,9 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
     private jwtService: JwtService,
     private ubsOrderFormService: UBSOrderFormService,
     private shareFormService: UBSOrderFormService,
-    private localStorageService: LocalStorageService,
+    public localStorageService: LocalStorageService,
     private orderService: OrderService,
-    public router: Router,
-    private route: ActivatedRoute
+    public router: Router
   ) {}
 
   toPersonalAccount(): void {
@@ -81,7 +80,7 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
     });
   }
 
-  private removeOrderFromLocalStorage(): void {
+  public removeOrderFromLocalStorage(): void {
     this.routeSubscription = this.router.events.subscribe((event) => {
       if (event instanceof NavigationEnd && event.url.toString() !== '/ubs/confirm') {
         this.localStorageService.removeOrderWithoutPayment();

--- a/src/app/ubs/ubs/components/ubs-submit-order/ubs-submit-order.component.ts
+++ b/src/app/ubs/ubs/components/ubs-submit-order/ubs-submit-order.component.ts
@@ -208,7 +208,7 @@ export class UBSSubmitOrderComponent extends FormBaseComponent implements OnInit
           console.log('RESPONSE ', response);
           const { orderId, link } = JSON.parse(response);
           this.shareFormService.orderUrl = '';
-          this.localStorageService.removeUbsOrderId();
+          this.localStorageService.removeUbsLiqPayOrderId();
           this.localStorageService.removeUBSExistingOrderId();
           this.shareFormService.orderUrl = link.toString();
           this.localStorageService.setUbsFondyOrderId(orderId);
@@ -233,12 +233,12 @@ export class UBSSubmitOrderComponent extends FormBaseComponent implements OnInit
         (response) => {
           const { orderId, link } = JSON.parse(response);
           this.shareFormService.orderUrl = '';
-          this.localStorageService.removeUbsOrderId();
+          this.localStorageService.removeUbsLiqPayOrderId();
           if (this.isFinalSumZero && !this.isTotalAmountZero) {
             this.ubsOrderFormService.transferOrderId(orderId);
             this.ubsOrderFormService.setOrderResponseErrorStatus(false);
             this.ubsOrderFormService.setOrderStatus(true);
-            this.localStorageService.setUbsOrderId(orderId);
+            this.localStorageService.setUbsLiqPayOrderId(orderId);
           } else {
             this.shareFormService.orderUrl = link.toString();
             this.localStorageService.setUbsFondyOrderId(orderId);
@@ -263,7 +263,7 @@ export class UBSSubmitOrderComponent extends FormBaseComponent implements OnInit
       .subscribe(
         (res) => {
           const { orderId, liqPayButton } = JSON.parse(res);
-          this.localStorageService.setUbsOrderId(orderId);
+          this.localStorageService.setUbsLiqPayOrderId(orderId);
           this.liqPayButtonForm = this.sanitizer.bypassSecurityTrustHtml(liqPayButton);
           setTimeout(() => {
             this.liqPayButton = document.getElementsByName('btn_text');

--- a/src/app/ubs/ubs/services/order.service.ts
+++ b/src/app/ubs/ubs/services/order.service.ts
@@ -105,7 +105,7 @@ export class OrderService {
   }
 
   getUbsOrderStatus(): Observable<any> {
-    const liqPayOrderId = this.localStorageService.getUbsOrderId();
+    const liqPayOrderId = this.localStorageService.getUbsLiqPayOrderId();
     const fondyOrderId = this.localStorageService.getUbsFondyOrderId();
     if (liqPayOrderId) {
       return this.getLiqPayStatus(liqPayOrderId);
@@ -165,8 +165,12 @@ export class OrderService {
     this.shareFormService.isDataSaved = true;
     this.shareFormService.orderDetails = null;
     this.shareFormService.personalData = null;
-    this.localStorageService.removeUbsOrderId();
+    this.localStorageService.removeUbsLiqPayOrderId();
     this.localStorageService.removeUbsFondyOrderId();
     this.shareFormService.saveDataOnLocalStorage();
+  }
+
+  saveOrderData(): void {
+    this.localStorageService.setOrderWithoutPayment(true);
   }
 }


### PR DESCRIPTION
**Before**
The error "Упс, щось пішло не так..." is displayed after clicking on the"Так, зберегти" bttn on the the alert message 'У разі закриття Ваше замовлення буде збережене у Вашому особистому кабінеті. Чи бажаєте Ви зберегти це замовлення?'

**After**
The system saves the order as a draft in the Client’s cabinet without using bonuses and certificates. It redirects the user to the order confirmation page when the User clicks on the “Так, зберегти” button on the alert message 'У разі закриття Ваше замовлення буде збережене у Вашому особистому кабінеті. Чи бажаєте Ви зберегти це замовлення?'