### PR TITLE
bugfix/#5494-wrong-title-Sender-client-info

### DIFF
--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -271,7 +271,7 @@
       "email-placeholder": "example@mail.com"
     },
     "recipient": {
-      "title": "Recipient",
+      "title": "Sender",
       "name-label": "Name",
       "surname-label": "Surname",
       "name-placeholder": "Name",


### PR DESCRIPTION
task: 
[Pick up city UBS.UBS Admin Cabinet] Admin sees wrong title of the Sender section in En localization in the 'Information about client' section of the order form #5494