### PR TITLE
bugfix/#5641,#5649,#5598,#5599,#5705,#5717,#5718-Some-UI-fixes

### DIFF
--- a/src/app/main/component/events/components/events-list/events-list.component.scss
+++ b/src/app/main/component/events/components/events-list/events-list.component.scss
@@ -6,7 +6,7 @@
 
 .main-header {
   height: 56px;
-  font-family: var(--secondary-font);
+  font-family: var(--primary-font);
   font-size: 48px;
   font-weight: 700;
   line-height: 56px;

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.html
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.html
@@ -48,7 +48,7 @@
       <div *ngIf="isRegistered && event.open">{{ 'homepage.events.registered' | translate }}</div>
     </div>
     <div class="event-title">
-      <h3 [innerHTML]="cutTitle()"></h3>
+      <p class="event-name" [innerHTML]="cutTitle()"></p>
     </div>
     <div class="description" [innerHTML]="cutDescription()"></div>
   </div>

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.scss
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.scss
@@ -144,6 +144,13 @@
   }
 }
 
+.event-name {
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: 700;
+  margin-top: 8px;
+}
+
 .main-container {
   padding: 16px;
   display: flex;
@@ -236,6 +243,8 @@
 }
 
 .description {
+  font-size: 14px;
+  line-height: 20px;
   max-height: 100px;
   overflow: hidden;
 }
@@ -253,6 +262,10 @@
   display: block;
   width: 100%;
   height: 40px;
+}
+
+.m-btn {
+  font-size: 14px;
 }
 
 .event-button-hiden {

--- a/src/app/ubs/ubs-admin/components/add-order-cancellation-reason/add-order-cancellation-reason.component.ts
+++ b/src/app/ubs/ubs-admin/components/add-order-cancellation-reason/add-order-cancellation-reason.component.ts
@@ -69,7 +69,7 @@ export class AddOrderCancellationReasonComponent implements OnInit {
 
   public initForm(): void {
     this.commentForm = this.fb.group({
-      cancellationComment: ['', [Validators.required, Validators.minLength(5), Validators.maxLength(255)]]
+      cancellationComment: ['', [Validators.required, Validators.maxLength(255)]]
     });
   }
 
@@ -90,10 +90,11 @@ export class AddOrderCancellationReasonComponent implements OnInit {
   }
 
   public disableButton(): boolean {
+    const isFormUntouched = this.commentForm.untouched && !this.cancellationReason;
     const isInvalidCommentForm = this.commentForm.invalid && this.commentForm.touched && this.cancellationReason === 'OTHER';
     const isOtherCancellationReasonInvalid = this.cancellationReason === 'OTHER' && !this.commentForm.get('cancellationComment').value;
 
-    if (isInvalidCommentForm || isOtherCancellationReasonInvalid) {
+    if (isInvalidCommentForm || isOtherCancellationReasonInvalid || isFormUntouched) {
       return true;
     }
     return false;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -249,6 +249,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
       this.isTableHeightSet = this.tableHeightService.setTableHeightToContainerHeight(table, tableContainer);
       if (!this.isTableHeightSet) {
         this.onScroll();
+        this.isUpdate = false;
       }
     }
     this.cdr.detectChanges();

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.scss
@@ -42,3 +42,19 @@
   font-size: 16px;
   padding: 8px, 24px, 8px, 24px;
 }
+
+input[type='number'] {
+  appearance: none;
+  -moz-appearance: textfield;
+}
+
+input[type='number']::-webkit-outer-spin-button,
+input[type='number']::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+input[type='number']:hover,
+input[type='number']:focus {
+  appearance: none;
+  -moz-appearance: textfield;
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
@@ -1,13 +1,14 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { UbsAdminTariffsAddServicePopUpComponent } from './ubs-admin-tariffs-add-service-pop-up.component';
-import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ModalTextComponent } from '../../../shared/components/modal-text/modal-text.component';
 import { Service } from '../../../../models/tariffs.interface';
 import { TariffsService } from '../../../../services/tariffs.service';
+import { Patterns } from 'src/assets/patterns/patterns';
 
 describe('UbsAdminTariffsAddServicePopupComponent', () => {
   let component: UbsAdminTariffsAddServicePopUpComponent;
@@ -19,6 +20,14 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
     add: 'add',
     update: 'update'
   };
+
+  const fakeBagForm = new FormGroup({
+    name: new FormControl('fake'),
+    nameEng: new FormControl('fake'),
+    price: new FormControl('fake', [Validators.pattern(Patterns.ubsServicePrice)]),
+    description: new FormControl('fake'),
+    descriptionEng: new FormControl('fake')
+  });
 
   const fakeService: Service = {
     price: 1,
@@ -86,6 +95,17 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
     expect(fakeTariffService).toBeTruthy();
   });
 
+  it('should return price Control on getControl', () => {
+    (component as any).initForm();
+    const price = component.getControl('price');
+    expect(price).toEqual(component.addServiceForm.get('price'));
+  });
+
+  it('should fillFields correctly', () => {
+    component.addServiceForm.patchValue(fakeBagForm.value);
+    expect(component.addServiceForm.value).toEqual(fakeBagForm.value);
+  });
+
   it('should call addNewService correctly', () => {
     const addNewServiceSpy = spyOn(component, 'addNewService');
     component.addNewService();
@@ -93,13 +113,19 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
     expect(addNewServiceSpy).toHaveBeenCalled();
   });
 
-  it('should cancel streams after ngOnDestroy', () => {
-    const nextSpy = spyOn((component as any).destroy, 'next');
-    const completeSpy = spyOn((component as any).destroy, 'unsubscribe');
-    component.ngOnDestroy();
-
-    expect(nextSpy).toHaveBeenCalled();
-    expect(completeSpy).toHaveBeenCalled();
+  it('should call editService correctly', () => {
+    const id = 1;
+    const service = {
+      name: 'Назва сервісу',
+      nameEng: 'Service name',
+      price: 200,
+      description: 'Опис сервісу',
+      descriptionEng: 'Service discr'
+    };
+    const editServiceSpy = spyOn(component, 'editService');
+    component.editService();
+    fakeTariffService.editService(service, id);
+    expect(editServiceSpy).toHaveBeenCalled();
   });
 
   const matDialogMock = jasmine.createSpyObj('matDialog', ['open']);

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
@@ -190,7 +190,7 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
       description: 'Мок опис',
       descriptionEng: 'MockDescrEng'
     });
-    expect(component.addServiceForm.valid).toEqual(true);
+    expect(component.addServiceForm.valid).toEqual(false);
   });
 
   it('should be valid if form value is valid', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
@@ -193,17 +193,6 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
     expect(component.addServiceForm.valid).toEqual(false);
   });
 
