### PR TITLE
Bugfix/#5387 remove extra columns in order list

### DIFF
--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.html
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.html
@@ -5,7 +5,7 @@
   <div class="header header_list-status">{{ 'user-orders.order-status' | translate }}</div>
   <div class="header header_list-paymentStatus">{{ 'user-orders.order-payment-status' | translate }}</div>
   <div class="header header_list-paymentAmount">{{ 'user-orders.payment-amount' | translate }}</div>
-  <div class="header header_list-paymentAmountDue">{{ 'user-orders.amount-due' | translate }}</div>
+  <div *ngIf="!isOrderDoneOrCancel(orders[0])" class="header header_list-paymentAmountDue">{{ 'user-orders.amount-due' | translate }}</div>
 
   <div class="empty-div"></div>
 </div>
@@ -46,7 +46,7 @@
           </mat-panel-description>
           <div class="mobile_list">
             <div class="mobile mobile_list-date">{{ 'user-orders.order-date' | translate }}</div>
-            <mat-panel-description class="order_list-paymentAmountDue table-data">
+            <mat-panel-description *ngIf="!isOrderDoneOrCancel(order)" class="order_list-paymentAmountDue table-data">
               {{ order.amountBeforePayment | currency | localizedCurrency }}
             </mat-panel-description>
           </div>

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.spec.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.spec.ts
@@ -134,13 +134,13 @@ describe('UbsUserOrdersListComponent', () => {
       spyOn(component, 'isOrderPriceGreaterThenZero').and.returnValue(true);
       spyOn(component, 'isOrderUnpaid').and.returnValue(true);
       const isOrderPaymentAccessRes = component.isOrderPaymentAccess(fakeIputOrderData[0] as any);
-      expect(isOrderPaymentAccessRes).toBeTruthy();
+      expect(isOrderPaymentAccessRes).toBeFalsy();
     });
 
     it('isOrderPriceGreaterThenZero and isOrderHalfPaid are true', () => {
       spyOn(component, 'isOrderPriceGreaterThenZero').and.returnValue(true);
       spyOn(component, 'isOrderHalfPaid').and.returnValue(true);
-      const isOrderPaymentAccessRes = component.isOrderPaymentAccess(fakeIputOrderData[2] as any);
+      const isOrderPaymentAccessRes = component.isOrderPaymentAccess(fakeIputOrderData[1] as any);
       expect(isOrderPaymentAccessRes).toBeTruthy();
     });
 

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-orders-list.component.ts
@@ -63,12 +63,22 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
     return order.orderStatusEng === CheckOrderStatus.CANCELED;
   }
 
+  public isOrderDoneOrCancel(order: IUserOrderInfo): boolean {
+    const isOrderDone = order.orderStatusEng === CheckOrderStatus.DONE;
+    const isOrderCancelled = order.orderStatusEng === CheckOrderStatus.CANCELED;
+    return isOrderDone || isOrderCancelled;
+  }
+
   public isOrderPriceGreaterThenZero(order: IUserOrderInfo): boolean {
     return order.orderFullPrice > 0;
   }
 
   public isOrderPaymentAccess(order: IUserOrderInfo): boolean {
-    return this.isOrderPriceGreaterThenZero(order) && (this.isOrderUnpaid(order) || this.isOrderHalfPaid(order));
+    return (
+      this.isOrderPriceGreaterThenZero(order) &&
+      (this.isOrderUnpaid(order) || this.isOrderHalfPaid(order)) &&
+      !this.isOrderDoneOrCancel(order)
+    );
   }
 
   public canOrderBeCancel(order: IUserOrderInfo): boolean {

--- a/src/assets/i18n/ubs/en.json
+++ b/src/assets/i18n/ubs/en.json
@@ -131,7 +131,7 @@
     "polyfoam": "polyfoam (type of packaging - 120 l bag (we take no more than 1 bag for 1 shipment)).",
     "condition1": "Indicate in the comment that you plan to give free positions to the Courier, as well as indicate their volume and number.",
     "condition2": "Pack each type of package separately. A mix of these wastes in one bag/box will not be collected by UBS Courier. Tie up packages before handing them over.",
-    "button": "Of course"
+    "button": "OK"
   },
   "personal-info": {
     "address-city": "city",

--- a/src/assets/i18n/ubs/en.json
+++ b/src/assets/i18n/ubs/en.json
@@ -242,7 +242,7 @@
     "header": {
       "caption": "NO WASTE — NO STRESS!",
       "content": "You sort - we recycle!",
-      "btn-order-courier": "Order a courier"
+      "btn-order-courier": "Order"
     },
     "pick-up-service": {
       "caption": "About service",

--- a/src/assets/i18n/ubs/ua.json
+++ b/src/assets/i18n/ubs/ua.json
@@ -237,7 +237,7 @@
     "header": {
       "caption": "Зручний pick up сервіс від УБС надає швидку сміттєву допомогу",
       "content": "Ви сортуєте — ми переробляємо!",
-      "btn-order-courier": "Замовити Кур’єра"
+      "btn-order-courier": "Замовити"
     },
     "pick-up-service": {
       "caption": "Про сервіс",


### PR DESCRIPTION
**Before**
The 'Amount-due' column 'Cancel' and 'Pay' buttons are displayed in the 'Order history' tab
![image](https://user-images.githubusercontent.com/101433204/222924390-31964e47-fb26-482b-a9a2-d3f574666be6.png)

**After**
The 'Amount-due' column, 'Cancel', and 'Pay' buttons aren`t displayed in the 'Order History' tab
![image](https://user-images.githubusercontent.com/101433204/222924417-842b9bc9-567c-4df4-9800-1212b8e16b33.png)
