### PR TITLE
hotfix/fix-bug-of-calculating-the-amount-of-bonuses-when-using-a-certificate-in-the-order

### DIFF
--- a/src/app/main/component/events/components/events-list/events-list.component.scss
+++ b/src/app/main/component/events/components/events-list/events-list.component.scss
@@ -103,6 +103,7 @@
   align-items: center;
   margin-right: 15px;
   white-space: nowrap;
+  cursor: pointer;
 }
 
 hr {

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -379,8 +379,8 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
   }
 
   public calculatePointsWithCertificate() {
-    const totalSumIsBiggerThanPoints = this.defaultPoints > this.finalSum - this.certificateSum;
     this.finalSum = this.showTotal;
+    const totalSumIsBiggerThanPoints = this.defaultPoints > this.finalSum - this.certificateSum;
     if (totalSumIsBiggerThanPoints) {
       this.pointsUsed = this.finalSum - this.certificateSum;
       this.points = this.defaultPoints - this.pointsUsed;


### PR DESCRIPTION
Incorrect process of calculating the amount of bonuses when using a certificate in the order.

Before:
https://github.com/ita-social-projects/GreenCityClient/assets/60553157/93abdb2a-8390-49c0-90ac-6124cb6230d9
After:
https://github.com/ita-social-projects/GreenCityClient/assets/60553157/113d5d31-19b2-4d01-a2a0-817dab24c8dd
