### PR TITLE
Bugfix/#5295 create event and join to event bttn not displayed for the non auth user

### DIFF
--- a/src/app/main/component/events/components/events-list/events-list.component.html
+++ b/src/app/main/component/events/components/events-list/events-list.component.html
@@ -12,11 +12,11 @@
         <div class="container-img">
           <img class="my-events-img" src="assets/events-icons/my-event.png" alt="my-event" />
         </div>
-        <a class="create" [routerLink]="['create-event']" *ngIf="isLoggedIn">
-          <div class="secondary-global-button create-button">
+        <div class="create">
+          <div class="secondary-global-button create-button"(click)="isUserLoggedRedirect()">
             <span class="create-button-text">{{ 'Create events' | translate }}</span>
           </div>
-        </a>
+        </div>
       </div>
     </div>
     <div class="filter-container">

--- a/src/app/main/component/events/components/events-list/events-list.component.spec.ts
+++ b/src/app/main/component/events/components/events-list/events-list.component.spec.ts
@@ -10,6 +10,7 @@ import { of } from 'rxjs';
 import { UserOwnAuthService } from '@global-service/auth/user-own-auth.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Store } from '@ngrx/store';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 
 describe('EventsListComponent', () => {
   let component: EventsListComponent;
@@ -43,15 +44,18 @@ describe('EventsListComponent', () => {
   languageServiceMock.getLangValue = (valUa: string, valEn: string) => {
     of(valEn);
   };
+  let matDialogService: jasmine.SpyObj<MatDialog>;
+  matDialogService = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [EventsListComponent],
-      imports: [TranslateModule.forRoot(), NgxPaginationModule, RouterTestingModule],
+      imports: [TranslateModule.forRoot(), NgxPaginationModule, RouterTestingModule, MatDialogModule],
       providers: [
         { provide: EventsService, useValue: EventsServiceMock },
         { provide: UserOwnAuthService, useValue: UserOwnAuthServiceMock },
-        { provide: Store, useValue: storeMock }
+        { provide: Store, useValue: storeMock },
+        { provide: MatDialog, useValue: matDialogService }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();

--- a/src/app/main/component/events/components/events-list/events-list.component.ts
+++ b/src/app/main/component/events/components/events-list/events-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, Injector, OnDestroy, OnInit } from '@angular/core';
 import { EventPageResponceDto, PaginationInterface } from '../../models/events.interface';
 import { UserOwnAuthService } from '@auth-service/user-own-auth.service';
 import { ReplaySubject } from 'rxjs';
@@ -9,6 +9,9 @@ import { IEcoEventsState } from 'src/app/store/state/ecoEvents.state';
 import { GetEcoEventsByPageAction } from 'src/app/store/actions/ecoEvents.actions';
 import { TagsArray, eventTimeList, eventStatusList, tempLocationList } from '../../models/event-consts';
 import { LanguageService } from '../../../../i18n/language.service';
+import { Router } from '@angular/router';
+import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component';
+import { MatDialog } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-events-list',
@@ -50,8 +53,14 @@ export class EventsListComponent implements OnInit, OnDestroy {
     private store: Store,
     private userOwnAuthService: UserOwnAuthService,
     private languageService: LanguageService,
-    private localStorageService: LocalStorageService
-  ) {}
+    private localStorageService: LocalStorageService,
+    private router: Router,
+    public injector: Injector
+  ) {
+    this.dialog = injector.get(MatDialog);
+  }
+  private dialog: MatDialog;
+
 
   ngOnInit(): void {
     this.localStorageService.setEditMode('canUserEdit', false);
@@ -102,8 +111,23 @@ export class EventsListComponent implements OnInit, OnDestroy {
     this.store.dispatch(GetEcoEventsByPageAction({ currentPage: event - 1, numberOfEvents: this.eventsPerPage }));
   }
 
-  getLangValue(uaValue: string, enValue: string): string {
+  public getLangValue(uaValue: string, enValue: string): string {
     return this.languageService.getLangValue(uaValue, enValue) as string;
+  }
+
+  public isUserLoggedRedirect(): void {
+    this.isLoggedIn ? this.router.navigate(['/events', 'create-event']) : this.openAuthModalWindow('sign-in');
+  }
+
+  public openAuthModalWindow(page: string): void {
+    this.dialog.open(AuthModalComponent, {
+      hasBackdrop: true,
+      closeOnNavigation: true,
+      panelClass: ['custom-dialog-container'],
+      data: {
+        popUpName: page
+      }
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/app/main/component/events/components/events-list/events-list.component.ts
+++ b/src/app/main/component/events/components/events-list/events-list.component.ts
@@ -40,6 +40,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
   statusList = eventStatusList;
   eventLocationList = tempLocationList;
   allSelected = false;
+  private dialog: MatDialog;
 
   public pageConfig(items: number, page: number, total: number): PaginationInterface {
     return {
@@ -59,7 +60,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
   ) {
     this.dialog = injector.get(MatDialog);
   }
-  private dialog: MatDialog;
+
 
 
   ngOnInit(): void {

--- a/src/app/main/component/events/events.module.ts
+++ b/src/app/main/component/events/events.module.ts
@@ -37,6 +37,7 @@ import { EventScheduleComponent } from './components/event-details/event-schedul
 import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatDialogModule } from '@angular/material/dialog';
 
 @NgModule({
   declarations: [
@@ -52,6 +53,7 @@ import { MatDividerModule } from '@angular/material/divider';
     EventScheduleComponent
   ],
   imports: [
+    MatDialogModule,
     RatingModule.forRoot(),
     ReactiveFormsModule,
     GooglePlaceModule,

--- a/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.spec.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.spec.ts
@@ -116,7 +116,7 @@ describe('EventsListItemModalComponent', () => {
 
     it(`should be called on click and open the auth modal`, () => {
       component.isRegistered = false;
-      spyOn(component, 'openAuthModalWindow').withArgs('sign-up');
+      spyOn(component, 'openAuthModalWindow').withArgs('sign-in');
       jasmine.clock().install();
       component.modalBtn();
       jasmine.clock().tick(500);

--- a/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.ts
@@ -46,7 +46,7 @@ export class EventsListItemModalComponent implements OnInit, OnDestroy {
     if (!this.isRegistered) {
       this.bsModalRef.hide();
       setTimeout(() => {
-        this.openAuthModalWindow('sign-up');
+        this.openAuthModalWindow('sign-in');
       }, 500);
     } else {
       this.onRateChange();

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.html
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.html
@@ -56,7 +56,7 @@
     <button class="secondary-global-button event-button" (click)="routeToEvent()">
       {{ 'event.btn-top' | translate }}
     </button>
-    <button class="{{ styleBtn }} event-button" [hidden]="isJoinBtnHidden" (click)="buttonAction()">{{ nameBtn | translate }}</button>
+    <button class="{{ styleBtn }} event-button" (click)="buttonAction()">{{ nameBtn | translate }}</button>
   </div>
   <div class="additional-info">
     <div class="date">

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
@@ -285,7 +285,9 @@ export class EventsListItemComponent implements OnInit, OnDestroy {
 
   addToFavourite() {
     this.bookmarkSelected = !this.bookmarkSelected;
-    if(!this.isRegistered) this.openAuthModalWindow('sign-in');
+    if (!this.isRegistered) {
+      this.openAuthModalWindow('sign-in');
+    }
   }
 
   public openAuthModalWindow(page: string): void {

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
@@ -283,7 +283,6 @@ export class EventsListItemComponent implements OnInit, OnDestroy {
     return this.langService.getLangValue(uaValue, enValue) as string;
   }
 
-
   addToFavourite() {
     this.bookmarkSelected = !this.bookmarkSelected;
     if(!this.isRegistered) this.openAuthModalWindow('sign-in');

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
@@ -20,6 +20,7 @@ import { UserOwnAuthService } from '@auth-service/user-own-auth.service';
 import { DatePipe } from '@angular/common';
 import { EventsService } from '../../../events/services/events.service';
 import { LanguageService } from 'src/app/main/i18n/language.service';
+import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component';
 
 @Component({
   selector: 'app-events-list-item',
@@ -282,8 +283,21 @@ export class EventsListItemComponent implements OnInit, OnDestroy {
     return this.langService.getLangValue(uaValue, enValue) as string;
   }
 
+
   addToFavourite() {
     this.bookmarkSelected = !this.bookmarkSelected;
+    if(!this.isRegistered) this.openAuthModalWindow('sign-in');
+  }
+
+  public openAuthModalWindow(page: string): void {
+    this.dialog.open(AuthModalComponent, {
+      hasBackdrop: true,
+      closeOnNavigation: true,
+      panelClass: ['custom-dialog-container'],
+      data: {
+        popUpName: page
+      }
+    });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Before: the 'Create Event' and 'Join to Event' bttn are n't displayed for the non-authorized user
After: the buttons “Joint Event”, “Create Event” or the icon “Add to Favorite” is available for the non-authorized user and the system is proposed to log in the system when a non-authorized user clicks on it.

