### PR TITLE
Bugfix/#4798 accessibility for sidebar

### DIFF
--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.html
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.html
@@ -1,23 +1,5 @@
 <div class="main">
-  <div [ngClass]="{ 'admin-sidebar-icons': isAdmin, 'sidebar-icons': true }" #sideBarIcons>
-    <ul class="sidebar-list">
-      <li class="toggle-arrow">
-        <button mat-icon-button aria-label="Sidebar menu" (click)="toggleSideBar()">
-          <mat-icon>arrow_forward</mat-icon>
-        </button>
-      </li>
-      <li
-        *ngFor="let listItem of listElements"
-        [routerLink]="listItem.routerLink"
-        [routerLinkActive]="['active']"
-        class="sidebar-list-item"
-      >
-        <img [src]="getIcon(listItem)" class="sidebar-list-item-icon" alt="sidebar list item icon" />
-      </li>
-    </ul>
-  </div>
-
-  <mat-drawer-container class="sidebar" autosize>
+  <mat-drawer-container class="sidebar" autosize role="navigation" aria-label="Sidebar menu">
     <mat-drawer
       #drawer
       [ngClass]="isAdmin ? 'admin-sidebar-slider' : 'sidebar-slider'"
@@ -25,11 +7,17 @@
       opened="true"
       disableClose="true"
       autoFocus="false"
+      aria-labelledby="sidebar-list"
     >
-      <ul class="sidebar-list">
+      <ul id="sidebar-list" class="sidebar-list">
         <li class="toggle-arrow">
-          <button mat-icon-button aria-label="Sidebar menu" (click)="toggleSideBar()">
-            <mat-icon>arrow_back</mat-icon>
+          <button
+            mat-icon-button
+            [attr.aria-label]="isExpanded ? 'Collapse sidebar menu' : 'Expand sidebar menu'"
+            (click)="toggleMenu()"
+            role="button"
+          >
+            <mat-icon>{{ isExpanded ? 'arrow_back' : 'arrow_forward' }}</mat-icon>
           </button>
         </li>
         <li
@@ -37,18 +25,27 @@
           [routerLink]="listItem.routerLink"
           [routerLinkActive]="['active']"
           class="sidebar-list-item"
+          [ngClass]="{ 'sidebar-list-item__collapsed': !isExpanded }"
+          role="listitem"
+          [attr.aria-label]="listItem.name | translate"
+          (keydown.enter)="navigateToPage(listItem.routerLink)"
+          (keydown.space)="navigateToPage(listItem.routerLink)"
         >
-          <img [src]="getIcon(listItem)" class="sidebar-list-item-icon" alt="sidebar list item icon" />
-          <span class="sidebar-list-item-link">{{ listItem.name | translate }}</span>
-          <div *ngIf="listItem.name === 'ubs-user.messages' && serviceUserMessages.countOfNoReadeMessages" class="count-unread-messages">
+          <img [src]="getIcon(listItem)" class="sidebar-list-item-icon" alt="{{ listItem.name | translate }} icon" />
+          <span *ngIf="isExpanded" class="sidebar-list-item-link">{{ listItem.name | translate }}</span>
+          <span
+            *ngIf="listItem.name === 'ubs-user.messages' && serviceUserMessages.countOfNoReadeMessages && isExpanded"
+            class="count-unread-messages"
+            aria-live="polite"
+          >
             ({{ serviceUserMessages.countOfNoReadeMessages }})
-          </div>
+          </span>
         </li>
       </ul>
     </mat-drawer>
 
-    <mat-drawer-content [ngClass]="isAdmin ? 'admin-main-content' : 'main-content'">
-      <div class="sidebar-container" #sidebarContainer>
+    <mat-drawer-content [ngClass]="isAdmin ? 'admin-main-content' : 'main-content'" role="main">
+      <div [ngClass]="{ 'margin-for-table': !isAdmin, 'sidebar-container': true }" #sidebarContainer>
         <ng-content></ng-content>
       </div>
     </mat-drawer-content>

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.html
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.html
@@ -28,8 +28,8 @@
           [ngClass]="{ 'sidebar-list-item__collapsed': !isExpanded }"
           role="listitem"
           [attr.aria-label]="listItem.name | translate"
-          (keydown.enter)="navigateToPage(listItem.routerLink)"
-          (keydown.space)="navigateToPage(listItem.routerLink)"
+          (keydown.enter)="navigateToPage($event, listItem.routerLink)"
+          (keydown.space)="navigateToPage($event, listItem.routerLink)"
         >
           <img [src]="getIcon(listItem)" class="sidebar-list-item-icon" alt="{{ listItem.name | translate }} icon" />
           <span *ngIf="isExpanded" class="sidebar-list-item-link">{{ listItem.name | translate }}</span>

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.scss
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.scss
@@ -23,7 +23,6 @@
       position: fixed;
       top: 50px;
       background-color: var(--ubs-primary-grey);
-      // width: 200px;
       z-index: 3;
     }
   }

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.scss
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.scss
@@ -16,7 +16,6 @@
       position: fixed;
       top: 80px;
       background-color: var(--ubs-primary-grey);
