### PR TITLE
#5356: fix payment with expired and used certificates

### DIFF
--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.html
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.html
@@ -85,7 +85,7 @@
 
   <button
     type="button"
-    *ngIf="addCert && finalSum > 0 && !certificates.failed[certificates.codes.length - 1]"
+    *ngIf="addCert && finalSum > 0 && !certificates.failed[certificates.failed.length - 1]"
     class="addCertificateBtn"
     [hidden]="certificates.codes.length > 4"
     [disabled]="

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -129,6 +129,9 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
     this.certificates.failed.push(
       cert.certificateStatus === CertificateStatus.EXPIRED || cert.certificateStatus === CertificateStatus.USED
     );
+    if (this.certificates.failed[this.certificates.failed.length - 1]) {
+      this.certificates.codes.splice(-1);
+    }
     this.certificateSum =
       this.certificates.failed[this.certificates.failed.length - 1] && this.formArrayCertificates.length === 1 ? 0 : this.certificateSum;
     this.certificates.creationDates.push(this.certificateDateTreat(cert.creationDate));


### PR DESCRIPTION
**Before**
The message 'Упс, щось пішло не так...' is appeared when a user creates an order and activates an expired or used certificate

**After**
When the user pays with a used or expired certificate and doesn't cancel it, he is redirected to the Fondy payment system