### PR TITLE
bugfix/#5838 - My space - calenar day style fix

### DIFF
--- a/src/app/main/component/user/components/profile/calendar/calendar.component.scss
+++ b/src/app/main/component/user/components/profile/calendar/calendar.component.scss
@@ -88,6 +88,8 @@ $bp-largest: 1200px;
       text-align: center;
 
       .calendar-grid-day {
+        display: flex;
+        justify-content: center;
         padding: 6px 0 0;
         cursor: pointer;
       }


### PR DESCRIPTION
My space - calendar:
- fixed that day are displayed in the center of the circle