### PR TITLE
bugfix/#5689-edited-popup-positioning

### DIFF
--- a/src/app/main/component/shared/components/calendar-base/calendar-base.component.ts
+++ b/src/app/main/component/shared/components/calendar-base/calendar-base.component.ts
@@ -321,11 +321,7 @@ export class CalendarBaseComponent implements OnDestroy {
     const habits = this.getHabitsForDay(this.userHabitsList, date);
     const pos = event.target.getBoundingClientRect();
     this.breakpointObserver.observe(['(max-width: 912px)']).subscribe((result: BreakpointState) => {
-      if (result.matches) {
-        horisontalPositioning = '';
-      } else {
-        horisontalPositioning = pos.left + '300px';
-      }
+      horisontalPositioning = result.matches ? '' : pos.left + '300px';
     });
     const dialogConfig = new MatDialogConfig();
     dialogConfig.disableClose = false;

--- a/src/app/main/component/shared/components/calendar-base/calendar-base.component.ts
+++ b/src/app/main/component/shared/components/calendar-base/calendar-base.component.ts
@@ -10,6 +10,7 @@ import { HabitsPopupComponent } from '@global-user/components/profile/calendar/h
 import { HabitsForDateInterface } from '@global-user/components/profile/calendar/habit-popup-interface';
 import { ItemClass } from './CalendarItemStyleClasses';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 
 @Component({
   selector: 'app-calendar-base',
@@ -64,7 +65,8 @@ export class CalendarBaseComponent implements OnDestroy {
     public translate: TranslateService,
     public languageService: LanguageService,
     public habitAssignService: HabitAssignService,
-    public dialog: MatDialog
+    public dialog: MatDialog,
+    public breakpointObserver: BreakpointObserver
   ) {}
 
   ngOnDestroy() {
@@ -308,6 +310,7 @@ export class CalendarBaseComponent implements OnDestroy {
 
   openDialogDayHabits(event, isMonthCalendar, dayItem: CalendarInterface) {
     const dateForHabitPopup = `${dayItem.year}-${dayItem.month + 1}-${dayItem.numberOfDate}`;
+    let horisontalPositioning: string;
     if (dayItem.numberOfDate) {
       this.habitAssignService.habitDate = new Date(dateForHabitPopup);
     } else {
@@ -317,13 +320,20 @@ export class CalendarBaseComponent implements OnDestroy {
     const date = this.formatDate(isMonthCalendar, dayItem);
     const habits = this.getHabitsForDay(this.userHabitsList, date);
     const pos = event.target.getBoundingClientRect();
+    this.breakpointObserver.observe(['(max-width: 912px)']).subscribe((result: BreakpointState) => {
+      if (result.matches) {
+        horisontalPositioning = '';
+      } else {
+        horisontalPositioning = pos.left + '300px';
+      }
+    });
     const dialogConfig = new MatDialogConfig();
     dialogConfig.disableClose = false;
     dialogConfig.autoFocus = true;
     dialogConfig.backdropClass = 'backdropBackground';
     dialogConfig.position = {
-      top: pos.y + 20 + 'px',
-      left: pos.x - 300 + 'px'
+      top: pos.top + '80px',
+      left: horisontalPositioning
     };
     dialogConfig.data = {
       habitsCalendarSelectedDate: this.formatSelectedDate(isMonthCalendar, dayItem),

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-calendar/habit-calendar.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-calendar/habit-calendar.component.ts
@@ -5,7 +5,7 @@ import { HabitAssignService } from './../../../../../../service/habit-assign/hab
 import { CalendarBaseComponent } from '@shared/components/calendar-base/calendar-base.component';
 import { CalendarInterface } from '@global-user/components/profile/calendar/calendar-interface';
 import { MatDialog } from '@angular/material/dialog';
-
+import { BreakpointObserver } from '@angular/cdk/layout';
 @Component({
   selector: 'app-habit-calendar',
   templateUrl: './../../../profile/calendar/calendar.component.html',
@@ -16,9 +16,10 @@ export class HabitCalendarComponent extends CalendarBaseComponent implements OnI
     public translate: TranslateService,
     public languageService: LanguageService,
     public habitAsignService: HabitAssignService,
-    public dialog: MatDialog
+    public dialog: MatDialog,
+    public breakpointObserver: BreakpointObserver
   ) {
-    super(translate, languageService, habitAsignService, dialog);
+    super(translate, languageService, habitAsignService, dialog, breakpointObserver);
   }
 
   ngOnInit() {

--- a/src/app/main/component/user/components/profile/calendar/calendar-week/calendar-week.component.ts
+++ b/src/app/main/component/user/components/profile/calendar/calendar-week/calendar-week.component.ts
@@ -9,6 +9,7 @@ import { takeUntil } from 'rxjs/operators';
 import { CalendarWeekInterface } from '../calendar-week/calendar-week-interface';
 import { CalendarInterface } from '../calendar-interface';
 import { MatDialog } from '@angular/material/dialog';
+import { BreakpointObserver } from '@angular/cdk/layout';
 
 @Component({
   selector: 'app-calendar-week',
@@ -27,9 +28,10 @@ export class CalendarWeekComponent extends CalendarBaseComponent implements OnIn
     public habitAssignService: HabitAssignService,
     public translate: TranslateService,
     public languageService: LanguageService,
-    public dialog: MatDialog
+    public dialog: MatDialog,
+    public breakpointObserver: BreakpointObserver
   ) {
-    super(translate, languageService, habitAssignService, dialog);
+    super(translate, languageService, habitAssignService, dialog, breakpointObserver);
   }
 
   ngOnInit() {

--- a/src/app/main/component/user/components/profile/calendar/calendar.component.ts
+++ b/src/app/main/component/user/components/profile/calendar/calendar.component.ts
@@ -5,6 +5,7 @@ import { LanguageService } from 'src/app/main/i18n/language.service';
 import { HabitAssignService } from '@global-service/habit-assign/habit-assign.service';
 import { CalendarInterface } from './calendar-interface';
 import { MatDialog } from '@angular/material/dialog';
+import { BreakpointObserver } from '@angular/cdk/layout';
 
 @Component({
   selector: 'app-calendar',
@@ -16,9 +17,10 @@ export class CalendarComponent extends CalendarBaseComponent implements OnInit, 
     public translate: TranslateService,
     public languageService: LanguageService,
     public habitAssignService: HabitAssignService,
-    public dialog: MatDialog
+    public dialog: MatDialog,
+    public breakpointObserver: BreakpointObserver
   ) {
-    super(translate, languageService, habitAssignService, dialog);
+    super(translate, languageService, habitAssignService, dialog, breakpointObserver);
   }
 
   ngOnInit() {

--- a/src/app/main/component/user/components/profile/calendar/habits-popup/habits-popup.component.scss
+++ b/src/app/main/component/user/components/profile/calendar/habits-popup/habits-popup.component.scss
@@ -60,3 +60,48 @@
 ::ng-deep .mat-dialog-container {
   padding: 0;
 }
+
+@media (max-width: 290px) {
+  .calendar-habits-open {
+    width: 234px;
+    height: 70px;
+    color: var(--primary-dark-grey);
+    margin-top: 20px;
+    box-shadow: none;
+    border-radius: 0;
+    overflow-x: hidden;
+  }
+
+  .habits-item {
+    font-weight: 400;
+    font-size: 10px;
+    line-height: 1px;
+    overflow: hidden;
+    color: var(--primary-dark-grey);
+    flex-wrap: wrap;
+    inline-size: 200px;
+    overflow-wrap: break-word;
+  }
+
+  .habits-list {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0;
+    margin: 0;
+  }
+
+  .habit-icon {
+    padding-right: 5px;
+    width: 25px;
+    height: auto;
+    cursor: pointer;
+  }
+
+  .habits-title {
+    font-weight: 700;
+    font-size: 8px;
+    line-height: 1px;
+    color: var(--primary-dark-grey);
+  }
+}

--- a/src/app/ubs/ubs-user/ubs-user-messages/ubs-user-messages.component.scss
+++ b/src/app/ubs/ubs-user/ubs-user-messages/ubs-user-messages.component.scss
@@ -151,6 +151,7 @@
   line-height: 24px;
   letter-spacing: 0;
   text-align: left;
+  margin: 3% 0 15% 0;
 
   li {
     margin-right: 10px;
@@ -240,6 +241,10 @@
     background-color: var(--after-primary-light-grey);
   }
 
+  .my-pagination {
+    margin-top: 3%;
+  }
+
   .time {
     margin-left: -8px;
   }
@@ -289,6 +294,10 @@
     }
   }
 
+  .my-pagination {
+    margin-top: 3%;
+  }
+
   .wrapper {
     width: 100vw;
     position: relative;
@@ -313,6 +322,10 @@
   .time {
     margin-right: 50px;
   }
+
+  .my-pagination {
+    margin-top: 3%;
+  }
 }
 
 @media (max-width: 300px) {
@@ -333,5 +346,9 @@
   .panel-title {
     font-size: 12px;
     margin-left: -15px;
+  }
+
+  .my-pagination {
+    margin-top: 3%;
   }
 }


### PR DESCRIPTION
#5689 Off-screen habits-calendar-popup on 'Edit habit' page after the page resize. 
#5582 The footer on the Messages page overlaps the content of the notification and pagination UI element when the user expands the 10th notification 