### PR TITLE
bugfix/#5715, #5693-Fix-display-order-status-and-payment-status-for-canceled-order

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-client-info/ubs-admin-order-client-info.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-client-info/ubs-admin-order-client-info.component.ts
@@ -36,7 +36,7 @@ export class UbsAdminOrderClientInfoComponent implements OnInit, OnChanges, OnDe
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.orderStatus.currentValue) {
+    if (changes.orderStatus?.currentValue) {
       this.isOrderDone = changes.orderStatus.currentValue === OrderStatus.DONE;
       this.isOrderCanceled = changes.orderStatus.currentValue === OrderStatus.CANCELED;
       this.isOrderNotTakenOut = changes.orderStatus.currentValue === OrderStatus.NOT_TAKEN_OUT;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
@@ -46,6 +46,9 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
     }
 
     if (changes.generalInfo) {
+      if (changes.generalInfo.currentValue.orderStatus === OrderStatus.CANCELED) {
+        this.generalInfo.orderPaymentStatus = PaymnetStatus.UNPAID;
+      }
       this.availableOrderStatuses = this.orderService.getAvailableOrderStatuses(
         changes.generalInfo.currentValue.orderStatus,
         changes.generalInfo.currentValue.orderStatusesDtos

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
@@ -46,7 +46,7 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
     }
 
     if (changes.generalInfo) {
-      if (changes.generalInfo.currentValue.orderStatus === OrderStatus.CANCELED) {
+      if (changes.generalInfo.currentValue.orderPaymentStatusNameEng === 'Unpaid') {
         this.generalInfo.orderPaymentStatus = PaymnetStatus.UNPAID;
       }
       this.availableOrderStatuses = this.orderService.getAvailableOrderStatuses(

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -110,7 +110,6 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
   public onCancelOrder(): void {
     this.isOrderStatusChanged = true;
     this.setOrderDetails();
-    this.initForm();
   }
 
   public getOrderInfo(orderId: number, submitMode: boolean): void {


### PR DESCRIPTION
Before: 
1. Admin can select the status "Canceled" in the order from the second time.
2. Payment status changes as follows: Unpayd-empty field-unpaid-paid in the order form.
3. After refresh order table page  Payment status changes.

After:
1. Admin can select the status "Canceled" from the first time in the order form.
2. Payment status not changes.
