### PR TITLE
bugfix/#5952 added tooltips for sidebar

### DIFF
--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -12,6 +12,7 @@ import { UbsBaseSidebarComponent } from './ubs-base-sidebar/ubs-base-sidebar.com
 import { TranslateModule } from '@ngx-translate/core';
 import { RouterModule } from '@angular/router';
 import { FilterListByLangPipe } from './sort-list-by-lang/filter-list-by-lang.pipe';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { HeaderComponent } from './header/header.component';
 import { SearchAllResultsComponent } from './search-all-results/search-all-results.component';
@@ -82,7 +83,8 @@ import { NewsListGalleryViewComponent } from './news-list-gallery-view/news-list
     NgxPageScrollModule,
     ReactiveFormsModule,
     FormsModule,
-    MatAutocompleteModule
+    MatAutocompleteModule,
+    MatTooltipModule
   ],
   exports: [
     SpinnerComponent,

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.html
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.html
@@ -30,6 +30,7 @@
           [attr.aria-label]="listItem.name | translate"
           (keydown.enter)="navigateToPage($event, listItem.routerLink)"
           (keydown.space)="navigateToPage($event, listItem.routerLink)"
+          [matTooltip]="!isExpanded ? (listItem.name | translate) : null"
         >
           <img [src]="getIcon(listItem)" class="sidebar-list-item-icon" alt="{{ listItem.name | translate }} icon" />
           <span *ngIf="isExpanded" class="sidebar-list-item-link">{{ listItem.name | translate }}</span>

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
@@ -16,6 +16,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { JwtService } from '@global-service/jwt/jwt.service';
 import { Router } from '@angular/router';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-ubs-base-sidebar',

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
@@ -16,7 +16,6 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { JwtService } from '@global-service/jwt/jwt.service';
 import { Router } from '@angular/router';
-import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-ubs-base-sidebar',


### PR DESCRIPTION
**Before**
There is no tooltip when the admin hovers the item in the sidebar
![image](https://github.com/ita-social-projects/GreenCityClient/assets/101433204/52d74bb6-a55a-4787-a49e-01f117beb04e)

**After**
There are tooltips with 'clues' when the admin hovers the sidebar
![image](https://github.com/ita-social-projects/GreenCityClient/assets/101433204/47eee4aa-1116-4183-972d-0c21daa677b3)
