### PR TITLE
bugfix/#5556-changed-style

### DIFF
--- a/src/app/ubs/ubs-user/ubs-user-messages/ubs-user-messages.component.html
+++ b/src/app/ubs/ubs-user/ubs-user-messages/ubs-user-messages.component.html
@@ -3,7 +3,7 @@
     <div class="main_header">{{ localization.title | translate }}</div>
     <div class="header-list">
       <div class="col-2 pl-4 id">{{ localization.id | translate }}</div>
-      <div class="col-5 pl-3">{{ localization.themeMessages | translate }}</div>
+      <div class="col-5 pl-3 theme">{{ localization.themeMessages | translate }}</div>
       <div class="col-2 time">{{ localization.time | translate }}</div>
     </div>
     <div class="under-line"></div>

--- a/src/app/ubs/ubs-user/ubs-user-messages/ubs-user-messages.component.scss
+++ b/src/app/ubs/ubs-user/ubs-user-messages/ubs-user-messages.component.scss
@@ -275,6 +275,11 @@
     }
   }
 
+  .panel-description {
+    line-height: 0.9;
+    margin-right: 0;
+  }
+
   .mat-expansion-panel-header {
     width: 100%;
     padding: 0 10px;

--- a/src/app/ubs/ubs-user/ubs-user-messages/ubs-user-messages.component.scss
+++ b/src/app/ubs/ubs-user/ubs-user-messages/ubs-user-messages.component.scss
@@ -300,3 +300,38 @@
     background-color: var(--after-primary-light-grey);
   }
 }
+
+@media (max-width: 420px) {
+  .theme {
+    margin-left: 40px;
+  }
+
+  .id {
+    margin-left: -50px;
+  }
+
+  .time {
+    margin-right: 50px;
+  }
+}
+
+@media (max-width: 300px) {
+  .header-list {
+    div {
+      font-size: 12px;
+    }
+  }
+
+  .panel-description {
+    font-size: 12px;
+  }
+
+  .date {
+    font-size: 12px;
+  }
+
+  .panel-title {
+    font-size: 12px;
+    margin-left: -15px;
+  }
+}


### PR DESCRIPTION
 #5556 The text in the title of the notification is cut and the titles of the fields overlap each other in the tab Notification