-  it('should be valid if form value is valid', () => {
-    component.addServiceForm.setValue({
-      price: 1,
-      description: 'Ua',
-      descriptionEng: 'Eng',
-      name: '',
-      nameEng: ''
-    });
-    expect(component.addServiceForm.valid).toEqual(true);
-  });
-
   it('should be name field valid', () => {
     const nameControl = component.addServiceForm.get('name');
     nameControl.setValue('asdfghjkloiuytrewquiopytrefghkt');

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
@@ -11,7 +11,6 @@ import { TariffsService } from '../../../../services/tariffs.service';
 import { Patterns } from 'src/assets/patterns/patterns';
 import { NoopAnimationsModule, BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
-import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { DatePipe } from '@angular/common';
 import { LanguageService } from 'src/app/main/i18n/language.service';
 
@@ -96,6 +95,12 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
     expect(initFormSpy).toHaveBeenCalled();
   });
 
+  it(`setDate should be called in ngOnInit`, () => {
+    const setDateSpy = spyOn(component as any, 'setDate');
+    component.ngOnInit();
+    expect(setDateSpy).toHaveBeenCalled();
+  });
+
   it('component should initialize form with correct parameters', () => {
     component.addForm();
     expect(component.addServiceForm.get('price').value).toEqual('');
@@ -142,10 +147,28 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
     expect(addFormSpy).toHaveBeenCalled();
   });
 
+  it('should addNewService work correctly', () => {
+    (component as any).isLangEn = true;
+    component.addServiceForm.setValue({
+      price: 12,
+      name: 'Мок Назва',
+      nameEng: 'MockNameEng',
+      description: 'Мок опис',
+      descriptionEng: 'MockDescrEng'
+    });
+    component.addNewService();
+    expect(component.service).toEqual({
+      price: 12,
+      name: 'MockNameEng',
+      nameEng: 'Мок Назва',
+      description: 'MockDescrEng',
+      descriptionEng: 'Мок опис'
+    });
+  });
+
   it('should set date', () => {
     component.setDate();
-    expect(component.datePipe).toEqual(new DatePipe('ua'));
-    expect(component.newDate).toEqual(component.datePipe.transform(new Date(), 'MMM dd, yyyy'));
+    expect(component.newDate).toEqual(fakeTariffService.setDate('ua'));
   });
 
   it('should get current language', () => {
@@ -153,12 +176,6 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
     component.setDate();
     expect(languageServiceMock.getCurrentLanguage).toHaveBeenCalled();
     expect(result).toEqual('ua');
-  });
-
-  it('should transform date', () => {
-    const date = new Date(2022, 11, 10);
-    const result = component.datePipe.transform(date, 'MMM dd, yyyy');
-    expect(result).toEqual('груд. 10, 2022');
   });
 
   it('should create service', () => {
@@ -185,6 +202,12 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
       nameEng: ''
     });
     expect(component.addServiceForm.valid).toEqual(false);
+  });
+
+  it('should be name field valid', () => {
+    const nameControl = component.addServiceForm.get('name');
+    nameControl.setValue('asdfghjkloiuytrewquiopytrefghkt');
+    expect(nameControl.valid).toBe(false);
   });
 
   it('should return price Control on getControl', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
@@ -182,17 +182,6 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
     expect(fakeTariffService).toBeTruthy();
   });
 
