### PR TITLE
bugfix/#5162 Added default Date section on Create event page

### DIFF
--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.html
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.html
@@ -34,7 +34,12 @@
           </div>
           <mat-form-field appearance="outline" class="date-item">
             <mat-label>Min 1 day</mat-label>
-            <mat-select formControlName="eventDuration" ngDefaultControl (selectionChange)="setDateCount(+$event.value.split(' ')[0])">
+            <mat-select
+              [(ngModel)]="selectedDay"
+              formControlName="eventDuration"
+              ngDefaultControl
+              (selectionChange)="setDateCount(+$event.value.split(' ')[0])"
+            >
               <mat-option *ngFor="let date of dateArrCount" [value]="date">
                 {{ date }}
               </mat-option>

--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.html
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.html
@@ -34,12 +34,7 @@
           </div>
           <mat-form-field appearance="outline" class="date-item">
             <mat-label>Min 1 day</mat-label>
-            <mat-select
-              [(ngModel)]="selectedDay"
-              formControlName="eventDuration"
-              ngDefaultControl
-              (selectionChange)="setDateCount(+$event.value.split(' ')[0])"
-            >
+            <mat-select formControlName="eventDuration" ngDefaultControl (selectionChange)="setDateCount(+$event.value.split(' ')[0])">
               <mat-option *ngFor="let date of dateArrCount" [value]="date">
                 {{ date }}
               </mat-option>

--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
@@ -36,6 +36,7 @@ export class CreateEditEventsComponent implements OnInit, OnDestroy {
   public contentValid: boolean;
   public checkAfterSend = true;
   public dateArrCount = WeekArray;
+  public selectedDay: string = WeekArray[0];
   public editMode: boolean;
   public editEvent: EventPageResponceDto;
   public imagesToDelete: string[] = [];
@@ -88,6 +89,8 @@ export class CreateEditEventsComponent implements OnInit, OnDestroy {
     if (!this.checkUserSigned()) {
       this.snackBar.openSnackBar('userUnauthorised');
     }
+
+    this.dates = [{ ...DateObj }];
   }
 
   get titleForm() {

--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
@@ -78,7 +78,7 @@ export class CreateEditEventsComponent implements OnInit, OnDestroy {
     this.eventFormGroup = new FormGroup({
       titleForm: new FormControl('', [Validators.required, Validators.minLength(1), Validators.maxLength(70), this.validateSpaces]),
       description: new FormControl('', [Validators.required, Validators.minLength(28), Validators.maxLength(63206)]),
-      eventDuration: new FormControl('', [Validators.required, Validators.minLength(2)])
+      eventDuration: new FormControl(this.selectedDay, [Validators.required, Validators.minLength(2)])
     });
 
     if (this.editMode) {

--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
@@ -36,7 +36,7 @@ export class CreateEditEventsComponent implements OnInit, OnDestroy {
   public contentValid: boolean;
   public checkAfterSend = true;
   public dateArrCount = WeekArray;
-  public selectedDay: string = WeekArray[0];
+  public selectedDay = WeekArray[0];
   public editMode: boolean;
   public editEvent: EventPageResponceDto;
   public imagesToDelete: string[] = [];


### PR DESCRIPTION
Before: The 'Date' and 'Time' sections aren`t displayed on the ''Create event' page by default.
After : The 'Date' and 'Time' sections are displayed on the 'Create event' page by default.