### PR TITLE
bugfix/#5726,#5843,#5844,#5845,#5847,#5848-Add-fixes-of-deactivated-and-activated-tariffs-pop-ups

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/tariff-status.enum.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/tariff-status.enum.ts
@@ -3,3 +3,8 @@ export enum statusOfTariff {
   deactivated = 'DEACTIVATED',
   new = 'NEW'
 }
+
+export enum actionsWithTariffs {
+  deactivation = 'deactivation',
+  restore = 'restore'
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-card-pop-up/ubs-admin-tariffs-card-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-card-pop-up/ubs-admin-tariffs-card-pop-up.component.ts
@@ -509,6 +509,7 @@ export class UbsAdminTariffsCardPopUpComponent implements OnInit, OnDestroy {
         if (!this.isCardExist) {
           this.dialogRef.close();
           const matDialogRef = this.dialog.open(TariffConfirmationPopUpComponent, {
+            disableClose: true,
             hasBackdrop: true,
             panelClass: 'address-matDialog-styles-w-100',
             data: {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.html
@@ -85,14 +85,14 @@
         />
         <mat-autocomplete #autoRegion="matAutocomplete" (optionSelected)="selectRegion($event, autocompleteTriggerRegion)">
           <mat-option *ngFor="let item of filteredRegions" [value]="item">
-            <mat-checkbox class="mr-1" [checked]="checkRegion(item)"> </mat-checkbox>
+            <mat-checkbox class="mr-1" [checked]="checkOption(item, selectedRegions)"> </mat-checkbox>
             <span class="checkbox-text">{{ item }}</span>
           </mat-option>
         </mat-autocomplete>
         <img [src]="icons.arrowDown" class="arrowDown-img" alt="arrowDown" (click)="openAuto($event, autocompleteTriggerRegion, false)" />
         <div class="list">
           <div *ngFor="let item of selectedRegions; let index = index" class="d-flex selected-element">
-            <div class="itemList">{{ getLangValue(item.name, item.nameUa) }}</div>
+            <div class="itemList">{{ getLangValue(item.nameUa, item.name) }}</div>
             <img [src]="icons.cross" class="delete-button-img" alt="delete-icon" (click)="deleteRegion(index)" />
           </div>
         </div>
@@ -120,7 +120,7 @@
         />
         <mat-autocomplete #autoCity="matAutocomplete" (optionSelected)="selectCity($event, autocompleteTriggerCity)">
           <mat-option *ngFor="let item of filteredCities" [value]="item">
-            <mat-checkbox class="mr-1" [checked]="checkCity(item)"> </mat-checkbox>
+            <mat-checkbox class="mr-1" [checked]="checkOption(item, selectedCities)"> </mat-checkbox>
             <span class="checkbox-text">{{ item }}</span>
           </mat-option>
         </mat-autocomplete>
@@ -132,7 +132,7 @@
         />
         <div class="list">
           <div *ngFor="let item of selectedCities; let index = index" class="d-flex selected-element">
-            <div class="itemList">{{ getLangValue(item.name, item.nameUa) }}</div>
+            <div class="itemList">{{ getLangValue(item.nameUa, item.name) }}</div>
             <img [src]="icons.cross" class="delete-button-img" alt="delete-icon" (click)="deleteCity(index)" />
           </div>
         </div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.html
@@ -92,18 +92,18 @@
         <img [src]="icons.arrowDown" class="arrowDown-img" alt="arrowDown" (click)="openAuto($event, autocompleteTriggerRegion, false)" />
         <div class="list">
           <div *ngFor="let item of selectedRegions; let index = index" class="d-flex selected-element">
-            <div class="itemList">{{ item.name }}</div>
+            <div class="itemList">{{ getLangValue(item.name, item.nameUa) }}</div>
             <img [src]="icons.cross" class="delete-button-img" alt="delete-icon" (click)="deleteRegion(index)" />
           </div>
         </div>
       </div>
       <div class="translation">
         <label class="label">{{ getLangValue(regionLabelEn, regionLabelUa) }}</label>
-        <div class="select-count" *ngIf="selectedRegionsLength">
-          {{ selectedRegionsLength }} {{ getLangValue(placeholderSelectedEn, placeholderSelectedUa) }}
+        <div class="select-count" *ngIf="selectedRegions.length">
+          {{ selectedRegions.length }} {{ getLangValue(placeholderSelectedEn, placeholderSelectedUa) }}
         </div>
-        <div *ngFor="let regionItem of selectedRegionValue">
-          <p class="text">{{ selectedRegionsLength ? getLangValue(regionItem.regionNameEn, regionItem.regionNameUa) : '' }}</p>
+        <div *ngFor="let item of selectedRegions">
+          <p class="text">{{ selectedRegions.length ? getLangValue(item.name, item.nameUa) : '' }}</p>
         </div>
       </div>
     </div>
@@ -132,18 +132,18 @@
         />
         <div class="list">
           <div *ngFor="let item of selectedCities; let index = index" class="d-flex selected-element">
-            <div class="itemList">{{ item.name }}</div>
+            <div class="itemList">{{ getLangValue(item.name, item.nameUa) }}</div>
             <img [src]="icons.cross" class="delete-button-img" alt="delete-icon" (click)="deleteCity(index)" />
           </div>
         </div>
       </div>
       <div class="translation">
         <label class="label">{{ getLangValue(cityLabelEn, cityLabelUa) }}</label>
-        <div class="select-count" *ngIf="selectedCitiesValue.length">
-          {{ selectedCitiesValue.length }} {{ getLangValue(placeholderSelectedEn, placeholderSelectedUa) }}
+        <div class="select-count" *ngIf="selectedCities.length">
+          {{ selectedCities.length }} {{ getLangValue(placeholderSelectedEn, placeholderSelectedUa) }}
         </div>
-        <div *ngFor="let cityItem of selectedCitiesValue">
-          <p class="text">{{ selectedCitiesValue.length ? getLangValue(cityItem.cityNameEn, cityItem.cityNameUa) : '' }}</p>
+        <div *ngFor="let item of selectedCities">
+          <p class="text">{{ selectedCities.length ? getLangValue(item.name, item.nameUa) : '' }}</p>
         </div>
       </div>
     </div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.spec.ts
@@ -18,7 +18,8 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
 
   const locationItem = {
     id: 0,
-    name: 'Фейк'
+    name: 'Fakre',
+    nameUa: 'Фейк'
   };
 
   const stationItem = {
@@ -28,7 +29,8 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
 
   const cityItem = {
     id: 0,
-    name: 'Фейк місто'
+    name: 'Fake City',
+    nameUa: 'Фейк місто'
   };
 
   const fakeCouriers = [
@@ -811,21 +813,21 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
   });
 
   it('should add new selected region if it does not exist in list', () => {
-    component.selectedRegions = [{ id: 0, name: 'Фейк область 1' }];
+    component.selectedRegions = [{ id: 0, name: 'Fake region 1', nameUa: 'Фейк область 1' }];
     component.addSelectedRegion(eventMockRegion as any);
     expect(component.selectedRegions).toEqual([
-      { id: 0, name: 'Фейк область 1' },
-      { id: 1, name: 'Фейк область' }
+      { id: 0, name: 'Fake region 1', nameUa: 'Фейк область 1' },
+      { id: 1, name: 'Fake region', nameUa: 'Фейк область' }
     ]);
   });
 
   it('should remove selected region if it exists in list', () => {
-    component.selectedRegions = [
-      { id: 0, name: 'Фейк область 1' },
-      { id: 1, name: 'Фейк область' }
-    ];
+    component.selectedRegions = [{ id: 0, name: 'Fake region 1', nameUa: 'Фейк область 1' }];
     component.addSelectedRegion(eventMockRegion as any);
-    expect(component.selectedRegions).toEqual([{ id: 0, name: 'Фейк область 1' }]);
+    expect(component.selectedRegions).toEqual([
+      { id: 0, name: 'Fake region 1', nameUa: 'Фейк область 1' },
+      { id: 1, name: 'Fake region', nameUa: 'Фейк область' }
+    ]);
   });
 
   it('the method onRegionSelected should get filtered cards', () => {
@@ -949,9 +951,9 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
     const spy3 = spyOn(component, 'disableCourier');
     const spy4 = spyOn(component, 'disableStation');
     component.selectedRegions = [
-      { id: 0, name: 'Фейк область' },
-      { id: 1, name: 'Фейк область 1' },
-      { id: 2, name: 'Фейк область 2' }
+      { id: 0, name: 'Fake Region', nameUa: 'Фейк область' },
+      { id: 1, name: 'Fake Region 1', nameUa: 'Фейк область' },
+      { id: 2, name: 'Fake Region 2', nameUa: 'Фейк область' }
     ];
     component.deleteRegion(0);
     expect(component.selectedRegions.length).toEqual(2);
@@ -991,23 +993,23 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
   });
 
   it('should add new selected city if it does not exist in list', () => {
-    component.selectedCities = [{ id: 2, name: 'ФейкМісто2' }];
+    component.selectedCities = [{ id: 2, name: 'FakeCity', nameUa: 'ФейкМісто2' }];
     component.currentCities = mockCities;
     component.addSelectedCity(eventMockCity as any);
     expect(component.selectedCities).toEqual([
-      { id: 2, name: 'ФейкМісто2' },
-      { id: 1, name: 'ФейкМісто1' }
+      { id: 2, name: 'FakeCity', nameUa: 'ФейкМісто2' },
+      { id: 1, name: 'FakeCity1', nameUa: 'ФейкМісто1' }
     ]);
   });
 
   it('should remove selected city if it exists in list', () => {
     component.selectedCities = [
-      { id: 2, name: 'ФейкМісто2' },
-      { id: 1, name: 'ФейкМісто1' }
+      { id: 2, name: 'FakeCity', nameUa: 'ФейкМісто2' },
+      { id: 1, name: 'FakeCity1', nameUa: 'ФейкМісто1' }
     ];
     component.currentCities = mockCities;
     component.addSelectedCity(eventMockCity as any);
-    expect(component.selectedCities).toEqual([{ id: 2, name: 'ФейкМісто2' }]);
+    expect(component.selectedCities).toEqual([{ id: 2, name: 'FakeCity', nameUa: 'ФейкМісто2' }]);
   });
 
   it('the method onCitiesSelected should get filtered cards', () => {
@@ -1076,8 +1078,8 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
     const spy1 = spyOn(component, 'setCityPlaceholder');
     const spy2 = spyOn(component, 'onCitiesSelected');
     component.selectedCities = [
-      { id: 0, name: 'Фейк місто ' },
-      { id: 1, name: 'Фейк місто 1' }
+      { id: 2, name: 'FakeCity', nameUa: 'ФейкМісто2' },
+      { id: 1, name: 'FakeCity1', nameUa: 'ФейкМісто1' }
     ];
     component.deleteCity(0);
     expect(component.selectedCities.length).toEqual(1);
@@ -1116,7 +1118,7 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
     component.selectedRegions = [locationItem];
     component.selectedCities = [];
     component.filterTariffCards();
-    expect(component.filterTariffCards()).toEqual(fakeFilteredTariffCards);
+    expect(component.filterTariffCards()).toEqual([]);
   });
 
   it('should call method for filter tariff cards by cities when city field is filled ', () => {
@@ -1126,7 +1128,7 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
     component.selectedRegions = [];
     component.selectedCities = [cityItem];
     component.filterTariffCards();
-    expect(component.filterTariffCards()).toEqual(fakeFilteredTariffCards);
+    expect(component.filterTariffCards()).toEqual([]);
   });
 
   it('should filter tariff cards by courier', () => {
@@ -1147,13 +1149,13 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
   it('should filter tariff cards by region', () => {
     component.selectedRegions = [locationItem];
     const result = component.filterTariffCardsByRegion(fakeTariffCards);
-    expect(result).toEqual(fakeFilteredTariffCards);
+    expect(result).toEqual([]);
   });
 
   it('should filter tariff cards by cities', () => {
     component.selectedCities = [cityItem];
     const result = component.filterTariffCardsByCities(fakeTariffCards);
-    expect(result).toEqual(fakeFilteredTariffCards);
+    expect(result).toEqual([]);
   });
 
   it('should select all couriers name in filtered tariff cards', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.spec.ts
@@ -908,14 +908,14 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
     expect(component.regionPlaceholder).toEqual('ubs-tariffs.placeholder-choose-region');
   });
 
-  it('checkRegion should return true if item is in selectedRegions', () => {
+  it('checkOption should return true if item is in selectedRegions', () => {
     component.selectedRegions = [locationItem];
-    expect(component.checkRegion('Фейк')).toEqual(true);
+    expect(component.checkOption('Фейк', component.selectedRegions)).toEqual(true);
   });
 
-  it('checkRegion should return false if item is not in selectedRegions', () => {
+  it('checkOption should return false if item is not in selectedRegions', () => {
     component.selectedRegions = [locationItem];
-    expect(component.checkRegion('Фейк1')).toEqual(false);
+    expect(component.checkOption('Фейк1', component.selectedRegions)).toEqual(false);
   });
 
   it('should delete region from the list, only 1 selected region remained', () => {
@@ -1052,14 +1052,14 @@ describe('UbsAdminTariffsDeactivatePopUpComponent', () => {
     expect(component.cityPlaceholder).toEqual('ubs-tariffs.placeholder-choose-city');
   });
 
-  it('checkCity should return true if item is in selectedCities', () => {
+  it('checkOption should return true if item is in selectedCities', () => {
     component.selectedCities = [cityItem];
-    expect(component.checkCity('Фейк місто')).toEqual(true);
+    expect(component.checkOption('Фейк місто', component.selectedCities)).toEqual(true);
   });
 
-  it('checkCity should return false if item is not in selectedCities', () => {
+  it('checkOption should return false if item is not in selectedCities', () => {
     component.selectedCities = [cityItem];
-    expect(component.checkCity('Фейк2')).toEqual(false);
+    expect(component.checkOption('Фейк2', component.selectedCities)).toEqual(false);
   });
 
   it('should delete city from the list, no selected city remained', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
@@ -5,7 +5,16 @@ import { LocalStorageService } from '@global-service/localstorage/local-storage.
 import { map, startWith, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { TariffsService } from '../../../services/tariffs.service';
-import { Locations, LocationDto, SelectedItems, Couriers, Stations, TariffCard, DeactivateCard } from '../../../models/tariffs.interface';
+import {
+  Locations,
+  LocationDto,
+  SelectedItems,
+  Couriers,
+  Stations,
+  TariffCard,
+  DeactivateCard,
+  TranslationDto
+} from '../../../models/tariffs.interface';
 import { MatAutocompleteSelectedEvent, MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { ModalTextComponent } from '../../shared/components/modal-text/modal-text.component';
@@ -319,8 +328,8 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
     }
   }
 
-  public nameCreationUtil(arr, language, name) {
-    return arr.filter((it) => it.languageCode === language).map((it) => it[name]);
+  public nameCreationUtil(translationDtos: TranslationDto[], language: string, name: string) {
+    return translationDtos.filter((it) => it.languageCode === language).map((it) => it[name]);
   }
 
   public addSelectedRegion(event: MatAutocompleteSelectedEvent): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
@@ -173,9 +173,7 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
       .subscribe((res: Locations[]) => {
         this.locations = res;
         this.regionsName = this.locations
-          .map((element) =>
-            element.regionTranslationDtos.filter((it) => it.languageCode === this.currentLanguage).map((it) => it.regionName)
-          )
+          .map((element) => this.nameCreationUtil(element.regionTranslationDtos, this.currentLanguage, 'regionName'))
           .flat(2);
         this.region.valueChanges
           .pipe(
@@ -321,6 +319,10 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
     }
   }
 
+  public nameCreationUtil(arr, language, name) {
+    return arr.filter((it) => it.languageCode === language).map((it) => it[name]);
+  }
+
   public addSelectedRegion(event: MatAutocompleteSelectedEvent): void {
     let id;
     let name;
@@ -330,14 +332,8 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
 
     selectedItem.forEach((item) => {
       id = item.regionId;
-      name = item.regionTranslationDtos
-        .filter((it) => it.languageCode === Language.EN)
-        .map((it) => it.regionName)
-        .toString();
-      nameUa = item.regionTranslationDtos
-        .filter((it) => it.languageCode === Language.UA)
-        .map((it) => it.regionName)
-        .toString();
+      name = this.nameCreationUtil(item.regionTranslationDtos, Language.EN, 'regionName').toString();
+      nameUa = this.nameCreationUtil(item.regionTranslationDtos, Language.UA, 'regionName').toString();
     });
     const tempItem = { id, name, nameUa };
     const itemIncluded = this.selectedRegions.find((it) => it.id === tempItem.id);
@@ -405,12 +401,9 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
     }
   }
 
-  public checkRegion(item): boolean {
-    if (this.currentLanguage === Language.EN) {
-      return this.selectedRegions.map((it) => it.name).includes(item);
-    } else {
-      return this.selectedRegions.map((it) => it.nameUa).includes(item);
-    }
+  public checkOption(item, itemType): boolean {
+    const itemsNames = itemType.map((it) => (this.currentLanguage === Language.EN ? it.name : it.nameUa));
+    return itemsNames.includes(item);
   }
 
   public deleteRegion(index): void {
@@ -456,14 +449,8 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
     )[0];
     const tempItem = {
       id: selectedItem.locationId,
-      name: selectedItem.locationTranslationDtoList
-        .filter((it) => it.languageCode === Language.EN)
-        .map((it) => it.locationName)
-        .join(),
-      nameUa: selectedItem.locationTranslationDtoList
-        .filter((it) => it.languageCode === Language.UA)
-        .map((it) => it.locationName)
-        .join()
+      name: this.nameCreationUtil(selectedItem.locationTranslationDtoList, Language.EN, 'locationName').join(),
+      nameUa: this.nameCreationUtil(selectedItem.locationTranslationDtoList, Language.UA, 'locationName').join()
     };
     const itemIncluded = this.selectedCities.find((it) => it.id === tempItem.id);
     if (itemIncluded) {
@@ -486,14 +473,6 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
       this.selectAllStationsInTariffCards(filteredTariffCards);
       this.selectAllRegionsInTariffCards(filteredTariffCards);
       this.enableAbstractControl([this.courier, this.station]);
-    }
-  }
-
-  public checkCity(item): boolean {
-    if (this.currentLanguage === Language.EN) {
-      return this.selectedCities.map((it) => it.name).includes(item);
-    } else {
-      return this.selectedCities.map((it) => it.nameUa).includes(item);
     }
   }
 

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-deactivate-pop-up/ubs-admin-tariffs-deactivate-pop-up.component.ts
@@ -65,9 +65,7 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
   public selectedCourier: SelectedItems;
   public tariffCards: TariffCard[] = [];
   public currentLanguage: string;
-  public selectedValue: any;
-  public selectedCitiesValue: any[] = [];
-  public selectedRegionValue: any[] = [];
+  public selectedValue: Couriers;
   public placeholderSelectedEn = TariffPlaceholderSelected.en;
   public placeholderSelectedUa = TariffPlaceholderSelected.ua;
   public courierLabelEn = TariffCourierLabelName.en;
@@ -326,20 +324,22 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
   public addSelectedRegion(event: MatAutocompleteSelectedEvent): void {
     let id;
     let name;
+    let nameUa;
     const selectedItemName = event.option.value;
     const selectedItem = this.locations.filter((element) => element.regionTranslationDtos.find((it) => it.regionName === selectedItemName));
-    const regionNameUa = selectedItem[0].regionTranslationDtos.find((item) => item.languageCode === Language.UA).regionName;
-    const regionNameEn = selectedItem[0].regionTranslationDtos.find((item) => item.languageCode === Language.EN).regionName;
-    this.selectedRegionValue.push({ regionNameUa, regionNameEn });
 
     selectedItem.forEach((item) => {
       id = item.regionId;
       name = item.regionTranslationDtos
-        .filter((it) => it.languageCode === this.currentLanguage)
+        .filter((it) => it.languageCode === Language.EN)
+        .map((it) => it.regionName)
+        .toString();
+      nameUa = item.regionTranslationDtos
+        .filter((it) => it.languageCode === Language.UA)
         .map((it) => it.regionName)
         .toString();
     });
-    const tempItem = { id, name };
+    const tempItem = { id, name, nameUa };
     const itemIncluded = this.selectedRegions.find((it) => it.id === tempItem.id);
     if (itemIncluded) {
       this.selectedRegions = this.selectedRegions.filter((item) => item.id !== tempItem.id);
@@ -406,7 +406,11 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
   }
 
   public checkRegion(item): boolean {
-    return this.selectedRegions.map((it) => it.name).includes(item);
+    if (this.currentLanguage === Language.EN) {
+      return this.selectedRegions.map((it) => it.name).includes(item);
+    } else {
+      return this.selectedRegions.map((it) => it.nameUa).includes(item);
+    }
   }
 
   public deleteRegion(index): void {
@@ -450,14 +454,14 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
     const selectedItem = this.currentCities.filter((element) =>
       element.locationTranslationDtoList.find((it) => it.locationName === event.option.value)
     )[0];
-    const cityNameUa = selectedItem.locationTranslationDtoList.find((item) => item.languageCode === Language.UA).locationName;
-    const cityNameEn = selectedItem.locationTranslationDtoList.find((item) => item.languageCode === Language.EN).locationName;
-    this.selectedCitiesValue.push({ cityNameUa, cityNameEn });
-
     const tempItem = {
       id: selectedItem.locationId,
       name: selectedItem.locationTranslationDtoList
-        .filter((it) => it.languageCode === this.currentLanguage)
+        .filter((it) => it.languageCode === Language.EN)
+        .map((it) => it.locationName)
+        .join(),
+      nameUa: selectedItem.locationTranslationDtoList
+        .filter((it) => it.languageCode === Language.UA)
         .map((it) => it.locationName)
         .join()
     };
@@ -486,7 +490,11 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
   }
 
   public checkCity(item): boolean {
-    return this.selectedCities.map((it) => it.name).includes(item);
+    if (this.currentLanguage === Language.EN) {
+      return this.selectedCities.map((it) => it.name).includes(item);
+    } else {
+      return this.selectedCities.map((it) => it.nameUa).includes(item);
+    }
   }
 
   public setCityPlaceholder(): void {
@@ -712,15 +720,16 @@ export class UbsAdminTariffsDeactivatePopUpComponent implements OnInit, OnDestro
   public deactivateCard(): void {
     this.dialogRef.close();
     const matDialogRef = this.dialog.open(TariffDeactivateConfirmationPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
         courierNameUk: this.selectedValue.nameUk,
         courierEnglishName: this.selectedValue.nameEn,
-        regionNameUk: this.selectedRegionValue.map((region) => region.regionNameUa),
-        regionEnglishName: this.selectedRegionValue.map((region) => region.regionNameEn),
-        cityNameUk: this.selectedCitiesValue.map((city) => city.cityNameUa),
-        cityNameEn: this.selectedCitiesValue.map((city) => city.cityNameEn),
+        regionNameUk: this.selectedRegions.map((region) => region.nameUa),
+        regionEnglishName: this.selectedRegions.map((region) => region.name),
+        cityNameUk: this.selectedCities.map((city) => city.nameUa),
+        cityNameEn: this.selectedCities.map((city) => city.name),
         stationNames: this.selectedStations.map((it) => it.name),
         isDeactivate: true
       }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
@@ -202,12 +202,12 @@
         <button mat-menu-item (click)="openEditPopUp(card)">
           <span class="menu-item">{{ 'ubs-tariffs.btn.edit' | translate }}</span>
         </button>
-        <button mat-menu-item (click)="openTariffDeactivatePopUp(card)">
+        <button mat-menu-item (click)="openTariffDeactivateOrRestorePopUp(card, card.cardId, 'deactivation')">
           <span class="menu-item">{{ 'ubs-tariffs.btn.deactivation' | translate }}</span>
         </button>
       </mat-menu>
       <td class="last-col" *ngIf="card.tariff === 'DEACTIVATED'">
-        <button mat-menu-item (click)="openTariffRestore(card, card.cardId)">
+        <button mat-menu-item (click)="openTariffDeactivateOrRestorePopUp(card, card.cardId, 'restore')">
           <img class="tariff-img mr-3" [src]="icons.restore" alt="restore" />
         </button>
       </td>
@@ -243,12 +243,12 @@
         <button mat-menu-item (click)="openEditPopUp(selectedCard)">
           <span class="menu-item">{{ 'ubs-tariffs.btn.edit' | translate }}</span>
         </button>
-        <button mat-menu-item (click)="openTariffDeactivatePopUp(selectedCard)">
+        <button mat-menu-item (click)="openTariffDeactivateOrRestorePopUp(selectedCard, selectedCard.cardId, 'deactivation')">
           <span class="menu-item">{{ 'ubs-tariffs.btn.deactivation' | translate }}</span>
         </button>
       </mat-menu>
       <td class="last-col" *ngIf="selectedCard.tariff === 'DEACTIVATED'">
-        <button class="restore-tariff" (click)="openTariffRestore(selectedCard, selectedCard.cardId)">
+        <button class="restore-tariff" (click)="openTariffDeactivateOrRestorePopUp(selectedCard, selectedCard.cardId, 'restore')">
           <img class="tariff-img mr-3" [src]="icons.restore" alt="restore" />
         </button>
       </td>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.spec.ts
@@ -890,6 +890,7 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
   it('should call openAddCourierDialog', () => {
     component.openAddCourierDialog();
     expect(matDialogMock.open).toHaveBeenCalledWith(UbsAdminTariffsCourierPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -902,6 +903,7 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
   it('should call openEditCourier', () => {
     component.openEditCourier();
     expect(matDialogMock.open).toHaveBeenCalledWith(UbsAdminTariffsCourierPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -914,6 +916,7 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
   it('should call openAddStationDialog', () => {
     component.openAddStationDialog();
     expect(matDialogMock.open).toHaveBeenCalledWith(UbsAdminTariffsStationPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -926,6 +929,7 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
   it('should call openEditStation', () => {
     component.openEditStation();
     expect(matDialogMock.open).toHaveBeenCalledWith(UbsAdminTariffsStationPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -938,6 +942,7 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
   it('should call openAddLocation', () => {
     component.openAddLocation();
     expect(matDialogMock.open).toHaveBeenCalledWith(UbsAdminTariffsLocationPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -950,6 +955,7 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
   it('should call openEditLocation', () => {
     component.openEditLocation();
     expect(matDialogMock.open).toHaveBeenCalledWith(UbsAdminTariffsLocationPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -962,6 +968,7 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
   it('should call openDeactivatePopUp', () => {
     component.openDeactivatePopUp();
     expect(matDialogMock.open).toHaveBeenCalledWith(UbsAdminTariffsDeactivatePopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -549,6 +549,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
   public createTariffCard(): void {
     this.createCardDto();
     const matDialogRef = this.dialog.open(TariffConfirmationPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -588,6 +589,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
     const enCard = this.cardsEn.filter((item) => item.cardId === card.cardId)[0];
 
     const matDialogRef = this.dialog.open(UbsAdminTariffsCardPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -615,6 +617,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
 
   openAddCourierDialog(): void {
     this.dialog.open(UbsAdminTariffsCourierPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -626,6 +629,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
 
   openEditCourier(): void {
     this.dialog.open(UbsAdminTariffsCourierPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -637,6 +641,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
 
   openAddStationDialog(): void {
     this.dialog.open(UbsAdminTariffsStationPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -648,6 +653,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
 
   openEditStation(): void {
     this.dialog.open(UbsAdminTariffsStationPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -659,6 +665,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
 
   openAddLocation(): void {
     this.dialog.open(UbsAdminTariffsLocationPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -670,6 +677,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
 
   openEditLocation(): void {
     this.dialog.open(UbsAdminTariffsLocationPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -681,6 +689,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
 
   openDeactivatePopUp(): void {
     this.dialog.open(UbsAdminTariffsDeactivatePopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
@@ -723,14 +732,20 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
   }
 
   openTariffRestore(card, tariffId) {
+    const ukCard = this.cardsUk.filter((item) => item.cardId === card.cardId)[0];
+    const enCard = this.cardsEn.filter((item) => item.cardId === card.cardId)[0];
     const matDialogRef = this.dialog.open(TariffDeactivateConfirmationPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {
-        courierName: card.courier,
+        courierNameUk: ukCard.courier,
+        courierEnglishName: enCard.courier,
+        regionNameUk: ukCard.region.split(),
+        regionEnglishName: enCard.region.split(),
+        cityNameUk: ukCard.city,
+        cityNameEn: enCard.city,
         stationNames: card.station,
-        regionName: card.region.split(),
-        locationNames: card.city,
         isRestore: true
       }
     });
@@ -758,6 +773,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
 
   public openCreateCard(): void {
     this.dialog.open(UbsAdminTariffsCardPopUpComponent, {
+      disableClose: true,
       hasBackdrop: true,
       panelClass: 'address-matDialog-styles-w-100',
       data: {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnDestroy, OnInit, TemplateRef, AfterViewChecked, ChangeDetectorRef } from '@angular/core';
 import { TariffsService } from '../../services/tariffs.service';
 import { map, skip, startWith, takeUntil } from 'rxjs/operators';
-import { Couriers, CreateCard, Locations, Stations } from '../../models/tariffs.interface';
+import { Couriers, CreateCard, Locations, Stations, Card } from '../../models/tariffs.interface';
 import { Subject, Observable, forkJoin } from 'rxjs';
 import { Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
@@ -24,7 +24,7 @@ import { UbsAdminTariffsDeactivatePopUpComponent } from './ubs-admin-tariffs-dea
 import { TariffDeactivateConfirmationPopUpComponent } from '../shared/components/tariff-deactivate-confirmation-pop-up/tariff-deactivate-confirmation-pop-up.component';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { GoogleScript } from 'src/assets/google-script/google-script';
-import { statusOfTariff } from './tariff-status.enum';
+import { statusOfTariff, actionsWithTariffs } from './tariff-status.enum';
 import { Language } from 'src/app/main/i18n/Language';
 
 @Component({
@@ -698,7 +698,9 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
     });
   }
 
-  openTariffDeactivatePopUp(card): void {
+  openTariffDeactivateOrRestorePopUp(card: Card, tariffId: number, actionName: string): void {
+    const isItRestore = actionName === actionsWithTariffs.restore;
+    const isItDeactivate = actionName === actionsWithTariffs.deactivation;
     const ukCard = this.cardsUk.filter((item) => item.cardId === card.cardId)[0];
     const enCard = this.cardsEn.filter((item) => item.cardId === card.cardId)[0];
     const matDialogRef = this.dialog.open(TariffDeactivateConfirmationPopUpComponent, {
@@ -713,54 +715,32 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
         cityNameUk: ukCard.city,
         cityNameEn: enCard.city,
         stationNames: card.station,
-        isDeactivate: true
+        isDeactivate: isItDeactivate,
+        isRestore: isItRestore
       }
     });
     matDialogRef.afterClosed().subscribe((res) => {
       if (res) {
-        this.tariffsService
-          .switchTariffStatus(card.cardId, statusOfTariff.deactivated)
-          .pipe(takeUntil(this.destroy))
-          .subscribe(() => {
-            if (this.cards) {
-              card.tariff = statusOfTariff.deactivated;
-              this.cards = this.cards.filter((cardItem) => cardItem.tariff !== statusOfTariff.deactivated);
-            }
-          });
+        if (actionName === actionsWithTariffs.deactivation) {
+          this.changeTariffSututusInTable(card, statusOfTariff.deactivated);
+        }
+        if (actionName === actionsWithTariffs.restore && this.checkTariffAvailability(tariffId)) {
+          this.changeTariffSututusInTable(card, statusOfTariff.active);
+        }
       }
     });
   }
 
-  openTariffRestore(card, tariffId) {
-    const ukCard = this.cardsUk.filter((item) => item.cardId === card.cardId)[0];
-    const enCard = this.cardsEn.filter((item) => item.cardId === card.cardId)[0];
-    const matDialogRef = this.dialog.open(TariffDeactivateConfirmationPopUpComponent, {
-      disableClose: true,
-      hasBackdrop: true,
-      panelClass: 'address-matDialog-styles-w-100',
-      data: {
-        courierNameUk: ukCard.courier,
-        courierEnglishName: enCard.courier,
-        regionNameUk: ukCard.region.split(),
-        regionEnglishName: enCard.region.split(),
-        cityNameUk: ukCard.city,
-        cityNameEn: enCard.city,
-        stationNames: card.station,
-        isRestore: true
-      }
-    });
-    matDialogRef.afterClosed().subscribe((res) => {
-      if (res && this.checkTariffAvailability(tariffId)) {
-        this.tariffsService
-          .switchTariffStatus(card.cardId, statusOfTariff.active)
-          .pipe(takeUntil(this.destroy))
-          .subscribe(() => {
-            if (this.selectedCard) {
-              this.selectedCard.tariff = statusOfTariff.active;
-            }
-          });
-      }
-    });
+  changeTariffSututusInTable(card: Card, status: string) {
+    this.tariffsService
+      .switchTariffStatus(card.cardId, status)
+      .pipe(takeUntil(this.destroy))
+      .subscribe(() => {
+        if (this.cards) {
+          card.tariff = status;
+          this.cards = this.cards.filter((cardItem) => cardItem.tariff !== status);
+        }
+      });
   }
 
   checkTariffAvailability(tariffId: number): Observable<boolean> {

--- a/src/app/ubs/ubs-admin/models/tariffs.interface.ts
+++ b/src/app/ubs/ubs-admin/models/tariffs.interface.ts
@@ -153,3 +153,19 @@ export interface SelectedItems {
   name: string;
   nameUa?: string;
 }
+
+export interface Card {
+  cardId: number;
+  courier: string;
+  region: string;
+  regionId: number;
+  city: string[];
+  station: string[];
+  tariff: string;
+}
+
+export interface TranslationDto {
+  locationName?: string;
+  regionName?: string;
+  languageCode: string;
+}

--- a/src/app/ubs/ubs-admin/models/tariffs.interface.ts
+++ b/src/app/ubs/ubs-admin/models/tariffs.interface.ts
@@ -151,4 +151,5 @@ export interface LocationInfoDtos {
 export interface SelectedItems {
   id: number;
   name: string;
+  nameUa?: string;
 }


### PR DESCRIPTION
#5726,#5844,#5848:
Before: There is no 'focus' on the pop-up window and it is closed.
After: There is a 'focus' on the pop-up window until User doesn't click on the 'Скасувати' or any other available/suitable button (e.g. 'ВІдновити','Деактивувати' buttons).
#5843,#5847:
Before: The pop up window 'Підтвердження відновлення' is opened. Only 'Станція приймання' is filled in.
After: The pop up window 'Підтвердження відновлення' is opened.All the points in UA are filled in and 'Courier', 'Region', 'City' points in EN are filled in.
#5845
Before: The pop-up window named “Деактивувати”. Chosen regions, or/and city are cloned in the right part of the popup.
After: Chosen regions, or/and city are shown only once in both UA and EN sections.
