### PR TITLE
bugfix/#5454-edited-styled-inputs-textallignment

### DIFF
--- a/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.html
@@ -8,7 +8,7 @@
     </button>
   </div>
   <ng-container *ngIf="!data.isDateFilter; else date">
-    <li *ngFor="let option of getOptionsForFiltering()">
+    <li *ngFor="let option of getOptionsForFiltering()" class="positioing">
       <mat-checkbox [checked]="option.filtered" (change)="changeColumnFilters($event?.checked, data.columnName, option)">
         {{ option | serverTranslate: data.currentLang }}
       </mat-checkbox>

--- a/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.scss
+++ b/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.scss
@@ -14,6 +14,10 @@ input[type='date'] {
   text-align: center;
 }
 
+.positioing {
+  margin-left: 10px;
+}
+
 .input-group {
   display: flex;
   flex-direction: column;

--- a/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.scss
+++ b/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.scss
@@ -1,7 +1,11 @@
 .filter-btn {
-  width: 145px;
+  width: 140px;
   border: 1px solid var(--ubs-quaternary-dark-grey);
   border-radius: 4px !important;
+}
+
+.btn-group {
+  gap: 7px;
 }
 
 .bg-lime {
@@ -9,18 +13,12 @@
   background-color: var(--ubs-primary-lime-green);
 }
 
+.positioing {
+  margin-left: 5px;
+}
+
 input[type='date'] {
   text-align: center;
-}
-
-.positioing {
-  margin-left: 10px;
-}
-
-.hidden {
-  overflow: hidden;
-  width: 50px;
-  height: 50px;
 }
 
 .input-group {

--- a/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.scss
+++ b/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.scss
@@ -1,6 +1,5 @@
 .filter-btn {
-  width: 155px;
-  margin: 0 5px;
+  width: 145px;
   border: 1px solid var(--ubs-quaternary-dark-grey);
   border-radius: 4px !important;
 }
@@ -16,6 +15,12 @@ input[type='date'] {
 
 .positioing {
   margin-left: 10px;
+}
+
+.hidden {
+  overflow: hidden;
+  width: 50px;
+  height: 50px;
 }
 
 .input-group {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.html
@@ -44,7 +44,7 @@
             </div>
             <div class="col-sm-2 d-flex justify-content-center form-group count" *ngIf="isVisible">
               <input
-                class="shadow-none form-control input p-2"
+                class="shadow-none form-control input p-1"
                 type="number"
                 min="0"
                 max="999"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.scss
@@ -248,7 +248,7 @@ input {
 
 @media only screen and (min-width: 250px) and (max-width: 376px) {
   .filter-table-btn {
-    margin-left: 7px;
+    margin-left: 15px;
     margin-right: 7px;
     width: 100px;
   }
@@ -260,15 +260,19 @@ input {
   }
 
   .search {
-    margin-left: 20px;
+    margin: 2%;
   }
 
   .view-table-btn {
     width: 100px;
+    margin-left: 7px;
+    margin-right: 7px;
   }
 
   .export-excel-btn {
     width: 110px;
+    margin-left: 7px;
+    margin-right: 7px;
   }
 }
 
@@ -286,7 +290,7 @@ input {
   }
 
   .search {
-    margin-left: 10px;
+    margin: 2%;
   }
 
   .view-table-btn {


### PR DESCRIPTION
#5489 The quantity of packages is cut by frame when it contains 3 digits
#5511 The 'Застосувати', 'Скасувати' buttons and checkboxes have different alignments in the pop-up of the column filter in the current orders view table
#5486 The horizontal and vertical scroll bars are displayed in the pop-up of column filter in the current orders view table
#5484 Search Field is not peoperly aligned on mobile devices #5484