### PR TITLE
bugfix/#5266 close pop-op after clicking on backgrouns

### DIFF
--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -217,20 +217,22 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
     this.isDialogOpen = true;
     const dialogRef = this.dialog.open(UbsOrderLocationPopupComponent, {
       hasBackdrop: true,
-      disableClose: true
+      disableClose: false
     });
 
     dialogRef
       .afterClosed()
       .pipe(takeUntil(this.destroy))
       .subscribe((res) => {
-        if (res.data) {
+        if (res && res.data) {
           this.locations = res.data;
           this.selectedLocationId = res.locationId;
           this.setCurrentLocation(res.currentLanguage);
           this.setLimitsValues();
           this.orderDetailsForm.markAllAsTouched();
           this.takeOrderData();
+        } else {
+          this.router.navigate(['/ubs']);
         }
         this.isDialogOpen = false;
       });


### PR DESCRIPTION
**Before**
The add location pop-up doen't close by clicking on the background

**After**
When a user clicks on the background, he is redirected to the UBS main page, and pop-up is closed