### PR TITLE
Bugfix/#5819 translate bag amount in order table

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-readonly/table-cell-readonly.comoponent.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-readonly/table-cell-readonly.comoponent.spec.ts
@@ -11,7 +11,7 @@ describe('TableCellReadonlyComponent', () => {
   let component: TableCellReadonlyComponent;
   let fixture: ComponentFixture<TableCellReadonlyComponent>;
 
-  const fakeStrValue = '20Л - 0шт; 120л - 3ШТ';
+  const fakeStrValue = '20л - 0шт; 120л - 3шт';
   const fakeColumn = {
     key: 'fakeKey',
     ua: 'ua',

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-readonly/table-cell-readonly.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-readonly/table-cell-readonly.component.ts
@@ -30,8 +30,14 @@ export class TableCellReadonlyComponent implements OnInit, OnChanges {
       this.title = !/^0\.00 (UAH|грн)$/.test(String(this.title)) ? `-${this.title}` : this.title;
     }
 
-    if (this.key === TableKeys.bagsAmount && this.lang === Language.EN) {
-      this.title = (this.title as string).toLowerCase().replace(/л|шт/gi, (el) => (el === 'л' ? 'L' : 'p'));
+    const replaceRules = {
+      [Language.EN]: { regex: /л|шт/gi, match: { л: 'L', шт: 'p' } },
+      [Language.UA]: { regex: /l|p/gi, match: { l: 'л', p: 'шт' } }
+    };
+
+    if (this.key === TableKeys.bagsAmount && replaceRules[this.lang]) {
+      const { regex, match } = replaceRules[this.lang];
+      this.title = (this.title as string).toLowerCase().replace(regex, (el) => match[el]);
     }
 
     this.data = this.title;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-readonly/table-cell-readonly.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-readonly/table-cell-readonly.component.ts
@@ -32,7 +32,7 @@ export class TableCellReadonlyComponent implements OnInit, OnChanges {
 
     const replaceRules = {
       [Language.EN]: { regex: /л|шт/gi, match: { л: 'L', шт: 'p' } },
-      [Language.UA]: { regex: /l|p/gi, match: { l: 'л', p: 'шт' } }
+      [Language.UA]: { regex: /[lp]/gi, match: { l: 'л', p: 'шт' } }
     };
 
     if (this.key === TableKeys.bagsAmount && replaceRules[this.lang]) {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -832,38 +832,36 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
       const isAdjColumnSticky = adjColumnIndex < this.stickyColumnsAmount;
       const { width: adjColumnOriginalWidth, left: adjColumnLeftBoundary } = this.getColumnHeaderBoundaries(adjColumnIndex);
 
-      let newColumnWidth = originalColumnWidth;
-      let newAdjColumnWidth = adjColumnOriginalWidth;
-      let cleanupMouseMove = () => {};
-      let cleanupMouseUp = () => {};
-      const onMouseMove = (moveEvent) => {
-        const movedToX = moveEvent.pageX;
-        const dx = isResizingRight ? movedToX - resizeStartX : -movedToX + resizeStartX;
-        if (originalColumnWidth + dx < this.minColumnWidth || adjColumnOriginalWidth - dx < this.minColumnWidth) {
-          return;
-        }
-        newColumnWidth = originalColumnWidth + dx;
-        newAdjColumnWidth = adjColumnOriginalWidth - dx;
-        this.setColumnWidth(columnIndex, newColumnWidth);
-        this.setColumnWidth(adjColumnIndex, newAdjColumnWidth);
-        // Move column if it is sticky
-        if (isAdjColumnSticky) {
-          const leftColumnLeftBoundary = isResizingRight ? leftColumnBoundary : adjColumnLeftBoundary;
-          const newLeftColumnWidth = isResizingRight ? newColumnWidth : newAdjColumnWidth;
-          const rightColumnIndex = isResizingRight ? adjColumnIndex : columnIndex;
-          const rightColumnOffsetX = leftColumnLeftBoundary + newLeftColumnWidth - tableOffsetX;
-          this.setStickyColumnOffsetX(rightColumnIndex, rightColumnOffsetX);
-        }
-      };
-      const onMouseUp = () => {
-        this.updateColumnsWidthPreference(columnIndex, newColumnWidth);
-        this.updateColumnsWidthPreference(adjColumnIndex, newAdjColumnWidth);
-        cleanupMouseMove();
-        cleanupMouseUp();
-      };
-      cleanupMouseMove = this.renderer.listen('document', 'mousemove', onMouseMove);
-      cleanupMouseUp = this.renderer.listen('document', 'mouseup', onMouseUp);
-    }
+    let newColumnWidth = originalColumnWidth;
+    let newAdjColumnWidth = adjColumnOriginalWidth;
+    let cleanupMouseMove = () => {};
+    let cleanupMouseUp = () => {};
+    const onMouseMove = (moveEvent) => {
+      const movedToX = moveEvent.pageX;
+      const dx = isResizingRight ? movedToX - resizeStartX : -movedToX + resizeStartX;
+      if (originalColumnWidth + dx < this.minColumnWidth || adjColumnOriginalWidth - dx < this.minColumnWidth) {
+        return;
+      }
+      newColumnWidth = originalColumnWidth + dx;
+      newAdjColumnWidth = adjColumnOriginalWidth - dx;
+      this.setColumnWidth(columnIndex, newColumnWidth);
+      this.setColumnWidth(adjColumnIndex, newAdjColumnWidth);
+      // Move column if it is sticky
+      if (isAdjColumnSticky) {
+        const leftColumnLeftBoundary = isResizingRight ? leftColumnBoundary : adjColumnLeftBoundary;
+        const newLeftColumnWidth = isResizingRight ? newColumnWidth : newAdjColumnWidth;
+        const rightColumnIndex = isResizingRight ? adjColumnIndex : columnIndex;
+        const rightColumnOffsetX = leftColumnLeftBoundary + newLeftColumnWidth - tableOffsetX;
+        this.setStickyColumnOffsetX(rightColumnIndex, rightColumnOffsetX);
+      }
+    };
+    const onMouseUp = () => {
+      this.updateColumnsWidthPreference(adjColumnIndex, newAdjColumnWidth);
+      cleanupMouseMove();
+      cleanupMouseUp();
+    };
+    cleanupMouseMove = this.renderer.listen('document', 'mousemove', onMouseMove);
+    cleanupMouseUp = this.renderer.listen('document', 'mouseup', onMouseUp);
   }
 
   private getTableOffsetX(): number | undefined {
@@ -911,6 +909,7 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
   updateColumnsWidthPreference(columnIndex: number, newWidth: number) {
     const col = this.columns[columnIndex];
     this.columnsWidthPreference.set(col.title.key, newWidth);
+
     this.adminTableService
       .setUbsAdminOrdersTableColumnsWidthPreference(this.columnsWidthPreference)
       .pipe(takeUntil(this.destroy))

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -832,36 +832,37 @@ export class UbsAdminTableComponent implements OnInit, AfterViewChecked, OnDestr
       const isAdjColumnSticky = adjColumnIndex < this.stickyColumnsAmount;
       const { width: adjColumnOriginalWidth, left: adjColumnLeftBoundary } = this.getColumnHeaderBoundaries(adjColumnIndex);
 
-    let newColumnWidth = originalColumnWidth;
-    let newAdjColumnWidth = adjColumnOriginalWidth;
-    let cleanupMouseMove = () => {};
-    let cleanupMouseUp = () => {};
-    const onMouseMove = (moveEvent) => {
-      const movedToX = moveEvent.pageX;
-      const dx = isResizingRight ? movedToX - resizeStartX : -movedToX + resizeStartX;
-      if (originalColumnWidth + dx < this.minColumnWidth || adjColumnOriginalWidth - dx < this.minColumnWidth) {
-        return;
-      }
-      newColumnWidth = originalColumnWidth + dx;
-      newAdjColumnWidth = adjColumnOriginalWidth - dx;
-      this.setColumnWidth(columnIndex, newColumnWidth);
-      this.setColumnWidth(adjColumnIndex, newAdjColumnWidth);
-      // Move column if it is sticky
-      if (isAdjColumnSticky) {
-        const leftColumnLeftBoundary = isResizingRight ? leftColumnBoundary : adjColumnLeftBoundary;
-        const newLeftColumnWidth = isResizingRight ? newColumnWidth : newAdjColumnWidth;
-        const rightColumnIndex = isResizingRight ? adjColumnIndex : columnIndex;
-        const rightColumnOffsetX = leftColumnLeftBoundary + newLeftColumnWidth - tableOffsetX;
-        this.setStickyColumnOffsetX(rightColumnIndex, rightColumnOffsetX);
-      }
-    };
-    const onMouseUp = () => {
-      this.updateColumnsWidthPreference(adjColumnIndex, newAdjColumnWidth);
-      cleanupMouseMove();
-      cleanupMouseUp();
-    };
-    cleanupMouseMove = this.renderer.listen('document', 'mousemove', onMouseMove);
-    cleanupMouseUp = this.renderer.listen('document', 'mouseup', onMouseUp);
+      let newColumnWidth = originalColumnWidth;
+      let newAdjColumnWidth = adjColumnOriginalWidth;
+      let cleanupMouseMove = () => {};
+      let cleanupMouseUp = () => {};
+      const onMouseMove = (moveEvent) => {
+        const movedToX = moveEvent.pageX;
+        const dx = isResizingRight ? movedToX - resizeStartX : -movedToX + resizeStartX;
+        if (originalColumnWidth + dx < this.minColumnWidth || adjColumnOriginalWidth - dx < this.minColumnWidth) {
+          return;
+        }
+        newColumnWidth = originalColumnWidth + dx;
+        newAdjColumnWidth = adjColumnOriginalWidth - dx;
+        this.setColumnWidth(columnIndex, newColumnWidth);
+        this.setColumnWidth(adjColumnIndex, newAdjColumnWidth);
+        // Move column if it is sticky
+        if (isAdjColumnSticky) {
+          const leftColumnLeftBoundary = isResizingRight ? leftColumnBoundary : adjColumnLeftBoundary;
+          const newLeftColumnWidth = isResizingRight ? newColumnWidth : newAdjColumnWidth;
+          const rightColumnIndex = isResizingRight ? adjColumnIndex : columnIndex;
+          const rightColumnOffsetX = leftColumnLeftBoundary + newLeftColumnWidth - tableOffsetX;
+          this.setStickyColumnOffsetX(rightColumnIndex, rightColumnOffsetX);
+        }
+      };
+      const onMouseUp = () => {
+        this.updateColumnsWidthPreference(adjColumnIndex, newAdjColumnWidth);
+        cleanupMouseMove();
+        cleanupMouseUp();
+      };
+      cleanupMouseMove = this.renderer.listen('document', 'mousemove', onMouseMove);
+      cleanupMouseUp = this.renderer.listen('document', 'mouseup', onMouseUp);
+    }
   }
 
   private getTableOffsetX(): number | undefined {


### PR DESCRIPTION
**Before**
Admin sees En-localization in the “Кількість пакетів” column when he/she switches from En-localization to Ua--localization.

**After**
https://github.com/ita-social-projects/GreenCityClient/assets/101433204/fec62e4f-8fa8-4352-9b9b-9192b63219bd

