### PR TITLE
bugfix/#5784,#5788,#5816,#5817-Some-fix-tariff-page-bugs

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.scss
@@ -68,6 +68,7 @@ form {
   background: transparent;
   border: none;
   color: var(--ubs-primary-light-grey);
+  text-overflow: ellipsis;
 }
 
 .input-wrapper input.region {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-add-tariff-service-pop-up/ubs-admin-tariffs-add-tariff-service-pop-up.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="addTariffServiceForm">
   <div *ngIf="data.button === 'add'">
-    <p class="add-location-title">{{ 'ubs-tariffs.btn.add_service2' | translate }}</p>
+    <p class="add-location-title">{{ 'ubs-tariffs.btn.add_tariff' | translate }}</p>
   </div>
   <div *ngIf="data.button === 'update'">
     <p class="add-location-title">{{ 'ubs-tariffs-add-service.edit_tariff' | translate }}</p>
@@ -23,7 +23,7 @@
         </div>
       </div>
       <div class="form-group">
-        <label for="name">{{ 'ubs-tariffs-add-service.lang.tariff_description' | translate }}</label>
+        <label for="name">{{ 'ubs-tariffs-add-service.lang.tariff_name' | translate }}</label>
         <input
           type="text"
           formControlName="nameEng"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
@@ -48,7 +48,7 @@
     <p class="title">{{ 'ubs-tariffs.tariffs_for_services' | translate }}</p>
     <button class="tariffs-add-button" [disabled]="isLoadBar" (click)="openAddTariffForServicePopup()">
       <mat-icon class="add-icon">add</mat-icon>
-      {{ 'ubs-tariffs.btn.add_service2' | translate }}
+      {{ 'ubs-tariffs.btn.add_tariff' | translate }}
     </button>
   </div>
   <div class="tariffs-table">
@@ -58,9 +58,9 @@
     <table aria-label="tariffsTable1">
       <tr>
         <th scope="row" class="empty"></th>
-        <th scope="row">{{ 'ubs-tariffs.name_of_the_service' | translate }}</th>
+        <th scope="row">{{ 'ubs-tariffs.name_of_the_tariff' | translate }}</th>
         <th scope="row">{{ 'ubs-tariffs.capacity' | translate }}</th>
-        <th scope="row">{{ 'ubs-tariffs.service_description' | translate }}</th>
+        <th scope="row">{{ 'ubs-tariffs.tariff_description' | translate }}</th>
         <th scope="row">{{ 'ubs-tariffs.basic_cost' | translate }}</th>
         <th scope="row">{{ 'ubs-tariffs.carriers_commission' | translate }}</th>
         <th scope="row">{{ 'ubs-tariffs.full_cost' | translate }}</th>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
@@ -130,8 +130,9 @@
                 (keypress)="checkOnNumber($event, minPriceOfOrder)"
                 id="from"
                 formControlName="minPriceOfOrder"
+                placeholder="0грн"
               />
-              <span class="line"></span>
+              <span class="line">-</span>
               <input
                 class="input"
                 type="number"
@@ -139,6 +140,7 @@
                 (keypress)="checkOnNumber($event, maxPriceOfOrder)"
                 id="to"
                 formControlName="maxPriceOfOrder"
+                placeholder="0грн"
               />
               <label id="label-limit" for="to"></label>
             </fieldset>
@@ -162,8 +164,9 @@
                 (keypress)="checkOnNumber($event, minBigBags)"
                 id="from-packages"
                 formControlName="minAmountOfBigBags"
+                placeholder="20"
               />
-              <span class="line"></span>
+              <span class="line">-</span>
               <input
                 class="input"
                 type="number"
@@ -171,6 +174,7 @@
                 (keypress)="checkOnNumber($event, maxBigBags)"
                 id="to-packages"
                 formControlName="maxAmountOfBigBags"
+                placeholder="20"
               />
               <label id="label-limit" for="to-packages"></label>
             </fieldset>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
@@ -130,7 +130,7 @@
                 (keypress)="checkOnNumber($event, minPriceOfOrder)"
                 id="from"
                 formControlName="minPriceOfOrder"
-                placeholder="0грн"
+                placeholder="{{ 'ubs-tariffs.placeholder_order_amount' | translate }}"
               />
               <span class="line">-</span>
               <input
@@ -140,7 +140,7 @@
                 (keypress)="checkOnNumber($event, maxPriceOfOrder)"
                 id="to"
                 formControlName="maxPriceOfOrder"
-                placeholder="0грн"
+                placeholder="{{ 'ubs-tariffs.placeholder_order_amount' | translate }}"
               />
               <label id="label-limit" for="to"></label>
             </fieldset>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.scss
@@ -139,7 +139,7 @@ h4 {
   span {
     width: 12px;
     height: 2px;
-    background: var(--ubs-quintynary-light-grey);
+    color: var(--ubs-quintynary-light-grey);
     margin: 0 6px 5px;
   }
 }
@@ -155,18 +155,23 @@ h4 {
   .input {
     width: 74px;
     height: 36px;
-    background: var(--ubs-primary-white);
-    border: 1px solid var(--ubs-quintynary-light-grey);
+    background: var(--ubs-grey-white);
+    border: 1px solid var(--ubs-primary-light-grey);
     box-sizing: border-box;
     border-radius: 4px;
     margin-bottom: 5px;
     padding: 8px;
   }
 
+  input::placeholder {
+    color: var(--ubs-primary-light-grey);
+  }
+
   label {
-    padding: 0 25px 2px 0;
+    padding: 0 12px 2px 0;
     min-width: 140px;
     white-space: nowrap;
+    color: var(--ubs-primary-grey);
   }
 
   .fields-wrapper {

--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -650,6 +650,7 @@
     "limits": "Limits",
     "order_limits": "Order limits",
     "min_order_amount": "Minimum order amount",
+    "placeholder_order_amount": "0UAH",
     "min_number_of_packages": "Minimum number of packages",
     "min_set_of_packages": "Minimum set of packages",
     "info_about_order_limits_header": "Information about order limits",

--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -641,8 +641,10 @@
     "delete-button": "Delete",
     "restore-button": "Restore",
     "name_of_the_service": "Name of the service",
+    "name_of_the_tariff": "Name of the tariff",
     "capacity": "Capacity",
     "service_description": "Service description",
+    "tariff_description": "Tariff description",
     "basic_cost": "Basic cost",
     "carriers_commission": "Carrier commission",
     "full_cost": "Full cost",
@@ -666,6 +668,7 @@
     "btn": {
       "add_service": "Add service",
       "add_service2": "Add service",
+      "add_tariff": "Add tariff",
       "save_changes": "Save changes",
       "add_carrier": "Add carrier",
       "add": "Add",

--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -789,6 +789,7 @@
       "placeholder-service": "Введіть назву послуги",
       "service_description": "Опис сервісу",
       "tariff_description": "Опис послуги",
+      "tariff_name": "Найменування послуги",
       "placeholder-text": "Опишіть, що саме входить у послугу, і умови /правила її надання"
     }
   },

--- a/src/assets/i18n/ubs-admin/ua.json
+++ b/src/assets/i18n/ubs-admin/ua.json
@@ -638,8 +638,10 @@
     "city-translate": "City",
     "restore-button": "Відновити",
     "name_of_the_service": "Найменування послуги",
+    "name_of_the_tariff": "Найменування тарифу",
     "capacity": "Об’єм",
     "service_description": "Опис послуги",
+    "tariff_description": "Опис тарифу",
     "basic_cost": "Базова вартість",
     "carriers_commission": "Комісія перевізника",
     "full_cost": "Повна вартість",
@@ -663,6 +665,7 @@
     "btn": {
       "add_service": "Додати сервіс",
       "add_service2": "Додати послугу",
+      "add_tariff": "Додати тариф",
       "save_changes": "Зберегти зміни",
       "add_carrier": "Додати перевізника",
       "add": "Додати",

--- a/src/assets/i18n/ubs-admin/ua.json
+++ b/src/assets/i18n/ubs-admin/ua.json
@@ -647,6 +647,7 @@
     "limits": "Ліміти",
     "order_limits": "Ліміти замовлення",
     "min_order_amount": "Сума замовлення",
+    "placeholder_order_amount": "0грн",
     "min_number_of_packages": "Кількість пакетів",
     "min_set_of_packages": "Мінімальний набір пакетів",
     "info_about_order_limits_header": "Інформація про ліміти замовлення",

--- a/src/assets/i18n/ubs-admin/ua.json
+++ b/src/assets/i18n/ubs-admin/ua.json
@@ -638,10 +638,10 @@
     "city-translate": "City",
     "restore-button": "Відновити",
     "name_of_the_service": "Найменування послуги",
-    "name_of_the_tariff": "Найменування тарифу",
+    "name_of_the_tariff": "Найменування послуги",
     "capacity": "Об’єм",
     "service_description": "Опис послуги",
-    "tariff_description": "Опис тарифу",
+    "tariff_description": "Опис послуги",
     "basic_cost": "Базова вартість",
     "carriers_commission": "Комісія перевізника",
     "full_cost": "Повна вартість",
@@ -665,7 +665,7 @@
     "btn": {
       "add_service": "Додати сервіс",
       "add_service2": "Додати послугу",
-      "add_tariff": "Додати тариф",
+      "add_tariff": "Додати послугу",
       "save_changes": "Зберегти зміни",
       "add_carrier": "Додати перевізника",
       "add": "Додати",
@@ -785,6 +785,7 @@
       "placeholder-service": "Enter a name for the service",
       "service_description": "Service description",
       "tariff_description": "Tariff description",
+      "tariff_name": "Name of the tariff",
       "placeholder-text": "Describe what is included in the service and the conditions / rules for its provision"
     }
   },


### PR DESCRIPTION
#5784
Before:
Alignments between input fields and labels 'Сума замовлення' / 'Кількість пакетів' are not even.
After:
Alignments between input fields and labels 'Сума замовлення' / 'Кількість пакетів' are according to the mockup
#5788
Before:
if screen small Tooltips in filters fields on tariff page are not fully displayed;
After:
Tooltips in filters fields are displayed with 3 dots when words do not fit.