### PR TITLE
Bugfix/#5585 ubs admin order table filtration by city and districts

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -213,8 +213,9 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
         this.restoredFilters.forEach((filter) => {
           if (Object.keys(filter).length < 2) {
             const column = this.adminTableService.changeColumnNameEqualToTable(Object.keys(filter)[0]);
+            const isLocation = column == 'city' || column == 'district';
             const value = String(Object.values(filter)[0]);
-            const options: IFilteredColumnValue = { key: value, filtered: false };
+            const options: IFilteredColumnValue = isLocation ? { en: value, filtered: true } : { key: value, filtered: true };
             this.changeFilters(true, column, options);
             this.applyFilters();
           } else {
@@ -887,14 +888,25 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
     return column.values.some((item) => item.filtered);
   }
 
-  checkIfFilteredBy(columnKey): boolean {
+  checkIfFilteredBy(columnKey: string): boolean {
     let key: string;
-    if (columnKey === 'paymentDate') {
-      key = 'paymentDateFrom';
-    } else {
-      key = columnKey === 'orderDate' ? 'orderDateFrom' : columnKey;
+    switch (columnKey) {
+      case 'paymentDate':
+        key = 'paymentDateFrom';
+        break;
+      case 'orderDate':
+        key = 'orderDateFrom';
+        break;
+      case 'city':
+        key = 'citiesEn';
+        break;
+      case 'district':
+        key = 'districtsEn';
+        break;
+      default:
+        key = columnKey;
+        break;
     }
-
     return this.adminTableService.filters ? this.adminTableService.filters.some((obj) => Object.keys(obj)[0] === key) : false;
   }
 

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -213,7 +213,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
         this.restoredFilters.forEach((filter) => {
           if (Object.keys(filter).length < 2) {
             const column = this.adminTableService.changeColumnNameEqualToTable(Object.keys(filter)[0]);
-            const isLocation = column == 'city' || column == 'district';
+            const isLocation = column === 'city' || column === 'district';
             const value = String(Object.values(filter)[0]);
             const options: IFilteredColumnValue = isLocation ? { en: value, filtered: true } : { key: value, filtered: true };
             this.changeFilters(true, column, options);

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -215,7 +215,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
             const column = this.adminTableService.changeColumnNameEqualToTable(Object.keys(filter)[0]);
             const isLocation = column === 'city' || column === 'district';
             const value = String(Object.values(filter)[0]);
-            const options: IFilteredColumnValue = isLocation ? { en: value, filtered: true } : { key: value, filtered: true };
+            const options: IFilteredColumnValue = isLocation ? { en: value } : { key: value };
             this.changeFilters(true, column, options);
             this.applyFilters();
           } else {

--- a/src/app/ubs/ubs-admin/models/ubs-admin.interface.ts
+++ b/src/app/ubs/ubs-admin/models/ubs-admin.interface.ts
@@ -356,7 +356,7 @@ export interface IFilteredColumnValue {
   key?: string;
   en?: string;
   ua?: string;
-  filtered: boolean;
+  filtered?: boolean;
 }
 
 export interface IDateFilters {

--- a/src/app/ubs/ubs-admin/services/admin-table.service.spec.ts
+++ b/src/app/ubs/ubs-admin/services/admin-table.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { AdminTableService } from './admin-table.service';
 import { environment } from '@environment/environment.js';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
@@ -109,7 +109,9 @@ describe('AdminTableService', () => {
       'responsibleNavigatorId',
       'responsibleCallerId',
       'responsibleLogicManId',
-      'orderStatus'
+      'orderStatus',
+      'citiesEn',
+      'districtsEn'
     ];
     const mockedColumns = [
       'dateOfExport',
@@ -117,7 +119,9 @@ describe('AdminTableService', () => {
       'responsibleNavigator',
       'responsibleCaller',
       'responsibleLogicMan',
-      'orderStatus'
+      'orderStatus',
+      'city',
+      'district'
     ];
 
     columns.forEach((column) => {
@@ -133,7 +137,9 @@ describe('AdminTableService', () => {
       'responsibleNavigator',
       'responsibleCaller',
       'responsibleLogicMan',
-      'orderStatus'
+      'orderStatus',
+      'city',
+      'district'
     ];
     const mockedColumns = [
       'deliveryDate',
@@ -141,7 +147,9 @@ describe('AdminTableService', () => {
       'responsibleNavigatorId',
       'responsibleCallerId',
       'responsibleLogicManId',
-      'orderStatus'
+      'orderStatus',
+      'citiesEn',
+      'districtsEn'
     ];
 
     columns.forEach((column) => {
@@ -177,6 +185,18 @@ describe('AdminTableService', () => {
     option = { key: 'FORMED', ua: 'Сформовано', en: 'Formed', filtered: false };
     service.changeFilters(true, 'orderStatus', option);
     expect(localStorageService.getUbsAdminOrdersTableTitleColumnFilter()).toContain({ orderStatus: option.key });
+  });
+
+  it('should set isLocation', () => {
+    let currentColumn = 'orderStatus';
+    let isLocation = currentColumn === 'citiesEn';
+    expect(isLocation).toBeFalsy();
+    currentColumn = 'citiesEn';
+    isLocation = currentColumn === 'citiesEn';
+    expect(isLocation).toBeTruthy();
+    currentColumn = 'districtsEn';
+    isLocation = currentColumn === 'districtsEn';
+    expect(isLocation).toBeTruthy();
   });
 
   it('should call changeDateFilters', () => {

--- a/src/app/ubs/ubs-admin/services/admin-table.service.ts
+++ b/src/app/ubs/ubs-admin/services/admin-table.service.ts
@@ -96,6 +96,12 @@ export class AdminTableService {
       case 'responsibleLogicMan':
         endPointColumnName = 'responsibleLogicManId';
         break;
+      case 'city':
+        endPointColumnName = 'citiesEn';
+        break;
+      case 'district':
+        endPointColumnName = 'districtsEn';
+        break;
       default:
         endPointColumnName = column;
         break;
@@ -121,6 +127,12 @@ export class AdminTableService {
       case 'responsibleLogicManId':
         tableColumnName = 'responsibleLogicMan';
         break;
+      case 'citiesEn':
+        tableColumnName = 'city';
+        break;
+      case 'districtsEn':
+        tableColumnName = 'district';
+        break;
       default:
         tableColumnName = column;
         break;
@@ -130,11 +142,12 @@ export class AdminTableService {
 
   changeFilters(checked: boolean, currentColumn: string, option: IFilteredColumnValue): void {
     const elem = {};
-    const columnName = this.changeColumnNameEqualToEndPoint(currentColumn);
+    let columnName = this.changeColumnNameEqualToEndPoint(currentColumn);
+    const isLocation = columnName == 'citiesEn' || columnName == 'districtsEn';
     this.columnsForFiltering.find((column) => {
       if (column.key === currentColumn) {
         column.values.find((value) => {
-          if (value.key === option.key) {
+          if (value.key === option.key || value.en === option.en) {
             value.filtered = checked;
           }
         });
@@ -142,10 +155,10 @@ export class AdminTableService {
     });
     this.setColumnsForFiltering(this.columnsForFiltering);
     if (checked) {
-      elem[columnName] = option.key;
+      elem[columnName] = isLocation ? option.en : option.key;
       this.filters = [...this.filters, elem];
     } else {
-      this.filters = this.filters.filter((filteredElem) => filteredElem[columnName] !== option.key);
+      this.filters = this.filters.filter((filteredElem) => filteredElem[columnName] !== (isLocation ? option.en : option.key));
     }
     this.localStorageService.setUbsAdminOrdersTableTitleColumnFilter(this.filters);
   }

--- a/src/app/ubs/ubs-admin/services/admin-table.service.ts
+++ b/src/app/ubs/ubs-admin/services/admin-table.service.ts
@@ -142,8 +142,8 @@ export class AdminTableService {
 
   changeFilters(checked: boolean, currentColumn: string, option: IFilteredColumnValue): void {
     const elem = {};
-    let columnName = this.changeColumnNameEqualToEndPoint(currentColumn);
-    const isLocation = columnName == 'citiesEn' || columnName == 'districtsEn';
+    const columnName = this.changeColumnNameEqualToEndPoint(currentColumn);
+    const isLocation = columnName === 'citiesEn' || columnName === 'districtsEn';
     this.columnsForFiltering.find((column) => {
       if (column.key === currentColumn) {
         column.values.find((value) => {


### PR DESCRIPTION
- Fixed that in UBS Admin - order table - filter by city and district work by en value