-      width: 228px;
       z-index: 3;
     }
 
@@ -24,7 +23,7 @@
       position: fixed;
       top: 50px;
       background-color: var(--ubs-primary-grey);
-      width: 200px;
+      // width: 200px;
       z-index: 3;
     }
   }
@@ -55,6 +54,10 @@
       cursor: pointer;
       padding: 15px 39px 15px 15px;
       white-space: nowrap;
+    }
+
+    .sidebar-list-item__collapsed {
+      padding: 15px;
     }
   }
 
@@ -168,7 +171,7 @@
   }
 
   .sidebar {
-    .sidebar-container {
+    .margin-for-table {
       margin-left: 85px !important;
     }
   }

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.spec.ts
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.spec.ts
@@ -81,11 +81,6 @@ describe('UbsBaseSidebarComponent', () => {
     expect(component.getIcon(listItem)).toBe(component.bellsNotification);
   });
 
-  it('should toggle sidebar menu state', () => {
-    component.toggleSideBar();
-    expect(component.toggleSideBar).toBeTruthy();
-  });
-
   it('should trigger onResize method when window is resized', () => {
     const spyOnResize = spyOn(component, 'onResize');
     window.dispatchEvent(new Event('resize'));

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
@@ -84,14 +84,12 @@ export class UbsBaseSidebarComponent implements AfterViewInit, AfterViewChecked,
 
   public toggleMenu() {
     this.isExpanded = !this.isExpanded;
-    //this.setIndexToSidebarIcons();
   }
 
   @HostListener('window:resize', ['$event'])
   onResize(event) {
     if (this.drawer) {
       this.isExpanded = event.target.innerWidth > this.sidebarChangeBreakpoint || window.innerWidth > this.sidebarChangeBreakpoint;
-      //this.setIndexToSidebarIcons();
     }
   }
 
@@ -113,7 +111,6 @@ export class UbsBaseSidebarComponent implements AfterViewInit, AfterViewChecked,
   ngAfterViewInit(): void {
     this.sidebarChangeBreakpoint = 1266;
     if (window.innerWidth < this.sidebarChangeBreakpoint && this.drawer) {
-      //this.drawer.toggle();
       this.isExpanded = false;
     }
     setTimeout(() => {

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
@@ -45,7 +45,7 @@ export class UbsBaseSidebarComponent implements AfterViewInit, AfterViewChecked,
     public serviceUserMessages: UserMessagesService,
     public breakpointObserver: BreakpointObserver,
     public jwtService: JwtService,
-    private router: Router,
+    private router?: Router,
     private cdr?: ChangeDetectorRef
   ) {}
 

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
@@ -51,17 +51,10 @@ export class UbsBaseSidebarComponent implements AfterViewInit, AfterViewChecked,
 
   public isExpanded = false;
 
-  public navigateToPage(routerLink: string): void {
+  public navigateToPage(event: Event, routerLink: string): void {
+    event.stopPropagation();
     const mainLink = this.isAdmin ? 'ubs-admin' : 'ubs-user';
-    console.log('el', this.listElements);
-    console.log('routerLink', routerLink);
-
-    const route = [mainLink];
-    const routes = routerLink.split('/');
-
-    route.push(...routes);
-
-    this.router.navigate(route);
+    this.router.navigate([mainLink, ...routerLink.split('/')]);
   }
 
   public setIndexToSidebarIcons(): void {

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
@@ -7,10 +7,9 @@ import {
   OnDestroy,
   ViewChild,
   ChangeDetectorRef,
-  AfterViewChecked,
-  EventEmitter
+  AfterViewChecked
 } from '@angular/core';
-import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { BreakpointObserver } from '@angular/cdk/layout';
 import { MatDrawer } from '@angular/material/sidenav';
 import { UserMessagesService } from '../../ubs/ubs-user/services/user-messages.service';
 import { Subject } from 'rxjs';

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
@@ -108,7 +108,6 @@ export class UbsBaseSidebarComponent implements AfterViewInit, AfterViewChecked,
     }
     setTimeout(() => {
       this.breakpointObserver.observe([this.CUSTOM_BREAKPOINTS.XSmall]).subscribe((result) => {
-        console.log(result);
         if (this.drawer) {
           this.drawer.mode = 'side';
           this.drawer.opened = !result.matches;
@@ -116,7 +115,6 @@ export class UbsBaseSidebarComponent implements AfterViewInit, AfterViewChecked,
       });
     }, 0);
     this.getCountOfUnreadNotification();
-    console.log(Breakpoints.Small, Breakpoints.XSmall);
   }
 
   ngAfterViewChecked(): void {


### PR DESCRIPTION
**Before**
Icons and items of the sidebar list element can be selected separately by using Tab key on the keyboard
![image](https://user-images.githubusercontent.com/101433204/234877456-65286380-2154-49de-8651-184f0fb81335.png)

**After**
Super Admin can select each element of the sidebar list by Tab key without pressing on the image separately name of the item
https://user-images.githubusercontent.com/101433204/234880704-6a35c8dc-79d7-4049-b5ed-20ca4c166100.mp4

