### PR TITLE
bugfix/#5734-Change-deactivate-pop-up-according-to-mock-up

### DIFF
--- a/src/app/ubs/ubs-admin/components/shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component.html
@@ -42,21 +42,11 @@
     <div class="form-block">
       <div class="ua-part">
         <label class="label">{{ 'ubs-tariffs.city' | translate }}</label>
-        <div *ngIf="lang">
-          <p *ngFor="let locationName of locationNames" class="text">{{ locationName }}</p>
-        </div>
-        <div *ngIf="!lang">
-          <p *ngFor="let locationEnglishName of locationEnglishNames" class="text">{{ locationEnglishName }}</p>
-        </div>
+        <p class="text">{{ getLangArrayValue(locationNames, locationEnglishNames) }}</p>
       </div>
       <div class="en-part">
         <label class="label">{{ getLangValue(cityLabelEn, cityLabelUa) }}</label>
-        <div *ngIf="lang">
-          <p *ngFor="let locationEnglishName of locationEnglishNames" class="text">{{ locationEnglishName }}</p>
-        </div>
-        <div *ngIf="!lang">
-          <p *ngFor="let locationName of locationNames" class="text">{{ locationName }}</p>
-        </div>
+        <p class="text">{{ getLangArrayValue(locationEnglishNames, locationNames) }}</p>
       </div>
     </div>
   </div>

--- a/src/app/ubs/ubs-admin/components/shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component.html
@@ -16,11 +16,11 @@
     <div class="form-block">
       <div class="ua-part">
         <label class="label">{{ 'ubs-tariffs.courier' | translate }}</label>
-        <p class="text">{{ courierName }}</p>
+        <p class="text">{{ getLangValue(courierName, courierEnglishName) }}</p>
       </div>
       <div class="en-part">
-        <label class="label">Courier</label>
-        <p class="text">{{ courierEnglishName }}</p>
+        <label class="label">{{ getLangValue(courierLabelEn, courierLabelUa) }}</label>
+        <p class="text">{{ getLangValue(courierEnglishName, courierName) }}</p>
       </div>
     </div>
     <div class="form-block">
@@ -32,21 +32,31 @@
     <div class="form-block">
       <div class="ua-part">
         <label class="label">{{ 'ubs-tariffs.region' | translate }}</label>
-        <p class="text">{{ regionName }}</p>
+        <p class="text">{{ getLangValue(regionName, regionEnglishName) }}</p>
       </div>
       <div class="en-part">
-        <label class="label">Region</label>
-        <p class="text">{{ regionEnglishName }}</p>
+        <label class="label">{{ getLangValue(regionLabelEn, regionLabelUa) }}</label>
+        <p class="text">{{ getLangValue(regionEnglishName, regionName) }}</p>
       </div>
     </div>
     <div class="form-block">
       <div class="ua-part">
         <label class="label">{{ 'ubs-tariffs.city' | translate }}</label>
-        <p *ngFor="let locationName of locationNames" class="text">{{ locationName }}</p>
+        <div *ngIf="lang">
+          <p *ngFor="let locationName of locationNames" class="text">{{ locationName }}</p>
+        </div>
+        <div *ngIf="!lang">
+          <p *ngFor="let locationEnglishName of locationEnglishNames" class="text">{{ locationEnglishName }}</p>
+        </div>
       </div>
       <div class="en-part">
-        <label class="label">City</label>
-        <p *ngFor="let locationEnglishName of locationEnglishNames" class="text">{{ locationEnglishName }}</p>
+        <label class="label">{{ getLangValue(cityLabelEn, cityLabelUa) }}</label>
+        <div *ngIf="lang">
+          <p *ngFor="let locationEnglishName of locationEnglishNames" class="text">{{ locationEnglishName }}</p>
+        </div>
+        <div *ngIf="!lang">
+          <p *ngFor="let locationName of locationNames" class="text">{{ locationName }}</p>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/ubs/ubs-admin/components/shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component.ts
@@ -7,7 +7,6 @@ import { ModalTextComponent } from '../modal-text/modal-text.component';
 import { LanguageService } from 'src/app/main/i18n/language.service';
 import { TariffsService } from 'src/app/ubs/ubs-admin/services/tariffs.service';
 import { TariffLocationLabelName, TariffCourierLabelName, TariffRegionLabelName } from '../../../ubs-admin-tariffs/ubs-tariffs.enum';