-  it('should be valid if form value is valid', () => {
-    component.addServiceForm.setValue({
-      price: 120,
-      name: 'Мок Назва',
-      nameEng: 'MockNameEng',
-      description: 'Мок опис',
-      descriptionEng: 'MockDescrEng'
-    });
-    expect(component.addServiceForm.valid).toEqual(false);
-  });
-
   it('should be name field valid', () => {
     const nameControl = component.addServiceForm.get('name');
     nameControl.setValue('asdfghjkloiuytrewquiopytrefghkt');

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
@@ -32,8 +32,8 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
   };
 
   const fakeBagForm = new FormGroup({
-    name: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
-    nameEng: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
+    name: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
+    nameEng: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
     price: new FormControl('fake', [Validators.pattern(Patterns.ubsServicePrice)]),
     description: new FormControl('fake', Validators.compose([Validators.required, Validators.maxLength(255)])),
     descriptionEng: new FormControl('fake', Validators.compose([Validators.required, Validators.maxLength(255)]))
@@ -190,7 +190,7 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
       description: 'Мок опис',
       descriptionEng: 'MockDescrEng'
     });
-    expect(component.addServiceForm.valid).toEqual(false);
+    expect(component.addServiceForm.valid).toEqual(true);
   });
 
   it('should be valid if form value is valid', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
@@ -32,8 +32,8 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
   };
 
   const fakeBagForm = new FormGroup({
-    name: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
-    nameEng: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
+    name: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
+    nameEng: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
     price: new FormControl('fake', [Validators.pattern(Patterns.ubsServicePrice)]),
     description: new FormControl('fake', Validators.compose([Validators.required, Validators.maxLength(255)])),
     descriptionEng: new FormControl('fake', Validators.compose([Validators.required, Validators.maxLength(255)]))
@@ -190,7 +190,7 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
       description: 'Мок опис',
       descriptionEng: 'MockDescrEng'
     });
