### PR TITLE
bugfix/#5227 pattern for houseNumb

### DIFF
--- a/src/assets/patterns/patterns.ts
+++ b/src/assets/patterns/patterns.ts
@@ -10,7 +10,7 @@ export const Patterns = {
   profileCityPattern: /^[іІєЄїЇёЁa-zA-Zа-яА-Я][іІєЄїЇёЁa-zA-Zа-яА-Я\-,’')(! ]*$/,
 
   ubsCorpusPattern: /^[A-Za-zА-Яа-яїЇіІєЄёЁ0-9]{0,4}$/,
-  ubsHousePattern: /^[A-Za-zА-Яа-яїЇіІєЄёЁ0-9\.\-\/\,\\]+$/,
+  ubsHousePattern: /^[A-Za-zА-Яа-яїЇіІєЄёЁ0-9\-\\\/]+$/,
   ubsEntrNumPattern: /^([1-9]\d*)?$/,
 
   serteficatePattern: /(?!0000)\d{4}-(?!0000)\d{4}/,


### PR DESCRIPTION
The new pattern was written so that the user could not enter forbidden special characters
![image](https://user-images.githubusercontent.com/101433204/226616191-f5d75399-2c28-4092-8d70-234ea1ca4d31.png)