-import { Language } from 'src/app/main/i18n/Language';
 
 @Component({
   selector: 'app-tariff-deactivate-confirmation-pop-up',

--- a/src/app/ubs/ubs-admin/components/shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component.ts
@@ -6,12 +6,7 @@ import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dial
 import { ModalTextComponent } from '../modal-text/modal-text.component';
 import { LanguageService } from 'src/app/main/i18n/language.service';
 import { TariffsService } from 'src/app/ubs/ubs-admin/services/tariffs.service';
-import {
-  TariffPlaceholderSelected,
-  TariffLocationLabelName,
-  TariffCourierLabelName,
-  TariffRegionLabelName
-} from '../../../ubs-admin-tariffs/ubs-tariffs.enum';
+import { TariffLocationLabelName, TariffCourierLabelName, TariffRegionLabelName } from '../../../ubs-admin-tariffs/ubs-tariffs.enum';
 import { Language } from 'src/app/main/i18n/Language';
 
 @Component({
@@ -33,7 +28,6 @@ export class TariffDeactivateConfirmationPopUpComponent implements OnInit {
   isRestore: boolean;
   isDeactivate: boolean;
   isDeactivatePopup = true;
-  lang = false;
   courierLabelEn = TariffCourierLabelName.en;
   courierLabelUa = TariffCourierLabelName.ua;
   regionLabelEn = TariffRegionLabelName.en;
@@ -69,13 +63,14 @@ export class TariffDeactivateConfirmationPopUpComponent implements OnInit {
   setDate(): void {
     const currentLang = this.languageService.getCurrentLanguage();
     this.newDate = this.tariffsService.setDate(currentLang);
-    if (currentLang === Language.UA) {
-      this.lang = true;
-    }
   }
 
   public getLangValue(uaValue: string, enValue: string): string {
     return this.languageService.getLangValue(uaValue, enValue) as string;
+  }
+
+  public getLangArrayValue(uaValue: string[], enValue: string[]) {
+    return this.languageService.getLangValue(uaValue, enValue) as string[];
   }
 
   public onCancelClick(): void {

--- a/src/app/ubs/ubs-admin/components/shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component.ts
@@ -6,6 +6,13 @@ import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dial
 import { ModalTextComponent } from '../modal-text/modal-text.component';
 import { LanguageService } from 'src/app/main/i18n/language.service';
 import { TariffsService } from 'src/app/ubs/ubs-admin/services/tariffs.service';
+import {
+  TariffPlaceholderSelected,
+  TariffLocationLabelName,
+  TariffCourierLabelName,
+  TariffRegionLabelName
+} from '../../../ubs-admin-tariffs/ubs-tariffs.enum';
+import { Language } from 'src/app/main/i18n/Language';
 
 @Component({
   selector: 'app-tariff-deactivate-confirmation-pop-up',
@@ -26,6 +33,13 @@ export class TariffDeactivateConfirmationPopUpComponent implements OnInit {
   isRestore: boolean;
   isDeactivate: boolean;
   isDeactivatePopup = true;
+  lang = false;
+  courierLabelEn = TariffCourierLabelName.en;
+  courierLabelUa = TariffCourierLabelName.ua;
+  regionLabelEn = TariffRegionLabelName.en;
+  regionLabelUa = TariffRegionLabelName.ua;
+  cityLabelEn = TariffLocationLabelName.en;
+  cityLabelUa = TariffLocationLabelName.ua;
 
   constructor(
     private tariffsService: TariffsService,
@@ -43,8 +57,8 @@ export class TariffDeactivateConfirmationPopUpComponent implements OnInit {
     this.regionName = this.modalData.regionNameUk ?? '';
     this.regionEnglishName = this.modalData.regionEnglishName ?? '';
     this.isDeactivate = this.modalData.isDeactivate;
-    this.locationNames = this.modalData.regionNameUk ?? '';
-    this.locationEnglishNames = this.modalData.regionEnglishName ?? '';
+    this.locationNames = this.modalData.cityNameUk ?? '';
+    this.locationEnglishNames = this.modalData.cityNameEn ?? '';
     this.isRestore = this.modalData.isRestore;
     this.localeStorageService.firstNameBehaviourSubject.pipe(takeUntil(this.unsubscribe)).subscribe((firstName) => {
       this.adminName = firstName;
@@ -53,8 +67,15 @@ export class TariffDeactivateConfirmationPopUpComponent implements OnInit {
   }
 
   setDate(): void {
-    const lang = this.languageService.getCurrentLanguage();
-    this.newDate = this.tariffsService.setDate(lang);
+    const currentLang = this.languageService.getCurrentLanguage();
+    this.newDate = this.tariffsService.setDate(currentLang);
+    if (currentLang === Language.UA) {
+      this.lang = true;
+    }
+  }
+
+  public getLangValue(uaValue: string, enValue: string): string {
+    return this.languageService.getLangValue(uaValue, enValue) as string;
   }
 
   public onCancelClick(): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.html
@@ -1,54 +1,24 @@
 <div class="w-100">
   <p class="add-location-title">{{ 'ubs-tariffs-add-location-pop-up.deactivate' | translate }}</p>
 </div>
-<app-dialog-tariff [row]="form" [newDate]="newDate" [name]="name" [edit]="true"></app-dialog-tariff>
+<app-dialog-tariff [row]="form" [newDate]="newDate" [name]="name" [edit]="true" [deactivatePopup]="true"></app-dialog-tariff>
 <ng-template #form>
   <form [formGroup]="CardForm">
-    <div class="d-flex">
-      <!-- Courier -->
-      <div class="form-wrapper">
-        <div>
-          <div class="d-flex first-row">
-            <div class="form-group">
-              <label>{{ 'ubs-tariffs.courier' | translate }}</label>
-              <input
-                formControlName="courier"
-                class="form-control"
-                placeholder="{{ 'ubs-tariffs.placeholder-choose-courier' | translate }}"
-                [matAutocomplete]="autoCourier"
-                #autocompleteTriggerCourier="matAutocompleteTrigger"
-              />
-              <mat-autocomplete #autoCourier="matAutocomplete" (optionSelected)="selectCourier($event)">
-                <mat-option *ngFor="let option of filteredCouriers" class="option-state" [value]="option">
-                  <span class="checkbox-text">{{ option }}</span>
-                </mat-option>
-              </mat-autocomplete>
-
-              <img
-                [src]="icons.arrowDown"
-                class="arrowDown-img"
-                alt="arrowDown"
-                (click)="openAuto($event, autocompleteTriggerCourier, false)"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-      <!-- Station -->
+    <!-- Courier -->
+    <div class="form-wrapper courier-wrapper">
       <div>
-        <div [ngClass]="selectedStations.length ? 'd-flex' : 'd-flex first-row'">
+        <div class="d-flex">
           <div class="form-group">
-            <label>{{ 'ubs-tariffs.station' | translate }}</label>
+            <label>{{ 'ubs-tariffs.courier' | translate }}</label>
             <input
-              formControlName="station"
+              formControlName="courier"
               class="form-control"
-              [placeholder]="stationPlaceholder"
-              [matAutocomplete]="autoStation"
-              #autocompleteTriggerStation="matAutocompleteTrigger"
+              placeholder="{{ 'ubs-tariffs.placeholder-choose-courier' | translate }}"
+              [matAutocomplete]="autoCourier"
+              #autocompleteTriggerCourier="matAutocompleteTrigger"
             />
-            <mat-autocomplete #autoStation="matAutocomplete" (optionSelected)="selectStation($event, autocompleteTriggerStation)">
-              <mat-option *ngFor="let option of filteredStations" class="option-state" [value]="option">
-                <mat-checkbox class="mr-1" [checked]="checkStation(option)"></mat-checkbox>
+            <mat-autocomplete #autoCourier="matAutocomplete" (optionSelected)="selectCourier($event)">
+              <mat-option *ngFor="let option of filteredCouriers" class="option-state" [value]="option">
                 <span class="checkbox-text">{{ option }}</span>
               </mat-option>
             </mat-autocomplete>
@@ -57,46 +27,69 @@
               [src]="icons.arrowDown"
               class="arrowDown-img"
               alt="arrowDown"
-              (click)="openAuto($event, autocompleteTriggerStation, false)"
+              (click)="openAuto($event, autocompleteTriggerCourier, false)"
             />
           </div>
         </div>
-        <div [ngClass]="selectedStations.length ? 'list' : 'dis-none'" class="list">
-          <div *ngFor="let item of selectedStations; let index = index" class="d-flex selected-element">
-            <div class="itemList">{{ item.name }}</div>
-            <img [src]="icons.cross" class="delete-button-img" alt="delete-icon" (click)="deleteStation(index)" />
-          </div>
+      </div>
+      <div class="translation">
+        <label class="label">{{ getLangValue(courierLabelEn, courierLabelUa) }}</label>
+        <p class="text">{{ selectedValue ? getLangValue(selectedValue.nameEn, selectedValue.nameUk) : '' }}</p>
+      </div>
+    </div>
+    <!-- Station -->
+    <div>
+      <div [ngClass]="selectedStations.length ? 'd-flex' : 'd-flex first-row'">
+        <div class="form-group">
+          <label>{{ 'ubs-tariffs.station' | translate }}</label>
+          <input
+            formControlName="station"
+            class="form-control"
+            [placeholder]="stationPlaceholder"
+            [matAutocomplete]="autoStation"
+            #autocompleteTriggerStation="matAutocompleteTrigger"
+          />
+          <mat-autocomplete #autoStation="matAutocomplete" (optionSelected)="selectStation($event, autocompleteTriggerStation)">
+            <mat-option *ngFor="let option of filteredStations" class="option-state" [value]="option">
+              <mat-checkbox class="mr-1" [checked]="checkStation(option)"></mat-checkbox>
+              <span class="checkbox-text">{{ option }}</span>
+            </mat-option>
+          </mat-autocomplete>
+
+          <img
+            [src]="icons.arrowDown"
+            class="arrowDown-img"
+            alt="arrowDown"
+            (click)="openAuto($event, autocompleteTriggerStation, false)"
+          />
+        </div>
+      </div>
+      <div [ngClass]="selectedStations.length ? 'list' : 'dis-none'" class="list">
+        <div *ngFor="let item of selectedStations; let index = index" class="d-flex selected-element">
+          <div class="itemList">{{ item.name }}</div>
+          <img [src]="icons.cross" class="delete-button-img" alt="delete-icon" (click)="deleteStation(index)" />
         </div>
       </div>
     </div>
 
-    <div class="d-flex">
-      <!-- Region -->
-      <div class="form-wrapper">
-        <div [ngClass]="selectedRegions.length ? 'd-flex' : 'd-flex first-row'">
-          <div class="form-group">
-            <label>{{ 'ubs-tariffs.region' | translate }}</label>
-            <input
-              #autocompleteTriggerRegion="matAutocompleteTrigger"
-              formControlName="region"
-              [placeholder]="regionPlaceholder"
-              [matAutocomplete]="autoRegion"
-              class="form-control"
-            />
-            <mat-autocomplete #autoRegion="matAutocomplete" (optionSelected)="selectRegion($event, autocompleteTriggerRegion)">
-              <mat-option *ngFor="let item of filteredRegions" [value]="item">
-                <mat-checkbox class="mr-1" [checked]="checkRegion(item)"> </mat-checkbox>
-                <span class="checkbox-text">{{ item }}</span>
-              </mat-option>
-            </mat-autocomplete>
-            <img
-              [src]="icons.arrowDown"
-              class="arrowDown-img"
-              alt="arrowDown"
-              (click)="openAuto($event, autocompleteTriggerRegion, false)"
-            />
-          </div>
-        </div>
+    <!-- Region -->
+    <div class="form-wrapper">
+      <div class="form-group">
+        <label>{{ 'ubs-tariffs.region' | translate }}</label>
+        <input
+          #autocompleteTriggerRegion="matAutocompleteTrigger"
+          formControlName="region"
+          [placeholder]="regionPlaceholder"
+          [matAutocomplete]="autoRegion"
+          class="form-control"
+        />
+        <mat-autocomplete #autoRegion="matAutocomplete" (optionSelected)="selectRegion($event, autocompleteTriggerRegion)">
+          <mat-option *ngFor="let item of filteredRegions" [value]="item">
+            <mat-checkbox class="mr-1" [checked]="checkRegion(item)"> </mat-checkbox>
+            <span class="checkbox-text">{{ item }}</span>
+          </mat-option>
+        </mat-autocomplete>
+        <img [src]="icons.arrowDown" class="arrowDown-img" alt="arrowDown" (click)="openAuto($event, autocompleteTriggerRegion, false)" />
         <div class="list">
           <div *ngFor="let item of selectedRegions; let index = index" class="d-flex selected-element">
             <div class="itemList">{{ item.name }}</div>
@@ -104,32 +97,39 @@
           </div>
         </div>
       </div>
-      <!-- City -->
-      <div>
-        <div [ngClass]="selectedCities.length ? 'd-flex' : 'd-flex first-row'">
-          <div class="form-group">
-            <label>{{ 'ubs-tariffs.city' | translate }}</label>
-            <input
-              #autocompleteTriggerCity="matAutocompleteTrigger"
-              formControlName="city"
-              [placeholder]="cityPlaceholder"
-              [matAutocomplete]="autoCity"
-              class="form-control"
-            />
-            <mat-autocomplete #autoCity="matAutocomplete" (optionSelected)="selectCity($event, autocompleteTriggerCity)">
-              <mat-option *ngFor="let item of filteredCities" [value]="item">
-                <mat-checkbox class="mr-1" [checked]="checkCity(item)"> </mat-checkbox>
-                <span class="checkbox-text">{{ item }}</span>
-              </mat-option>
-            </mat-autocomplete>
-            <img
-              [src]="icons.arrowDown"
-              class="arrowDown-img"
-              alt="arrowDown"
-              (click)="openAuto($event, autocompleteTriggerCity, city.disabled)"
-            />
-          </div>
+      <div class="translation">
+        <label class="label">{{ getLangValue(regionLabelEn, regionLabelUa) }}</label>
+        <div class="select-count" *ngIf="selectedRegionsLength">
+          {{ selectedRegionsLength }} {{ getLangValue(placeholderSelectedEn, placeholderSelectedUa) }}
         </div>
+        <div *ngFor="let regionItem of selectedRegionValue">
+          <p class="text">{{ selectedRegionsLength ? getLangValue(regionItem.regionNameEn, regionItem.regionNameUa) : '' }}</p>
+        </div>
+      </div>
+    </div>
+    <!-- City -->
+    <div class="form-wrapper">
+      <div class="form-group">
+        <label>{{ 'ubs-tariffs.city' | translate }}</label>
+        <input
+          #autocompleteTriggerCity="matAutocompleteTrigger"
+          formControlName="city"
+          [placeholder]="cityPlaceholder"
+          [matAutocomplete]="autoCity"
+          class="form-control"
+        />
+        <mat-autocomplete #autoCity="matAutocomplete" (optionSelected)="selectCity($event, autocompleteTriggerCity)">
+          <mat-option *ngFor="let item of filteredCities" [value]="item">
+            <mat-checkbox class="mr-1" [checked]="checkCity(item)"> </mat-checkbox>
+            <span class="checkbox-text">{{ item }}</span>
+          </mat-option>
+        </mat-autocomplete>
+        <img
+          [src]="icons.arrowDown"
+          class="arrowDown-img"
+          alt="arrowDown"
+          (click)="openAuto($event, autocompleteTriggerCity, city.disabled)"
+        />
         <div class="list">
           <div *ngFor="let item of selectedCities; let index = index" class="d-flex selected-element">
             <div class="itemList">{{ item.name }}</div>
@@ -137,10 +137,19 @@
           </div>
         </div>
       </div>
+      <div class="translation">
+        <label class="label">{{ getLangValue(cityLabelEn, cityLabelUa) }}</label>
+        <div class="select-count" *ngIf="selectedCitiesValue.length">
+          {{ selectedCitiesValue.length }} {{ getLangValue(placeholderSelectedEn, placeholderSelectedUa) }}
+        </div>
+        <div *ngFor="let cityItem of selectedCitiesValue">
+          <p class="text">{{ selectedCitiesValue.length ? getLangValue(cityItem.cityNameEn, cityItem.cityNameUa) : '' }}</p>
+        </div>
+      </div>
     </div>
   </form>
   <div class="buttons-wrapper">
-    <div class="d-flex buttons" mat-dialog-actions>
+    <div class="buttons" mat-dialog-actions>
       <button class="secondary-global-button btn m-0 mr-2" mat-button (click)="onNoClick()">
         {{ 'ubs-tariffs-add-location-pop-up.cancel_button' | translate }}
       </button>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.scss
@@ -1,22 +1,47 @@
 @import '../ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component';
 
-.english-part {
-  width: 248px;
-  font-weight: 400;
-  font-family: var(--ubs-quaternary-font);
+form {
+  display: flex;
+  flex-direction: column;
+  width: 570px;
+}
+
+.d-flex {
+  width: 45%;
+}
+
+.text {
+  margin-bottom: 0;
+}
+
+.translation {
+  width: 45%;
 
   label {
+    font-family: var(--ubs-quaternary-font);
     font-size: 16px;
     line-height: 24px;
+    font-weight: 400;
     color: var(--ubs-secondary-grey);
-    margin-bottom: 0;
+    margin-bottom: 8px;
   }
 
-  .english-name {
+  .select-count {
+    margin-bottom: 20px;
+  }
+
+  .text,
+  .select-count {
+    font-family: var(--ubs-quaternary-font);
     font-size: 14px;
     line-height: 20px;
+    font-weight: 400;
     color: var(--ubs-freinacht-black);
   }
+}
+
+.courier-wrapper {
+  margin-bottom: 20px;
 }
 
 .form-group label::after {
@@ -24,7 +49,9 @@
 }
 
 .form-wrapper {
-  margin-right: 56px;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 16px;
 }
 
 .first-row .form-group {
@@ -57,7 +84,7 @@ input {
   display: flex;
   align-items: flex-start;
   flex-direction: column;
-  margin: 8px 0;
+  margin: 16px 0;
 }
 
 .selected-element {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.spec.ts
@@ -1377,28 +1377,6 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
     expect(component.deactivateCardObj).toEqual(result);
   });
 
-  it('method deactivateCard should open pop up with data', () => {
-    component.selectedRegions.push(locationItem);
-    component.selectedStations.push(stationItem);
-    component.selectedCities.push(cityItem);
-    component.selectedCourier = { id: 0, name: 'фейкКурєр1' };
-    const spy = spyOn(component, 'createDeactivateCardDto');
-    matDialogMock.open.and.returnValue(fakeMatDialogRef as any);
-    component.deactivateCard();
-    expect(fakeMatDialogRef.close).toHaveBeenCalled();
-    expect(spy).toHaveBeenCalled();
-    expect(matDialogMock.open).toHaveBeenCalledWith(TariffDeactivateConfirmationPopUpComponent, {
-      hasBackdrop: true,
-      panelClass: 'address-matDialog-styles-w-100',
-      data: {
-        courierName: 'фейкКурєр1',
-        stationNames: ['Фейк1'],
-        regionName: ['Фейк'],
-        locationNames: ['Фейк місто']
-      }
-    });
-  });
-
   it('method onNoClick should invoke destroyRef.close()', () => {
     component.selectedRegions.push(locationItem);
     component.selectedStations.push(stationItem);

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
@@ -13,6 +13,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { TariffDeactivateConfirmationPopUpComponent } from '../../shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component';
 import { LanguageService } from 'src/app/main/i18n/language.service';
 import { TariffPlaceholderSelected, TariffLocationLabelName, TariffCourierLabelName, TariffRegionLabelName } from '../ubs-tariffs.enum';
+import { Language } from 'src/app/main/i18n/Language';
 
 enum status {
   active = 'ACTIVE',
@@ -327,11 +328,8 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
     let name;
     const selectedItemName = event.option.value;
     const selectedItem = this.locations.filter((element) => element.regionTranslationDtos.find((it) => it.regionName === selectedItemName));
-    let regionNameUa;
-    let regionNameEn;
-    selectedItem[0].regionTranslationDtos.forEach((item) => {
-      item.languageCode === 'ua' ? (regionNameUa = item.regionName) : (regionNameEn = item.regionName);
-    });
+    const regionNameUa = selectedItem[0].regionTranslationDtos.find((item) => item.languageCode === Language.UA).regionName;
+    const regionNameEn = selectedItem[0].regionTranslationDtos.find((item) => item.languageCode === Language.EN).regionName;
     this.selectedRegionValue.push({ regionNameUa, regionNameEn });
 
     selectedItem.forEach((item) => {
@@ -452,12 +450,10 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
     const selectedItem = this.currentCities.filter((element) =>
       element.locationTranslationDtoList.find((it) => it.locationName === event.option.value)
     )[0];
-    let cityNameUa;
-    let cityNameEn;
-    selectedItem.locationTranslationDtoList.forEach((item) => {
-      item.languageCode === 'ua' ? (cityNameUa = item.locationName) : (cityNameEn = item.locationName);
-    });
+    const cityNameUa = selectedItem.locationTranslationDtoList.find((item) => item.languageCode === Language.UA).locationName;
+    const cityNameEn = selectedItem.locationTranslationDtoList.find((item) => item.languageCode === Language.EN).locationName;
     this.selectedCitiesValue.push({ cityNameUa, cityNameEn });
+
     const tempItem = {
       id: selectedItem.locationId,
       name: selectedItem.locationTranslationDtoList

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
@@ -12,6 +12,7 @@ import { ModalTextComponent } from '../../shared/components/modal-text/modal-tex
 import { TranslateService } from '@ngx-translate/core';
 import { TariffDeactivateConfirmationPopUpComponent } from '../../shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component';
 import { LanguageService } from 'src/app/main/i18n/language.service';
+import { TariffPlaceholderSelected, TariffLocationLabelName, TariffCourierLabelName, TariffRegionLabelName } from '../ubs-tariffs.enum';
 
 enum status {
   active = 'ACTIVE',
@@ -63,6 +64,17 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
   public selectedCourier: SelectedItems;
   public tariffCards: TariffCard[] = [];
   public currentLanguage: string;
+  public selectedValue: any;
+  public selectedCitiesValue: any[] = [];
+  public selectedRegionValue: any[] = [];
+  public placeholderSelectedEn = TariffPlaceholderSelected.en;
+  public placeholderSelectedUa = TariffPlaceholderSelected.ua;
+  public courierLabelEn = TariffCourierLabelName.en;
+  public courierLabelUa = TariffCourierLabelName.ua;
+  public regionLabelEn = TariffRegionLabelName.en;
+  public regionLabelUa = TariffRegionLabelName.ua;
+  public cityLabelEn = TariffLocationLabelName.en;
+  public cityLabelUa = TariffLocationLabelName.ua;
   deactivateCardObj: DeactivateCard;
 
   constructor(
@@ -190,10 +202,10 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
   }
 
   public selectCourier(event: MatAutocompleteSelectedEvent): void {
-    const selectedValue = this.couriers.find((ob) => this.getLangValue(ob.nameUk, ob.nameEn) === event.option.value);
+    this.selectedValue = this.couriers.find((ob) => this.getLangValue(ob.nameUk, ob.nameEn) === event.option.value);
     this.selectedCourier = {
-      id: selectedValue.courierId,
-      name: this.getLangValue(selectedValue.nameUk, selectedValue.nameEn)
+      id: this.selectedValue.courierId,
+      name: this.getLangValue(this.selectedValue.nameUk, this.selectedValue.nameEn)
     };
     this.onSelectedCourier();
   }
@@ -315,6 +327,12 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
     let name;
     const selectedItemName = event.option.value;
     const selectedItem = this.locations.filter((element) => element.regionTranslationDtos.find((it) => it.regionName === selectedItemName));
+    let regionNameUa;
+    let regionNameEn;
+    selectedItem[0].regionTranslationDtos.forEach((item) => {
+      item.languageCode === 'ua' ? (regionNameUa = item.regionName) : (regionNameEn = item.regionName);
+    });
+    this.selectedRegionValue.push({ regionNameUa, regionNameEn });
 
     selectedItem.forEach((item) => {
       id = item.regionId;
@@ -434,6 +452,12 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
     const selectedItem = this.currentCities.filter((element) =>
       element.locationTranslationDtoList.find((it) => it.locationName === event.option.value)
     )[0];
+    let cityNameUa;
+    let cityNameEn;
+    selectedItem.locationTranslationDtoList.forEach((item) => {
+      item.languageCode === 'ua' ? (cityNameUa = item.locationName) : (cityNameEn = item.locationName);
+    });
+    this.selectedCitiesValue.push({ cityNameUa, cityNameEn });
     const tempItem = {
       id: selectedItem.locationId,
       name: selectedItem.locationTranslationDtoList
@@ -695,10 +719,14 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
-        courierName: this.selectedCourier?.name,
+        courierNameUk: this.selectedValue.nameUk,
+        courierEnglishName: this.selectedValue.nameEn,
+        regionNameUk: this.selectedRegionValue.map((region) => region.regionNameUa),
+        regionEnglishName: this.selectedRegionValue.map((region) => region.regionNameEn),
+        cityNameUk: this.selectedCitiesValue.map((city) => city.cityNameUa),
+        cityNameEn: this.selectedCitiesValue.map((city) => city.cityNameEn),
         stationNames: this.selectedStations.map((it) => it.name),
-        regionName: this.selectedRegions.map((it) => it.name),
-        locationNames: this.selectedCities.map((it) => it.name)
+        isDeactivate: true
       }
     });
     this.createDeactivateCardDto();

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-tariffs.enum.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-tariffs.enum.ts
@@ -2,3 +2,18 @@ export enum TariffPlaceholderSelected {
   ua = 'обрано',
   en = 'selected'
 }
+
+export enum TariffLocationLabelName {
+  ua = 'Місто',
+  en = 'City'
+}
+
+export enum TariffRegionLabelName {
+  ua = 'Область',
+  en = 'Region'
+}
+
+export enum TariffCourierLabelName {
+  ua = 'Кур`єр',
+  en = 'Courier'
+}


### PR DESCRIPTION
Before:
The new pop-up window appeared with all selected points as text in 1 language and only the button 'Скасувати' and such text is visible in the upper right corner of the popup window: 'Введіть наступні дані АНГЛІЙСЬКОЮ мовою".
After:
The new pop-up window named “Підтвердити деактивацію” appeared with all selected points as text in 2 languages and the buttons 'Деактивувати' and 'Скасувати'.