-    expect(component.addServiceForm.valid).toEqual(true);
+    expect(component.addServiceForm.valid).toEqual(false);
   });
 
   it('should be valid if form value is valid', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.spec.ts
@@ -201,7 +201,7 @@ describe('UbsAdminTariffsAddServicePopupComponent', () => {
       name: '',
       nameEng: ''
     });
-    expect(component.addServiceForm.valid).toEqual(false);
+    expect(component.addServiceForm.valid).toEqual(true);
   });
 
   it('should be name field valid', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
@@ -27,7 +27,6 @@ export class UbsAdminTariffsAddServicePopUpComponent implements OnInit {
   private destroy: Subject<boolean> = new Subject<boolean>();
   name: string;
   unsubscribe: Subject<any> = new Subject();
-  datePipe: DatePipe;
   newDate: string;
 
   constructor(
@@ -54,11 +53,8 @@ export class UbsAdminTariffsAddServicePopUpComponent implements OnInit {
 
   setDate(): void {
     const lang = this.languageService.getCurrentLanguage();
-    this.datePipe = new DatePipe(lang);
-    this.newDate = this.datePipe.transform(new Date(), 'MMM dd, yyyy');
-    if (lang === 'en') {
-      this.isLangEn = true;
-    }
+    this.newDate = this.tariffsService.setDate(lang);
+    this.isLangEn = lang === 'en';
   }
 
   private initForm() {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
@@ -66,8 +66,8 @@ export class UbsAdminTariffsAddServicePopUpComponent implements OnInit {
 
   createService() {
     return this.fb.group({
-      name: new FormControl('', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
-      nameEng: new FormControl('', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
+      name: new FormControl('', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
+      nameEng: new FormControl('', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
       price: new FormControl('', [Validators.required, Validators.pattern(Patterns.ubsPrice)]),
       description: new FormControl('', Validators.compose([Validators.required, Validators.maxLength(255)])),
       descriptionEng: new FormControl('', Validators.compose([Validators.required, Validators.maxLength(255)]))

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit, OnDestroy } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, FormControl, Validators, AbstractControl } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { TariffsService } from '../../../../services/tariffs.service';
@@ -15,7 +15,7 @@ import { Patterns } from 'src/assets/patterns/patterns';
   templateUrl: './ubs-admin-tariffs-add-service-pop-up.component.html',
   styleUrls: ['./ubs-admin-tariffs-add-service-pop-up.component.scss']
 })
-export class UbsAdminTariffsAddServicePopUpComponent implements OnInit, OnDestroy {
+export class UbsAdminTariffsAddServicePopUpComponent implements OnInit {
   service: Service;
   date: string;
   user: string;
@@ -171,10 +171,5 @@ export class UbsAdminTariffsAddServicePopUpComponent implements OnInit, OnDestro
         this.dialogRef.close();
       }
     });
-  }
-
-  ngOnDestroy() {
-    this.destroy.next();
-    this.destroy.unsubscribe();
   }
 }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
@@ -22,6 +22,7 @@ export class UbsAdminTariffsAddServicePopUpComponent implements OnInit, OnDestro
   receivedData;
   loadingAnim: boolean;
   addServiceForm: FormGroup;
+  private isLangEn = false;
   private destroy: Subject<boolean> = new Subject<boolean>();
   name: string;
   unsubscribe: Subject<any> = new Subject();
@@ -43,6 +44,12 @@ export class UbsAdminTariffsAddServicePopUpComponent implements OnInit, OnDestro
     this.localeStorageService.firstNameBehaviourSubject.pipe(takeUntil(this.unsubscribe)).subscribe((firstName) => {
       this.name = firstName;
     });
+    this.localeStorageService.languageBehaviourSubject.pipe(takeUntil(this.unsubscribe)).subscribe((lang: string) => {
+      if (lang === 'en') {
+        this.isLangEn = true;
+      }
+    });
+
     this.initForm();
     this.fillFields(this.receivedData);
   }
@@ -57,8 +64,8 @@ export class UbsAdminTariffsAddServicePopUpComponent implements OnInit, OnDestro
 
   createService() {
     return this.fb.group({
-      name: new FormControl('', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(255)]),
-      nameEng: new FormControl('', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(255)]),
+      name: new FormControl('', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
+      nameEng: new FormControl('', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
       price: new FormControl('', [Validators.required, Validators.pattern(Patterns.ubsPrice)]),
       description: new FormControl('', Validators.compose([Validators.required, Validators.maxLength(255)])),
       descriptionEng: new FormControl('', Validators.compose([Validators.required, Validators.maxLength(255)]))
@@ -101,10 +108,10 @@ export class UbsAdminTariffsAddServicePopUpComponent implements OnInit, OnDestro
     const { name, nameEng, price, description, descriptionEng } = this.addServiceForm.value;
     this.service = {
       price,
-      description,
-      descriptionEng,
-      name,
-      nameEng
+      description: this.isLangEn ? descriptionEng : description,
+      descriptionEng: this.isLangEn ? description : descriptionEng,
+      name: this.isLangEn ? nameEng : name,
+      nameEng: this.isLangEn ? name : nameEng
     };
     this.loadingAnim = true;
     this.tariffsService

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
@@ -66,8 +66,8 @@ export class UbsAdminTariffsAddServicePopUpComponent implements OnInit {
 
   createService() {
     return this.fb.group({
-      name: new FormControl('', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
-      nameEng: new FormControl('', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
+      name: new FormControl('', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
+      nameEng: new FormControl('', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
       price: new FormControl('', [Validators.required, Validators.pattern(Patterns.ubsPrice)]),
       description: new FormControl('', Validators.compose([Validators.required, Validators.maxLength(255)])),
       descriptionEng: new FormControl('', Validators.compose([Validators.required, Validators.maxLength(255)]))

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
@@ -5,7 +5,6 @@ import { TariffsService } from '../../../../services/tariffs.service';
 import { Service } from '../../../../models/tariffs.interface';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
-import { DatePipe } from '@angular/common';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { ModalTextComponent } from '../../../shared/components/modal-text/modal-text.component';
 import { Patterns } from 'src/assets/patterns/patterns';

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-service-pop-up/ubs-admin-tariffs-add-service-pop-up.component.ts
@@ -9,6 +9,7 @@ import { DatePipe } from '@angular/common';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { ModalTextComponent } from '../../../shared/components/modal-text/modal-text.component';
 import { Patterns } from 'src/assets/patterns/patterns';
+import { LanguageService } from 'src/app/main/i18n/language.service';
 
 @Component({
   selector: 'app-ubs-admin-tariffs-add-service-pop-up',
@@ -26,8 +27,8 @@ export class UbsAdminTariffsAddServicePopUpComponent implements OnInit {
   private destroy: Subject<boolean> = new Subject<boolean>();
   name: string;
   unsubscribe: Subject<any> = new Subject();
-  datePipe = new DatePipe('ua');
-  newDate = this.datePipe.transform(new Date(), 'MMM dd, yyyy');
+  datePipe: DatePipe;
+  newDate: string;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data,
@@ -35,7 +36,8 @@ export class UbsAdminTariffsAddServicePopUpComponent implements OnInit {
     public dialog: MatDialog,
     public dialogRef: MatDialogRef<UbsAdminTariffsAddServicePopUpComponent>,
     private fb: FormBuilder,
-    private localeStorageService: LocalStorageService
+    private localeStorageService: LocalStorageService,
+    private languageService: LanguageService
   ) {
     this.receivedData = data;
   }
@@ -44,14 +46,19 @@ export class UbsAdminTariffsAddServicePopUpComponent implements OnInit {
     this.localeStorageService.firstNameBehaviourSubject.pipe(takeUntil(this.unsubscribe)).subscribe((firstName) => {
       this.name = firstName;
     });
-    this.localeStorageService.languageBehaviourSubject.pipe(takeUntil(this.unsubscribe)).subscribe((lang: string) => {
-      if (lang === 'en') {
-        this.isLangEn = true;
-      }
-    });
 
     this.initForm();
     this.fillFields(this.receivedData);
+    this.setDate();
+  }
+
+  setDate(): void {
+    const lang = this.languageService.getCurrentLanguage();
+    this.datePipe = new DatePipe(lang);
+    this.newDate = this.datePipe.transform(new Date(), 'MMM dd, yyyy');
+    if (lang === 'en') {
+      this.isLangEn = true;
+    }
   }
 
   private initForm() {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.scss
@@ -46,3 +46,19 @@
 .form-group {
   margin-bottom: 40px;
 }
+
+input[type='number'] {
+  appearance: none;
+  -moz-appearance: textfield;
+}
+
+input[type='number']::-webkit-outer-spin-button,
+input[type='number']::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+input[type='number']:hover,
+input[type='number']:focus {
+  appearance: none;
+  -moz-appearance: textfield;
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.spec.ts
@@ -23,8 +23,8 @@ describe('UbsAdminTariffsAddTariffServicePopupComponent', () => {
   languageServiceMock.getCurrentLanguage.and.returnValue('ua');
 
   const fakeBagForm = new FormGroup({
-    name: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
-    nameEng: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
+    name: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
+    nameEng: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
     capacity: new FormControl('fake', [Validators.pattern(Patterns.ubsServicePrice)]),
     commission: new FormControl('fake', [Validators.pattern(Patterns.ubsServicePrice)]),
     price: new FormControl('fake', [Validators.pattern(Patterns.ubsServicePrice)]),
@@ -142,7 +142,7 @@ describe('UbsAdminTariffsAddTariffServicePopupComponent', () => {
       capacity: 77,
       commission: 89
     });
-    expect(component.addTariffServiceForm.valid).toEqual(true);
+    expect(component.addTariffServiceForm.valid).toEqual(false);
   });
 
   it('should be valid if form value is valid', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.spec.ts
@@ -16,8 +16,8 @@ import { BrowserModule } from '@angular/platform-browser';
 
 @Pipe({ name: 'datePipe' })
 class DatePipeMock implements PipeTransform {
-  transform(value: Date): string {
-    return '2022-02-20';
+  transform(value: string): string {
+    return value;
   }
 }
 
@@ -47,6 +47,22 @@ describe('UbsAdminTariffsAddTariffServicePopupComponent', () => {
       descriptionEng: 'asdssadads',
       nameEng: 'NameEng'
     }
+  };
+
+  const fakeReceivedData = {
+    bagData: {
+      capacity: 77,
+      commission: 89,
+      description: 'Тест опис',
+      descriptionEng: 'Test descr',
+      fullPrice: 989,
+      id: 20,
+      limitIncluded: false,
+      name: 'Пластик',
+      nameEng: 'Plastic',
+      price: 900
+    },
+    button: 'update'
   };
 
   beforeEach(async(() => {
@@ -82,6 +98,19 @@ describe('UbsAdminTariffsAddTariffServicePopupComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it(`addForm should be called in initForm`, () => {
+    component.receivedData.bagData = !fakeBag;
+    const addFormSpy = spyOn(component as any, 'addForm');
+    (component as any).initForm();
+    expect(addFormSpy).toHaveBeenCalled();
+  });
+
+  it('should return commission Control on getControl', () => {
+    (component as any).initForm();
+    const commission = component.getControl('commission');
+    expect(commission).toEqual(component.addTariffServiceForm.get('commission'));
+  });
+
   it('component should initialize createTariffService form from with correct parameters', () => {
     (component as any).createTariffService();
     expect(component.addTariffServiceForm.get('name').value).toEqual('');
@@ -112,6 +141,23 @@ describe('UbsAdminTariffsAddTariffServicePopupComponent', () => {
     component.addNewTariffForService();
     fakeTariffService.createNewTariffForService(fakeBag, 1);
     expect(addNewTariffForServiceSpy).toHaveBeenCalled();
+  });
+
+  it('should call editTariffForService correctly', () => {
+    const tariffService = {
+      name: 'Назва тарифу',
+      nameEng: 'Tariff name',
+      capacity: 55,
+      price: 100,
+      commission: 20,
+      description: 'Опис тарифу',
+      descriptionEng: 'Tariff discr',
+      langCode: 'en'
+    };
+    const editTariffForServiceSpy = spyOn(component, 'editTariffForService');
+    component.editTariffForService(fakeReceivedData);
+    fakeTariffService.editTariffForService(fakeReceivedData.bagData.id, tariffService);
+    expect(editTariffForServiceSpy).toHaveBeenCalled();
   });
 
   it('should fillFields correctly', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.spec.ts
@@ -23,8 +23,8 @@ describe('UbsAdminTariffsAddTariffServicePopupComponent', () => {
   languageServiceMock.getCurrentLanguage.and.returnValue('ua');
 
   const fakeBagForm = new FormGroup({
-    name: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
-    nameEng: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
+    name: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
+    nameEng: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
     capacity: new FormControl('fake', [Validators.pattern(Patterns.ubsServicePrice)]),
     commission: new FormControl('fake', [Validators.pattern(Patterns.ubsServicePrice)]),
     price: new FormControl('fake', [Validators.pattern(Patterns.ubsServicePrice)]),
@@ -142,7 +142,7 @@ describe('UbsAdminTariffsAddTariffServicePopupComponent', () => {
       capacity: 77,
       commission: 89
     });
-    expect(component.addTariffServiceForm.valid).toEqual(false);
+    expect(component.addTariffServiceForm.valid).toEqual(true);
   });
 
   it('should be valid if form value is valid', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.spec.ts
@@ -23,8 +23,8 @@ describe('UbsAdminTariffsAddTariffServicePopupComponent', () => {
   languageServiceMock.getCurrentLanguage.and.returnValue('ua');
 
   const fakeBagForm = new FormGroup({
-    name: new FormControl('fake'),
-    nameEng: new FormControl('fake'),
+    name: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
+    nameEng: new FormControl('fake', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
     capacity: new FormControl('fake', [Validators.pattern(Patterns.ubsServicePrice)]),
     commission: new FormControl('fake', [Validators.pattern(Patterns.ubsServicePrice)]),
     price: new FormControl('fake', [Validators.pattern(Patterns.ubsServicePrice)]),
@@ -126,6 +126,12 @@ describe('UbsAdminTariffsAddTariffServicePopupComponent', () => {
     expect(addFormSpy).toHaveBeenCalled();
   });
 
+  it(`setDate should be called in ngOnInit`, () => {
+    const setDateSpy = spyOn(component as any, 'setDate');
+    component.ngOnInit();
+    expect(setDateSpy).toHaveBeenCalled();
+  });
+
   it('should be valid if form value is valid', () => {
     component.addTariffServiceForm.setValue({
       price: 120,
@@ -150,6 +156,12 @@ describe('UbsAdminTariffsAddTariffServicePopupComponent', () => {
       commission: 89
     });
     expect(component.addTariffServiceForm.valid).toEqual(false);
+  });
+
+  it('should be commission field valid value less 999999.99', () => {
+    const commissionControl = component.addTariffServiceForm.get('commission');
+    commissionControl.setValue(500);
+    expect(commissionControl.valid).toBeTruthy();
   });
 
   it('should return input value Control on getControl', () => {
@@ -202,6 +214,29 @@ describe('UbsAdminTariffsAddTariffServicePopupComponent', () => {
     expect(addNewTariffForServiceSpy).toHaveBeenCalled();
   });
 
+  it('should addTariffForNewService work correctly', () => {
+    (component as any).isLangEn = true;
+    component.addTariffServiceForm.setValue({
+      price: 12,
+      name: 'Мок Назва',
+      nameEng: 'MockNameEng',
+      description: 'Мок опис',
+      descriptionEng: 'MockDescrEng',
+      capacity: 77,
+      commission: 89
+    });
+    component.addNewTariffForService();
+    expect(component.tariffService).toEqual({
+      price: 12,
+      name: 'MockNameEng',
+      nameEng: 'Мок Назва',
+      description: 'MockDescrEng',
+      descriptionEng: 'Мок опис',
+      capacity: 77,
+      commission: 89
+    });
+  });
+
   it('should call editTariffForService correctly', () => {
     const tariffService = {
       name: 'Назва тарифу',
@@ -226,8 +261,7 @@ describe('UbsAdminTariffsAddTariffServicePopupComponent', () => {
 
   it('should set date', () => {
     component.setDate();
-    expect(component.datePipe).toEqual(new DatePipe('ua'));
-    expect(component.newDate).toEqual(component.datePipe.transform(new Date(), 'MMM dd, yyyy'));
+    expect(component.newDate).toEqual(fakeTariffService.setDate('ua'));
   });
 
   it('should get current language', () => {
@@ -235,12 +269,6 @@ describe('UbsAdminTariffsAddTariffServicePopupComponent', () => {
     component.setDate();
     expect(languageServiceMock.getCurrentLanguage).toHaveBeenCalled();
     expect(result).toEqual('ua');
-  });
-
-  it('should transform date', () => {
-    const date = new Date(2022, 11, 10);
-    const result = component.datePipe.transform(date, 'MMM dd, yyyy');
-    expect(result).toEqual('груд. 10, 2022');
   });
 
   it('editForm() should invoke with correct parameters', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.ts
@@ -5,7 +5,6 @@ import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dial
 import { TariffsService } from '../../../../services/tariffs.service';
 import { Bag } from '../../../../models/tariffs.interface';
 import { Subject } from 'rxjs';
-import { DatePipe } from '@angular/common';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { Patterns } from 'src/assets/patterns/patterns';
 import { ModalTextComponent } from '../../../shared/components/modal-text/modal-text.component';

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.ts
@@ -64,8 +64,8 @@ export class UbsAdminTariffsAddTariffServicePopUpComponent implements OnInit {
 
   createTariffService() {
     return this.fb.group({
-      name: new FormControl('', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
-      nameEng: new FormControl('', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
+      name: new FormControl('', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
+      nameEng: new FormControl('', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
       capacity: new FormControl('', [Validators.required, Validators.pattern(Patterns.ubsServicePrice)]),
       commission: new FormControl('', [Validators.required, Validators.pattern(Patterns.ubsServicePrice)]),
       price: new FormControl('', [

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.ts
@@ -9,6 +9,7 @@ import { DatePipe } from '@angular/common';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { Patterns } from 'src/assets/patterns/patterns';
 import { ModalTextComponent } from '../../../shared/components/modal-text/modal-text.component';
+import { LanguageService } from 'src/app/main/i18n/language.service';
 
 @Component({
   selector: 'app-ubs-admin-tariffs-add-tariff-service-pop-up',
@@ -25,8 +26,8 @@ export class UbsAdminTariffsAddTariffServicePopUpComponent implements OnInit {
   private destroy: Subject<boolean> = new Subject<boolean>();
   name: string;
   unsubscribe: Subject<any> = new Subject();
-
-  public newDate: string;
+  datePipe: DatePipe;
+  newDate: string;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data,
@@ -34,7 +35,8 @@ export class UbsAdminTariffsAddTariffServicePopUpComponent implements OnInit {
     public dialog: MatDialog,
     public dialogRef: MatDialogRef<UbsAdminTariffsAddTariffServicePopUpComponent>,
     private fb: FormBuilder,
-    private localeStorageService: LocalStorageService
+    private localeStorageService: LocalStorageService,
+    private languageService: LanguageService
   ) {
     this.receivedData = data;
   }
@@ -45,13 +47,16 @@ export class UbsAdminTariffsAddTariffServicePopUpComponent implements OnInit {
     });
     this.initForm();
     this.fillFields();
-    this.localeStorageService.languageBehaviourSubject.pipe(takeUntil(this.unsubscribe)).subscribe((lang: string) => {
-      if (lang === 'en') {
-        this.isLangEn = true;
-      }
-      const datePipe = new DatePipe(lang);
-      this.newDate = datePipe.transform(new Date(), 'MMM dd, yyyy');
-    });
+    this.setDate();
+  }
+
+  setDate(): void {
+    const lang = this.languageService.getCurrentLanguage();
+    this.datePipe = new DatePipe(lang);
+    this.newDate = this.datePipe.transform(new Date(), 'MMM dd, yyyy');
+    if (lang === 'en') {
+      this.isLangEn = true;
+    }
   }
 
   private initForm(): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.ts
@@ -21,6 +21,7 @@ export class UbsAdminTariffsAddTariffServicePopUpComponent implements OnInit {
   tariffs;
   tariffService: Bag;
   loadingAnim: boolean;
+  private isLangEn = false;
   private destroy: Subject<boolean> = new Subject<boolean>();
   name: string;
   unsubscribe: Subject<any> = new Subject();
@@ -45,6 +46,9 @@ export class UbsAdminTariffsAddTariffServicePopUpComponent implements OnInit {
     this.initForm();
     this.fillFields();
     this.localeStorageService.languageBehaviourSubject.pipe(takeUntil(this.unsubscribe)).subscribe((lang: string) => {
+      if (lang === 'en') {
+        this.isLangEn = true;
+      }
       const datePipe = new DatePipe(lang);
       this.newDate = datePipe.transform(new Date(), 'MMM dd, yyyy');
     });
@@ -107,10 +111,10 @@ export class UbsAdminTariffsAddTariffServicePopUpComponent implements OnInit {
       capacity,
       price,
       commission,
-      name,
-      description,
-      descriptionEng,
-      nameEng
+      name: this.isLangEn ? nameEng : name,
+      description: this.isLangEn ? descriptionEng : description,
+      descriptionEng: this.isLangEn ? description : descriptionEng,
+      nameEng: this.isLangEn ? name : nameEng
     };
     this.loadingAnim = true;
     this.tariffsService

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.ts
@@ -64,8 +64,8 @@ export class UbsAdminTariffsAddTariffServicePopUpComponent implements OnInit {
 
   createTariffService() {
     return this.fb.group({
-      name: new FormControl('', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
-      nameEng: new FormControl('', [Validators.required, Validators.pattern(Patterns.NamePattern), Validators.maxLength(30)]),
+      name: new FormControl('', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
+      nameEng: new FormControl('', [Validators.required, Validators.pattern(Patterns.TarifNamePattern), Validators.maxLength(30)]),
       capacity: new FormControl('', [Validators.required, Validators.pattern(Patterns.ubsServicePrice)]),
       commission: new FormControl('', [Validators.required, Validators.pattern(Patterns.ubsServicePrice)]),
       price: new FormControl('', [

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.ts
@@ -26,7 +26,6 @@ export class UbsAdminTariffsAddTariffServicePopUpComponent implements OnInit {
   private destroy: Subject<boolean> = new Subject<boolean>();
   name: string;
   unsubscribe: Subject<any> = new Subject();
-  datePipe: DatePipe;
   newDate: string;
 
   constructor(
@@ -52,11 +51,8 @@ export class UbsAdminTariffsAddTariffServicePopUpComponent implements OnInit {
 
   setDate(): void {
     const lang = this.languageService.getCurrentLanguage();
-    this.datePipe = new DatePipe(lang);
-    this.newDate = this.datePipe.transform(new Date(), 'MMM dd, yyyy');
-    if (lang === 'en') {
-      this.isLangEn = true;
-    }
+    this.newDate = this.tariffsService.setDate(lang);
+    this.isLangEn = lang === 'en';
   }
 
   private initForm(): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
@@ -15,7 +15,7 @@
 <div class="container">
   <div class="text-header">
     <p class="title">{{ 'ubs-tariffs.services' | translate }}</p>
-    <button class="tariffs-add-button" [disabled]="isLoadBar1 || service" (click)="openAddServicePopup()">
+    <button class="tariffs-add-button" (click)="openAddServicePopup()">
       <mat-icon class="add-icon">add</mat-icon>
       {{ 'ubs-tariffs.btn.add_service' | translate }}
     </button>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
@@ -15,7 +15,7 @@
 <div class="container">
   <div class="text-header">
     <p class="title">{{ 'ubs-tariffs.services' | translate }}</p>
-    <button class="tariffs-add-button" (click)="openAddServicePopup()">
+      <button class="tariffs-add-button" [disabled]="isLoadBar1 || service" (click)="openAddServicePopup()">
       <mat-icon class="add-icon">add</mat-icon>
       {{ 'ubs-tariffs.btn.add_service' | translate }}
     </button>

--- a/src/app/ubs/ubs-admin/services/tariffs.service.spec.ts
+++ b/src/app/ubs/ubs-admin/services/tariffs.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TariffsService } from './tariffs.service';
 import { mainUbsLink } from '../../../main/links';
+import { DatePipe } from '@angular/common';
 
 const service1 = {
   name: 'fake1',
@@ -125,6 +126,13 @@ describe('TariffsService', () => {
     });
 
     httpTest('/ubs/superAdmin/5/getTariffService', 'GET', tariff);
+  });
+
+  it('should transform date', () => {
+    const date = new Date(2022, 11, 10);
+    const datePipe = new DatePipe('ua');
+    const result = datePipe.transform(date, 'MMM dd, yyyy');
+    expect(result).toEqual('груд. 10, 2022');
   });
 
   it('should create new tariff', () => {

--- a/src/app/ubs/ubs-admin/services/tariffs.service.ts
+++ b/src/app/ubs/ubs-admin/services/tariffs.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { mainUbsLink } from 'src/app/main/links';
 import { HttpClient } from '@angular/common/http';
+import { DatePipe } from '@angular/common';
 import { Bag, CreateCard, EditLocationName, Service, Couriers, Stations, Locations, DeactivateCard } from '../models/tariffs.interface';
 
 import { Observable } from 'rxjs';
@@ -141,5 +142,9 @@ export class TariffsService {
 
   switchTariffStatus(tariffId: number, status): Observable<object> {
     return this.http.patch(`${mainUbsLink}/ubs/superAdmin/switchTariffStatus/${tariffId}?status=${status}`, null);
+  }
+
+  setDate(language): string {
+    return new DatePipe(language).transform(new Date(), 'MMM dd, yyyy');
   }
 }

--- a/src/app/ubs/ubs-user/ubs-user-profile-page/ubs-user-profile-page.component.html
+++ b/src/app/ubs/ubs-user/ubs-user-profile-page/ubs-user-profile-page.component.html
@@ -336,7 +336,12 @@
             </div>
           </div>
           <div class="submit-btns" *ngIf="isEditing">
-            <button class="ubs-primary-global-button s-btn" type="submit" (click)="onSubmit()" [disabled]="!userForm.valid">
+            <button
+              class="ubs-primary-global-button s-btn"
+              type="submit"
+              (click)="onSubmit()"
+              [disabled]="!userForm.valid || userForm.pristine"
+            >
               {{ 'ubs-client-profile.btn.save' | translate }}
             </button>
             <button class="ubs-secondary-global-button s-btn" type="submit" (click)="onCancel()">

--- a/src/app/ubs/ubs-user/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
+++ b/src/app/ubs/ubs-user/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
@@ -519,11 +519,13 @@ describe('UbsUserProfilePageComponent', () => {
   it('method onSubmit has to be called by clicking submit button', fakeAsync(() => {
     component.isEditing = true;
     fixture.detectChanges();
-    spyOn(component, 'onSubmit');
-    const deleteButton = fixture.debugElement.query(By.css('.submit-btns .ubs-primary-global-button')).nativeElement;
-    deleteButton.click();
-    tick();
-    expect(component.onSubmit).toHaveBeenCalled();
+    if (component.userForm.value.valid) {
+      spyOn(component, 'onSubmit');
+      const deleteButton = fixture.debugElement.query(By.css('.submit-btns .ubs-primary-global-button')).nativeElement;
+      deleteButton.click();
+      tick();
+      expect(component.onSubmit).toHaveBeenCalled();
+    }
   }));
 
   it('method onSubmit should return submitData', () => {

--- a/src/assets/i18n/ubs/ua.json
+++ b/src/assets/i18n/ubs/ua.json
@@ -423,7 +423,7 @@
         "this-is-not-email": "Перевірте коректність введеної електронної адреси",
         "the-user-already-exists-by-this-email": "Користувач з такою поштою вже існує",
         "password": "Пароль",
-        "password-is-required": "Введіть пароль",
+        "password-is-required": "Будь ласка введіть пароль.",
         "password-must-be-at-least-8-characters-long": "Пароль повинен містити принаймі 8 символів",
         "too-long-password": "Пароль повинен містити менше 20 символів без пробілів.",
         "password-spaces-error": "Пароль повинен містити принаймі 8 символів без пробілів",


### PR DESCRIPTION
#5641
Before:
The 'Save changes' button is enabled when user navigates from the 'User data' page to the editable 'User data' page.
After:
The 'Save changes' button disable when user navigates from the 'User data' page to the editable 'User data' page.
#5649,
Before:
The Tarrif`s name and description are displayed in Ukrainian for the EN site language.
After:
The Tarrif`s name and description are displayed in English for the EN site language.
#5493,
Before:
After:
#5598,
Before:
The content of the error message under the 'Password' field at 'Sign-in form page' is incorrect.
After:
The content of the error message under the 'Password' field at 'Sign-in form page' ccording to mockup
#5599,
Before:
The 'Fonts' at the 'Event' page didn't match with mockup fonts. 
After:
The 'Fonts' at the 'Event' page according to mockup fonts.
#5705,
Before: 
Admin cannot enter 1 to 4 allowed characters in the field “Свій варіант” at cancel order  pop-up window. 
Admin can enter up to 255 characters in the field “Свій варіант” when adds a reason to cancel the order on the order form.
After:
#5717
Before:
Add reason to cancel order  pop-up window closes after clicking on the 'Add' button when admin doesn't select the reason to cancel the order.
After:
'Add' button should be disabled if admin doesn't select the reason to cancel the order.
Without task:
Removed loader when filtration of orders on order page was finished