### PR TITLE
bugfix/#5437/UBS_Admin.Orders.Order_Details

### DIFF
--- a/src/app/ubs/ubs-admin/components/add-order-not-taken-out-reason/add-order-not-taken-out-reason.component.html
+++ b/src/app/ubs/ubs-admin/components/add-order-not-taken-out-reason/add-order-not-taken-out-reason.component.html
@@ -10,6 +10,7 @@
     <h6>{{ 'order-not-taken-out.label-reason' | translate }}</h6>
     <textarea
       placeholder="{{ 'order-not-taken-out.placeholder' | translate }}"
+      maxlength="256"
       cols="50"
       rows="6"
       formControlName="notTakenOutReason"

--- a/src/app/ubs/ubs-admin/components/add-order-not-taken-out-reason/add-order-not-taken-out-reason.component.html
+++ b/src/app/ubs/ubs-admin/components/add-order-not-taken-out-reason/add-order-not-taken-out-reason.component.html
@@ -16,7 +16,7 @@
       formControlName="notTakenOutReason"
       [(ngModel)]="notTakenOutReason"
     ></textarea>
-    <div class="error-message" *ngIf="addNotTakenOutForm.invalid && addNotTakenOutForm.get('notTakenOutReason').touched">
+    <div class="error-message" *ngIf="addNotTakenOutForm.invalid && addNotTakenOutForm.get('notTakenOutReason').dirty">
       <p>{{ 'order-not-taken-out.reason-error-message' | translate }}</p>
     </div>
   </form>

--- a/src/app/ubs/ubs-admin/components/add-order-not-taken-out-reason/add-order-not-taken-out-reason.component.scss
+++ b/src/app/ubs/ubs-admin/components/add-order-not-taken-out-reason/add-order-not-taken-out-reason.component.scss
@@ -3,7 +3,8 @@
   max-width: 573px;
   padding: 0 45px;
   overflow-y: auto;
-  height: calc(100vh - 48px);
+  max-height: 880px;
+  height: 90vh;
 
   &::-webkit-scrollbar {
     width: 8px;
@@ -80,6 +81,7 @@ textarea {
   align-items: center;
   width: 100%;
   height: 141px;
+  resize: none;
 }
 
 textarea::placeholder {


### PR DESCRIPTION
[UBS Admin. Orders. Order details] The frame of the field 'Опишіть, що сталося' on the pop-up 'Додайте причину невивезеного замовлення' can be extended by the Admin and the pop-up has not the end of it if an Admin provides zooming <= 90% #5437

https://github.com/ita-social-projects/GreenCity/issues/5437