### PR TITLE
bugfix/#5284-Disable 'Save' btn  in the raite modal in case if rating is not selected

### DIFF
--- a/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.html
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.html
@@ -1,23 +1,21 @@
 <div class="modal-inner">
   <h3 class="modal-title">
-    {{ isRegistered ? 'Evaluate the event and the organizer' : 'You cannot add this event. First register on the site'
-    }}
+    {{ isRegistered ? 'Evaluate the event and the organizer' : 'You cannot add this event. First register on the site' }}
   </h3>
   <div class="modal-rating" [hidden]="!isRegistered">
-    <rating (onHover)="hoveringOver($event)" [(ngModel)]="rate" [customTemplate]="star" [max]="max"
-      [readonly]="isReadonly"> </rating>
+    <rating (onHover)="hoveringOver($event)" [(ngModel)]="rate" [customTemplate]="star" [max]="max" [readonly]="isReadonly"> </rating>
     <ng-template #star let-index="index" let-value="value">
-      <span class="star {{ index < value ? 'fill' : 'empty' }}"></span>
+      <span (click)="starsHandler(value, index)" class="star {{ index < value ? 'fill' : 'empty' }}"></span>
     </ng-template>
     <p class="modal-text">{{ text | translate }}</p>
   </div>
 
   <div class="modal-bnt-group">
-    <button class="secondary-global-button modal-btn modal-btn-cancel" (click)="bsModalRef.hide()">{{'event.btn-close'
-      | translate}}</button>
-    <button (click)="modalBtn()" class="primary-global-button modal-btn">{{ isRegistered ? ('event.btn-save' |
-      translate
-      ):
-      ('event.btn-register' | translate)}}</button>
+    <button class="secondary-global-button modal-btn modal-btn-cancel" (click)="bsModalRef.hide()">
+      {{ 'event.btn-close' | translate }}
+    </button>
+    <button [ngClass]="{ disabled: !isEventRaited }" (click)="modalBtn()" class="primary-global-button modal-btn">
+      {{ isRegistered ? ('event.btn-save' | translate) : ('event.btn-register' | translate) }}
+    </button>
   </div>
 </div>

--- a/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.scss
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.scss
@@ -5,6 +5,12 @@
   }
 }
 
+.disabled {
+  pointer-events: none !important;
+  background-color: var(--primary-grey);
+}
+// [disabled]="!isEventRaited"
+
 .modal-inner {
   display: flex;
   width: 500px;

--- a/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.scss
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.scss
@@ -9,7 +9,6 @@
   pointer-events: none !important;
   background-color: var(--primary-grey);
 }
-// [disabled]="!isEventRaited"
 
 .modal-inner {
   display: flex;

--- a/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.spec.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.spec.ts
@@ -9,6 +9,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { of, Subject } from 'rxjs';
 import { EventEmitter, Injectable } from '@angular/core';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @Injectable()
 class TranslationServiceStub {
@@ -64,7 +65,7 @@ describe('EventsListItemModalComponent', () => {
         { provide: TranslateService, useClass: TranslationServiceStub },
         { provide: LocalStorageService, useValue: localStorageServiceMock }
       ],
-      imports: [RatingModule.forRoot(), ModalModule.forRoot(), MatDialogModule, TranslateModule.forRoot()]
+      imports: [RatingModule.forRoot(), ModalModule.forRoot(), MatDialogModule, TranslateModule.forRoot(), BrowserAnimationsModule]
     }).compileComponents();
   }));
 

--- a/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.ts
@@ -22,6 +22,7 @@ export class EventsListItemModalComponent implements OnInit, OnDestroy {
   public isPosting: boolean;
   public text: string;
   public elementName: string;
+  public isEventRaited = false;
 
   private dialog: MatDialog;
   private destroyed$: ReplaySubject<any> = new ReplaySubject<any>(1);
@@ -40,6 +41,10 @@ export class EventsListItemModalComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.subscribeToLangChange();
     this.bindLang(this.localStorageService.getCurrentLanguage());
+  }
+
+  public starsHandler(index: number, value: number): void {
+    index > value ? (this.isEventRaited = true) : (this.isEventRaited = false);
   }
 
   public modalBtn(): void {

--- a/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component.ts
@@ -44,7 +44,7 @@ export class EventsListItemModalComponent implements OnInit, OnDestroy {
   }
 
   public starsHandler(index: number, value: number): void {
-    index > value ? (this.isEventRaited = true) : (this.isEventRaited = false);
+    this.isEventRaited = index > value;
   }
 
   public modalBtn(): void {


### PR DESCRIPTION
Before:
The button 'Save' is not disabled in the modal 'Evaluate the event and the organizer'
After:
The button 'Save' is disabled in the modal 'Evaluate the event and the organizer' if event  not raited.