### PR TITLE
bugfix/#6074,#6075,#6076,#6077,#6078-Changing-the-access-to-elements-of-admin-sidemenu-according-to-employees-roles

### DIFF
--- a/src/app/main/component/auth/components/sign-in/sign-in.component.spec.ts
+++ b/src/app/main/component/auth/components/sign-in/sign-in.component.spec.ts
@@ -59,8 +59,9 @@ describe('SignIn component', () => {
   googleServiceMock.signIn = () => of(userSuccessSignIn);
 
   let jwtServiceMock: JwtService;
-  jwtServiceMock = jasmine.createSpyObj('JwtService', ['getUserRole']);
+  jwtServiceMock = jasmine.createSpyObj('JwtService', ['getUserRole', 'getEmailFromAccessToken']);
   jwtServiceMock.getUserRole = () => 'true';
+  jwtServiceMock.getEmailFromAccessToken = () => 'true';
   jwtServiceMock.userRole$ = new BehaviorSubject('test');
 
   beforeEach(async(() => {

--- a/src/app/main/component/auth/components/sign-in/sign-in.component.ts
+++ b/src/app/main/component/auth/components/sign-in/sign-in.component.ts
@@ -17,6 +17,7 @@ import { ProfileService } from '../../../user/components/profile/profile-service
 import { environment } from '@environment/environment';
 import { accounts } from 'google-one-tap';
 import { Patterns } from 'src/assets/patterns/patterns';
+import { UbsAdminEmployeeService } from 'src/app/ubs/ubs-admin/services/ubs-admin-employee.service';
 
 declare var google: any;
 @Component({
@@ -58,6 +59,7 @@ export class SignInComponent implements OnInit, OnDestroy, OnChanges {
     private localStorageService: LocalStorageService,
     private userOwnAuthService: UserOwnAuthService,
     private profileService: ProfileService,
+    private ubsAdminEmployeeService: UbsAdminEmployeeService,
     private zone: NgZone
   ) {}
 
@@ -192,7 +194,18 @@ export class SignInComponent implements OnInit, OnDestroy, OnChanges {
     const getUbsRoleSignIn = this.jwtService.getUserRole();
     const isUbsRoleAdmin = getUbsRoleSignIn === 'ROLE_UBS_EMPLOYEE' ? ['ubs-admin', 'orders'] : ['ubs'];
     this.jwtService.userRole$.next(getUbsRoleSignIn);
+    this.definitionOfAuthoritiesAndPositions();
     this.router.navigate(this.isUbs ? isUbsRoleAdmin : ['profile', data.userId]);
+  }
+
+  private definitionOfAuthoritiesAndPositions() {
+    const userEmail = this.jwtService.getEmailFromAccessToken();
+    this.ubsAdminEmployeeService.getEmployeeLoginPositions(userEmail).subscribe((positions) => {
+      this.ubsAdminEmployeeService.employeePositions$.next(positions);
+    });
+    this.ubsAdminEmployeeService.getEmployeePositionsAuthorities(userEmail).subscribe((positionsAuthorities) => {
+      this.ubsAdminEmployeeService.employeePositionsAuthorities$.next(positionsAuthorities);
+    });
   }
 
   private onSignInFailure(errors: HttpErrorResponse): void {

--- a/src/app/main/component/events/components/event-details/event-details.component.html
+++ b/src/app/main/component/events/components/event-details/event-details.component.html
@@ -117,10 +117,10 @@
           </div>
         </div>
 
-        <div class="save-join-event-block" *ngIf="role === roles.USER && !isOver">
-          <button class="secondary-global-button">{{ 'homepage.events.btn.save-btn' | translate }}</button>
+        <div class="save-join-event-block" *ngIf="role === roles.USER">
+          <button *ngIf="!isOver" class="secondary-global-button">{{ 'homepage.events.btn.save-btn' | translate }}</button>
           <button
-            *ngIf="!isUserCanRate"
+            *ngIf="!isUserCanRate && !isOver"
             [ngClass]="isUserCanJoin ? 'primary-global-button' : 'secondary-global-button'"
             (click)="buttonAction()"
           >

--- a/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
+++ b/src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component.ts
@@ -23,7 +23,7 @@ import { Router } from '@angular/router';
   styleUrls: ['./ubs-base-sidebar.component.scss']
 })
 export class UbsBaseSidebarComponent implements AfterViewInit, AfterViewChecked, OnDestroy {
-  private destroySub: Subject<boolean> = new Subject<boolean>();
+  public destroySub: Subject<boolean> = new Subject<boolean>();
   readonly bellsNoneNotification = 'assets/img/sidebarIcons/none_notification_Bell.svg';
   readonly bellsNotification = 'assets/img/sidebarIcons/notification_Bell.svg';
   private adminRoleValue = 'ROLE_UBS_EMPLOYEE';

--- a/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.html
@@ -143,8 +143,7 @@
           <label for="district">{{ 'address-details.district' | translate }}</label>
           <select
             [formControlName]="getLangValue('addressDistrict', 'addressDistrictEng')"
-            class="shadow-none form-control"
-            disabled="!isEmployeeCanEditOrder"
+            [ngClass]="isEmployeeCanEditOrder ? 'shadow-none form-control' : 'shadow-none form-control readonly'"
             (change)="onDistrictSelected()"
           >
             <option *ngFor="let district of districts" [ngValue]="getLangValue(district.nameUa, district.nameEn)">

--- a/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.html
@@ -25,7 +25,7 @@
               (keyup)="setPredictCities()"
               [formControlName]="getLangValue('addressCity', 'addressCityEng')"
               class="form-control"
-              [readonly]="isStatus"
+              [readonly]="isStatus || !isEmployeeCanEditOrder"
               id="city"
               placeholder="{{ 'address-details.city' | translate }}"
               matInput
@@ -58,7 +58,7 @@
               type="text"
               class="form-control"
               placeholder="{{ 'address-details.street' | translate }}"
-              [readonly]="isStatus"
+              [readonly]="isStatus || !isEmployeeCanEditOrder"
               [formControlName]="getLangValue('addressStreet', 'addressStreetEng')"
               [matAutocomplete]="autoStreet"
               (keyup)="setPredictStreets()"
@@ -86,7 +86,7 @@
               <input
                 type="text"
                 class="form-control"
-                [readonly]="isStatus"
+                [readonly]="isStatus || !isEmployeeCanEditOrder"
                 id="house"
                 formControlName="addressHouseNumber"
                 placeholder="{{ 'address-details.house' | translate }}"
@@ -114,7 +114,7 @@
               <input
                 type="text"
                 class="form-control"
-                [readonly]="isStatus"
+                [readonly]="isStatus || !isEmployeeCanEditOrder"
                 id="building"
                 formControlName="addressHouseCorpus"
                 placeholder="{{ 'address-details.building' | translate }}"
@@ -129,7 +129,7 @@
                 formControlName="addressEntranceNumber"
                 type="text"
                 class="form-control"
-                [readonly]="isStatus"
+                [readonly]="isStatus || !isEmployeeCanEditOrder"
                 id="entrance"
                 placeholder="{{ 'address-details.entrance' | translate }}"
               />
@@ -144,6 +144,7 @@
           <select
             [formControlName]="getLangValue('addressDistrict', 'addressDistrictEng')"
             class="shadow-none form-control"
+            disabled="!isEmployeeCanEditOrder"
             (change)="onDistrictSelected()"
           >
             <option *ngFor="let district of districts" [ngValue]="getLangValue(district.nameUa, district.nameEn)">

--- a/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.scss
@@ -107,3 +107,7 @@ label {
     width: 100%;
   }
 }
+
+.readonly {
+  pointer-events: none;
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.ts
@@ -21,6 +21,8 @@ export class UbsAdminAddressDetailsComponent implements OnInit, OnDestroy {
   @Input() addressComment: string;
   @Input() addressExportDetailsDto: FormGroup;
   @Input() generalInfo: IGeneralOrderInfo;
+  @Input() isEmployeeCanEditOrder: boolean;
+
   pageOpen: boolean;
   autocompleteService: GoogleAutoService;
   streetPredictionList: GooglePrediction[];
@@ -42,6 +44,9 @@ export class UbsAdminAddressDetailsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.isStatus = this.generalInfo.orderStatus === OrderStatus.CANCELED;
+    if (!this.isEmployeeCanEditOrder) {
+      this.addressHouseNumber.disable();
+    }
   }
 
   get addressRegion() {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee.component.ts
@@ -17,7 +17,7 @@ import { Store } from '@ngrx/store';
 import { TariffsService } from '../../services/tariffs.service';
 import { MatAutocompleteSelectedEvent, MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { MatChipInputEvent } from '@angular/material/chips';
-import { EmployeePositions, Employees, Page } from '../../models/ubs-admin.interface';
+import { EmployeePositions, EmployeePositionsAuthorities, Employees, Page } from '../../models/ubs-admin.interface';
 import {
   selectOptions,
   filterOptions,
@@ -150,7 +150,7 @@ export class UbsAdminEmployeeComponent implements OnInit {
   definitionUserAuthorities(): void {
     this.userEmail = this.jwtService.getEmailFromAccessToken();
     this.getEmployeePositionbyEmail(this.userEmail);
-    this.ubsAdminEmployeeService.getEmployeePositionsAuthorities(this.userEmail).subscribe((employee) => {
+    this.ubsAdminEmployeeService.getEmployeePositionsAuthorities(this.userEmail).subscribe((employee: EmployeePositionsAuthorities) => {
       this.userAuthorities = employee.authorities;
       this.isThisUserCanCreateEmployee = this.userAuthorities.includes(authoritiesChangeEmployee.add);
       this.isThisUserCanEditEmployee = this.userAuthorities.includes(authoritiesChangeEmployee.edit);

--- a/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.html
@@ -60,7 +60,11 @@
       </div>
       <div class="form-group col-md-4">
         <label for="station">{{ 'export-details.station' | translate }}</label>
-        <select formControlName="receivingStationId" class="form-control" id="station" disabled="!isEmployeeCanEditOrder">
+        <select
+          formControlName="receivingStationId"
+          id="station"
+          [ngClass]="isEmployeeCanEditOrder ? 'form-control' : 'form-control readonly'"
+        >
           <option *ngFor="let station of allReceivingStations" [value]="station">
             {{ station }}
           </option>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.html
@@ -31,6 +31,7 @@
           class="form-control"
           id="export-date"
           formControlName="dateExport"
+          [readonly]="!this.isEmployeeCanEditOrder"
         />
       </div>
       <div class="form-group export-time">
@@ -42,6 +43,7 @@
             class="form-control time-from"
             id="export-time-from"
             formControlName="timeDeliveryFrom"
+            [readonly]="!isEmployeeCanEditOrder"
             (click)="showTimePickerClick()"
           />
           <div class="hyphen">-</div>
@@ -51,18 +53,19 @@
             class="form-control time-to"
             id="export-time-to"
             formControlName="timeDeliveryTo"
+            [readonly]="!isEmployeeCanEditOrder"
             (click)="showTimePickerClick()"
           />
         </div>
       </div>
       <div class="form-group col-md-4">
         <label for="station">{{ 'export-details.station' | translate }}</label>
-        <select formControlName="receivingStationId" class="form-control" id="station">
+        <select formControlName="receivingStationId" class="form-control" id="station" disabled="!isEmployeeCanEditOrder">
           <option *ngFor="let station of allReceivingStations" [value]="station">
             {{ station }}
           </option>
         </select>
-        <button class="reset-button" (click)="resetValue()">
+        <button *ngIf="isEmployeeCanEditOrder" class="reset-button" (click)="resetValue()">
           <img [src]="resetFieldImg" alt="reset field" />
         </button>
       </div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.scss
@@ -136,6 +136,10 @@ select {
   @include input;
 }
 
+.readonly {
+  pointer-events: none;
+}
+
 .dropdown_time {
   position: fixed;
   background: rgba(0, 0, 0, 0.3);

--- a/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.spec.ts
@@ -78,6 +78,7 @@ describe('UbsAdminExportDetailsComponent', () => {
   });
 
   it('showTimePickerClick should re-assign values to properties', () => {
+    component.isEmployeeCanEditOrder = true;
     component.showTimePickerClick();
 
     expect(component.showTimePicker).toBe(true);

--- a/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-export-details/ubs-admin-export-details.component.ts
@@ -15,6 +15,7 @@ export class UbsAdminExportDetailsComponent implements OnInit, OnDestroy, AfterV
   @Input() exportInfo: IExportDetails;
   @Input() exportDetailsDto: FormGroup;
   @Input() orderStatus: string;
+  @Input() isEmployeeCanEditOrder: boolean;
 
   private destroy$: Subject<boolean> = new Subject<boolean>();
   pageOpen: boolean;
@@ -83,9 +84,11 @@ export class UbsAdminExportDetailsComponent implements OnInit, OnDestroy, AfterV
   }
 
   showTimePickerClick(): void {
-    this.showTimePicker = true;
-    this.fromInput = this.exportDetailsDto.get('timeDeliveryFrom').value;
-    this.toInput = this.exportDetailsDto.get('timeDeliveryTo').value;
+    if (this.isEmployeeCanEditOrder) {
+      this.showTimePicker = true;
+      this.fromInput = this.exportDetailsDto.get('timeDeliveryFrom').value;
+      this.toInput = this.exportDetailsDto.get('timeDeliveryTo').value;
+    }
   }
 
   checkDate(event: any): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-client-info/ubs-admin-order-client-info.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-client-info/ubs-admin-order-client-info.component.html
@@ -57,7 +57,7 @@
                   class="form-control name-input"
                   type="text"
                   id="recipient-name"
-                  [readonly]="isOrderCanceled"
+                  [readonly]="isOrderCanceled || !this.isEmployeeCanEditOrder"
                   formControlName="recipientName"
                 />
                 <div *ngIf="userInfoDto.controls['recipientName'].invalid && userInfoDto.controls['recipientName'].touched">
@@ -69,7 +69,7 @@
               <div>
                 <input
                   class="form-control name-input"
-                  [readonly]="isOrderCanceled"
+                  [readonly]="isOrderCanceled || !this.isEmployeeCanEditOrder"
                   type="text"
                   id="recipient-surname"
                   formControlName="recipientSurName"
@@ -88,7 +88,7 @@
             </label>
             <input
               class="form-control"
-              [readonly]="isOrderCanceled"
+              [readonly]="isOrderCanceled || !this.isEmployeeCanEditOrder"
               type="tel"
               id="recipient-tel"
               placeholder="{{ 'customer-info.recipient.tel-placeholder' | translate }}"
@@ -108,7 +108,7 @@
             </label>
             <input
               class="form-control"
-              [readonly]="isOrderCanceled"
+              [readonly]="isOrderCanceled || !this.isEmployeeCanEditOrder"
               type="email"
               id="recipient-email"
               placeholder="{{ 'customer-info.recipient.email-placeholder' | translate }}"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-client-info/ubs-admin-order-client-info.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-client-info/ubs-admin-order-client-info.component.ts
@@ -19,6 +19,7 @@ export class UbsAdminOrderClientInfoComponent implements OnInit, OnChanges, OnDe
   @Input() userInfoDto: FormGroup;
   @Input() orderId: number;
   @Input() orderStatus: string;
+  @Input() isEmployeeCanEditOrder: boolean;
 
   phoneMask = Masks.phoneMask;
   isTherePlus = Patterns.isTherePlus;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.html
@@ -38,7 +38,7 @@
                 min="0"
                 max="999"
                 formControlName="confirmedQuantity{{ bag.id }}"
-                [attr.disabled]="isDisabledConfirmQuantity() ? true : null"
+                [attr.disabled]="isDisabledConfirmQuantity() ? true : null || !isEmployeeCanEditOrder"
                 (change)="onQuantityChange('confirmed', bag.id)"
                 disabled
               />
@@ -51,6 +51,7 @@
                 max="999"
                 formControlName="actualQuantity{{ bag.id }}"
                 [attr.disabled]="isOrderCancelled && isOrderPaid ? true : null"
+                [readonly]="!isEmployeeCanEditOrder"
                 (change)="onQuantityChange('actual', bag.id)"
               />
             </div>
@@ -111,6 +112,7 @@
                   min="0"
                   [value]="courierPrice | currency"
                   (change)="changeUbsCourierSum($event)"
+                  [readonly]="!isEmployeeCanEditOrder"
                 />
                 <span>
                   {{ '' | localizedCurrency }}
@@ -129,6 +131,7 @@
                   min="0"
                   [value]="writeoffAtStationSum"
                   [disabled]="isDisabledWriteOffStation"
+                  [readonly]="!isEmployeeCanEditOrder"
                   (change)="changeWriteOffSum($event)"
                 />
                 <span>
@@ -178,11 +181,12 @@
                     [unmask]="false"
                     placeholder="XXXXXXXXXX"
                     formControlName="{{ i }}"
+                    [readonly]="!isEmployeeCanEditOrder"
                   />
                   <span input-close-button (click)="deleteOrder(i)">&times;</span>
                 </div>
               </ng-container>
-              <button *ngIf="checkMaxOrdersFromShop()" class="add-order-num" (click)="addOrderNumberFromShop()">
+              <button *ngIf="checkMaxOrdersFromShop() && isEmployeeCanEditOrder" class="add-order-num" (click)="addOrderNumberFromShop()">
                 {{ 'order-details.additional-orders' | translate }}
               </button>
             </div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.html
@@ -33,7 +33,8 @@
             </div>
             <div class="col-sm-2 d-flex justify-content-center form-group count">
               <input
-                class="shadow-none form-control input p-2"
+                [ngClass]="isEmployeeCanEditOrder ? 'form-control' : 'form-control readonly'"
+                class="shadow-none input p-2"
                 type="number"
                 min="0"
                 max="999"
@@ -51,7 +52,6 @@
                 max="999"
                 formControlName="actualQuantity{{ bag.id }}"
                 [attr.disabled]="isOrderCancelled && isOrderPaid ? true : null"
-                [readonly]="!isEmployeeCanEditOrder"
                 (change)="onQuantityChange('actual', bag.id)"
               />
             </div>
@@ -131,7 +131,6 @@
                   min="0"
                   [value]="writeoffAtStationSum"
                   [disabled]="isDisabledWriteOffStation"
-                  [readonly]="!isEmployeeCanEditOrder"
                   (change)="changeWriteOffSum($event)"
                 />
                 <span>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.scss
@@ -193,3 +193,7 @@
     height: 135px;
   }
 }
+
+.readonly {
+  pointer-events: none;
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.spec.ts
@@ -9,6 +9,7 @@ import { OrderService } from '../../services/order.service';
 import { UbsAdminOrderDetailsFormComponent } from './ubs-admin-order-details-form.component';
 import { FormGroup, FormControl, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { OrderStatus } from 'src/app/ubs/ubs/order-status.enum';
+import { LanguageService } from 'src/app/main/i18n/language.service';
 
 describe('UbsAdminOrderDetailsFormComponent', () => {
   let component: UbsAdminOrderDetailsFormComponent;
@@ -57,6 +58,11 @@ describe('UbsAdminOrderDetailsFormComponent', () => {
     orderFullPrice: new FormControl(9999)
   });
 
+  const languageServiceMock = jasmine.createSpyObj('languageService', ['getLangValue']);
+  languageServiceMock.getLangValue = (valUa: string, valEn: string) => {
+    return valUa;
+  };
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [UbsAdminOrderDetailsFormComponent],
@@ -69,7 +75,13 @@ describe('UbsAdminOrderDetailsFormComponent', () => {
         ReactiveFormsModule,
         TranslateModule.forRoot()
       ],
-      providers: [{ provide: MAT_DIALOG_DATA, useValue: [] }, { provide: MatDialogRef, useValue: [] }, OrderService, FormBuilder]
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: [] },
+        { provide: MatDialogRef, useValue: [] },
+        { provide: LanguageService, useValue: languageServiceMock },
+        OrderService,
+        FormBuilder
+      ]
     }).compileComponents();
   }));
 
@@ -169,8 +181,18 @@ describe('UbsAdminOrderDetailsFormComponent', () => {
     (component as any).calculateFinalSum();
 
     expect(component.bagsInfo.finalSum.planned).toBe(55);
-    expect(component.bagsInfo.finalSum.confirmed).toBe(140);
     expect(component.bagsInfo.finalSum.actual).toBe(225);
+  });
+
+  it('should calculate final sum correctly', () => {
+    const spy = spyOn(component as any, 'checkMinOrderLimit');
+    const spy2 = spyOn(component as any, 'calculateOverpayment');
+    const spy3 = spyOn(component as any, 'setFinalFullPrice');
+
+    (component as any).calculateFinalSum();
+    expect(spy).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+    expect(spy3).toHaveBeenCalled();
   });
 
   it('should toggle the value of pageOpen property', () => {
@@ -224,5 +246,66 @@ describe('UbsAdminOrderDetailsFormComponent', () => {
       component.isOrderCancelled = false;
       expect(component.getOrderBonusValue(null)).toEqual('');
     });
+  });
+
+  it('should isDisabledConfirmQuantity() return true', () => {
+    component.isOrderBroughtByHimself = true;
+    component.isDisabledConfirmQuantity();
+    expect(component.isDisabledConfirmQuantity()).toBeTruthy();
+  });
+
+  it('should isDisabledConfirmQuantity() return true', () => {
+    component.isOrderBroughtByHimself = false;
+    component.isOrderCancelled = false;
+    component.isOrderNotTakenOut = false;
+    component.isOrderDone = false;
+    component.isDisabledConfirmQuantity();
+    expect(component.isDisabledConfirmQuantity()).toBeFalsy();
+  });
+
+  it('should calculateOverpayment metod call if isOrderBroughtByHimself = true', () => {
+    component.isOrderBroughtByHimself = true;
+    component.orderDetails.bonuses = 10;
+    component.orderDetails.paidAmount = 20;
+    component.orderDetails.certificateDiscount = 5;
+    component.writeoffAtStationSum = 7;
+    (component as any).calculateOverpayment();
+    expect(component.overpayment).toBe(28);
+  });
+
+  it('should calculateOverpayment metod call if showUbsCourier = true', () => {
+    component.showUbsCourier = true;
+    component.bagsInfo.sum['confirmed'] = 140;
+    component.orderDetails.certificateDiscount = 12;
+    component.courierPrice = 20;
+    component.orderDetails.bonuses = 250;
+
+    (component as any).calculateOverpayment();
+    expect(component.overpayment).toBe(102);
+  });
+
+  it('should calculateOverpayment metod call if showUbsCourier = false and isOrderBroughtByHimself = false', () => {
+    component.showUbsCourier = false;
+    component.showUbsCourier = false;
+    component.bagsInfo.sum['confirmed'] = 140;
+    component.orderDetails.certificateDiscount = 12;
+    component.orderDetails.bonuses = 250;
+    component.orderDetails.paidAmount = 20;
+    (component as any).calculateOverpayment();
+    expect(component.overpayment).toBe(142);
+  });
+
+  it('should changeWriteOffSum metod call', () => {
+    const eventMock = { target: { value: '150' } };
+    const spy = spyOn(component as any, 'emitSumForStation');
+    const spy2 = spyOn(component as any, 'calculateFinalSum');
+    component.changeWriteOffSum(eventMock);
+    expect(spy).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+  });
+
+  it('should return ua value by getLangValue', () => {
+    const value = component.getLangValue('value', 'enValue');
+    expect(value).toBe('value');
   });
 });

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.spec.ts
@@ -275,7 +275,7 @@ describe('UbsAdminOrderDetailsFormComponent', () => {
 
   it('should calculateOverpayment metod call if showUbsCourier = true', () => {
     component.showUbsCourier = true;
-    component.bagsInfo.sum['confirmed'] = 140;
+    component.bagsInfo.sum.confirmed = 140;
     component.orderDetails.certificateDiscount = 12;
     component.courierPrice = 20;
     component.orderDetails.bonuses = 250;
@@ -287,7 +287,7 @@ describe('UbsAdminOrderDetailsFormComponent', () => {
   it('should calculateOverpayment metod call if showUbsCourier = false and isOrderBroughtByHimself = false', () => {
     component.showUbsCourier = false;
     component.showUbsCourier = false;
-    component.bagsInfo.sum['confirmed'] = 140;
+    component.bagsInfo.sum.confirmed = 140;
     component.orderDetails.certificateDiscount = 12;
     component.orderDetails.bonuses = 250;
     component.orderDetails.paidAmount = 20;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.ts
@@ -54,6 +54,7 @@ export class UbsAdminOrderDetailsFormComponent implements OnInit, OnChanges {
   @Input() orderStatusInfo;
   @Input() totalPaid: number;
   @Input() orderInfo: IOrderInfo;
+  @Input() isEmployeeCanEditOrder: boolean;
 
   constructor(private fb: FormBuilder, private orderService: OrderService, private langService: LanguageService) {}
 

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.html
@@ -13,7 +13,7 @@
         <span class="price">{{ totalPaid | currency | localizedCurrency }}</span>
       </div>
       <div>
-        <button class="btn button-payment-operations btn-add-payment" (click)="openPopup(false)">
+        <button *ngIf="isEmployeeCanEditOrder" class="btn button-payment-operations btn-add-payment" (click)="openPopup(false)">
           <span class="plus">+</span>{{ 'order-payment.add-payment-btn' | translate }}
         </button>
       </div>
@@ -57,7 +57,12 @@
         <button class="btn button-payment-operations btn-enroll-to-bonus-account" (click)="enrollToBonusAccount(this.overpayment)">
           {{ 'order-payment.enroll-on-bonus-account' | translate }}
         </button>
-        <button [disabled]="isMoneyReturning" class="btn button-payment-operations btn-return-money" (click)="returnMoney(orderId)">
+        <button
+          *ngIf="isEmployeeCanEditOrder"
+          [disabled]="isMoneyReturning"
+          class="btn button-payment-operations btn-return-money"
+          (click)="returnMoney(orderId)"
+        >
           {{ 'order-payment.return-money' | translate }}
         </button>
       </div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.ts
@@ -21,6 +21,7 @@ export class UbsAdminOrderPaymentComponent implements OnInit, OnChanges, OnDestr
   @Input() actualPrice: number;
   @Input() totalPaid: number;
   @Input() orderStatus: string;
+  @Input() isEmployeeCanEditOrder: boolean;
 
   @Output() newPaymentStatus = new EventEmitter<string>();
   @Output() paymentUpdate = new EventEmitter<number>();

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
@@ -19,9 +19,8 @@
                 <select
                   id="order"
                   *ngIf="isOrderStatusSelected"
-                  class="form-control"
+                  [ngClass]="isEmployeeCanEditOrder ? 'form-control' : 'form-control readonly'"
                   formControlName="orderStatus"
-                  disabled="!isEmployeeCanEditOrder"
                   (change)="onChangedOrderStatus($event.target.value)"
                 >
                   <option
@@ -65,10 +64,10 @@
         <div class="form-group">
           <label for="comment" class="form__label">{{ 'order-edit.comment.label' | translate }}</label>
           <textarea
-            class="form-control mw-100"
+            [ngClass]="isEmployeeCanEditOrder ? 'form-control' : 'form-control readonly'"
+            class="mw-100"
             id="comment"
             formControlName="adminComment"
-            disabled="!isEmployeeCanEditOrder"
             placeholder="{{ 'order-edit.comment.placeholder' | translate }}"
           ></textarea>
           <div class="validation" *ngIf="adminComment.invalid && adminComment.touched">

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
@@ -21,6 +21,7 @@
                   *ngIf="isOrderStatusSelected"
                   class="form-control"
                   formControlName="orderStatus"
+                  disabled="!isEmployeeCanEditOrder"
                   (change)="onChangedOrderStatus($event.target.value)"
                 >
                   <option
@@ -67,6 +68,7 @@
             class="form-control mw-100"
             id="comment"
             formControlName="adminComment"
+            disabled="!isEmployeeCanEditOrder"
             placeholder="{{ 'order-edit.comment.placeholder' | translate }}"
           ></textarea>
           <div class="validation" *ngIf="adminComment.invalid && adminComment.touched">

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.scss
@@ -56,3 +56,7 @@ p {
     height: 125px;
   }
 }
+
+.readonly {
+  pointer-events: none;
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
@@ -23,6 +23,7 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
   @Input() generalInfo: IGeneralOrderInfo;
   @Input() currentLanguage: string;
   @Input() additionalPayment: string;
+  @Input() isEmployeeCanEditOrder: boolean;
   @Output() changedOrderStatus = new EventEmitter<string>();
   @Output() cancelReason = new EventEmitter<string>();
 

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
@@ -18,6 +18,7 @@
           [unPaidAmount]="unPaidAmount"
           [currentLanguage]="currentLanguage"
           [additionalPayment]="additionalPayment"
+          [isEmployeeCanEditOrder]="isEmployeeCanEditOrder"
           (changedOrderStatus)="onChangedOrderStatus($event)"
           (cancelReason)="onCancelReason($event)"
         >
@@ -27,12 +28,14 @@
           [userInfo]="userInfo"
           [orderId]="orderId"
           [orderStatus]="currentOrderStatus"
+          [isEmployeeCanEditOrder]="isEmployeeCanEditOrder"
         >
         </app-ubs-admin-order-client-info>
         <app-ubs-admin-address-details
           [addressExportDetailsDto]="getFormGroup('addressExportDetailsDto')"
           [addressComment]="orderInfo.addressComment"
           [generalInfo]="generalInfo"
+          [isEmployeeCanEditOrder]="isEmployeeCanEditOrder"
         >
         </app-ubs-admin-address-details>
         <app-ubs-admin-order-details-form
@@ -41,6 +44,7 @@
           [orderStatusInfo]="orderStatusInfo"
           [orderInfo]="orderInfo"
           [totalPaid]="totalPaid"
+          [isEmployeeCanEditOrder]="isEmployeeCanEditOrder"
           (deleteNumberOrderFromEcoShopChanged)="deleteNumberOrderFromEcoShopChange($event)"
           (changeOverpayment)="changeOverpayment($event)"
           (checkMinOrder)="setMinOrder($event)"
@@ -54,6 +58,7 @@
           [totalPaid]="totalPaid"
           [orderInfo]="orderInfo"
           [orderStatus]="currentOrderStatus"
+          [isEmployeeCanEditOrder]="isEmployeeCanEditOrder"
           (newPaymentStatus)="onUpdatePaymentStatus($event)"
           (paymentUpdate)="onPaymentUpdate($event)"
         ></app-ubs-admin-order-payment>
@@ -61,12 +66,14 @@
           [exportDetailsDto]="getFormGroup('exportDetailsDto')"
           [exportInfo]="exportInfo"
           [orderStatus]="currentOrderStatus"
+          [isEmployeeCanEditOrder]="isEmployeeCanEditOrder"
         >
         </app-ubs-admin-export-details>
         <app-ubs-admin-responsible-persons
           [responsiblePersonsForm]="getFormGroup('responsiblePersonsForm')"
           [responsiblePersonInfo]="responsiblePersonInfo"
           [orderStatus]="currentOrderStatus"
+          [isEmployeeCanEditOrder]="isEmployeeCanEditOrder"
         >
         </app-ubs-admin-responsible-persons>
         <app-ubs-admin-order-history [orderInfo]="orderInfo" (cancelReason)="onCancelReason($event)"></app-ubs-admin-order-history>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -140,13 +140,12 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
     let isThisPositionCanEdit = false;
     let isThisRoleCanEdit = false;
     if (this.employeePositions) {
-      isThisPositionCanEdit =
-        this.employeePositions.filter((positionsItem: string) => positionsForEditOrder.includes(positionsItem)).length > 0;
+      isThisPositionCanEdit = !!this.employeePositions.filter((positionsItem: string) => positionsForEditOrder.includes(positionsItem))
+        .length;
     }
 
     if (this.employeeAuthorities) {
-      isThisRoleCanEdit =
-        this.employeeAuthorities.filter((authoritiesItem) => authoritiesItem === abilityEditAuthorities.orders).length > 0;
+      isThisRoleCanEdit = !!this.employeeAuthorities.filter((authoritiesItem) => authoritiesItem === abilityEditAuthorities.orders).length;
     }
 
     if (isThisPositionCanEdit || isThisRoleCanEdit) {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -24,7 +24,9 @@ import {
   IResponsiblePersons,
   IUpdateResponsibleEmployee,
   IUserInfo,
-  ResponsibleEmployee
+  ResponsibleEmployee,
+  abilityEditAuthorities,
+  employeePositionsName
 } from '../../models/ubs-admin.interface';
 import { IAppState } from 'src/app/store/state/app.state';
 import { ChangingOrderData } from 'src/app/store/actions/bigOrderTable.actions';
@@ -33,6 +35,7 @@ import { Patterns } from 'src/assets/patterns/patterns';
 import { GoogleScript } from 'src/assets/google-script/google-script';
 import { PhoneNumberValidator } from 'src/app/shared/phone-validator/phone.validator';
 import { OrderStatus } from 'src/app/ubs/ubs/order-status.enum';
+import { UbsAdminEmployeeService } from '../../services/ubs-admin-employee.service';
 
 @Component({
   selector: 'app-ubs-admin-order',
@@ -74,6 +77,9 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
   private orderService: OrderService;
   private statuses = [OrderStatus.BROUGHT_IT_HIMSELF, OrderStatus.CANCELED, OrderStatus.FORMED];
   public arrowIcon = 'assets/img/icon/arrows/arrow-left.svg';
+  private employeeAuthorities: string[];
+  private employeePositions: string[];
+  public isEmployeeCanEditOrder = false;
   constructor(
     private translate: TranslateService,
     private localStorageService: LocalStorageService,
@@ -84,7 +90,8 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
     private changeDetector: ChangeDetectorRef,
     private injector: Injector,
     private store: Store<IAppState>,
-    private googleScript: GoogleScript
+    private googleScript: GoogleScript,
+    public ubsAdminEmployeeService: UbsAdminEmployeeService
   ) {
     this.matSnackBar = injector.get<MatSnackBarComponent>(MatSnackBarComponent);
     this.orderService = injector.get<OrderService>(OrderService);
@@ -106,6 +113,45 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       this.orderId = +params.id;
     });
     this.getOrderInfo(this.orderId, false);
+    this.ubsAdminEmployeeService.employeePositions$.pipe(takeUntil(this.destroy$)).subscribe((employeePositions) => {
+      if (employeePositions.length) {
+        this.authoritiesSubscription(employeePositions);
+      }
+    });
+  }
+
+  private authoritiesSubscription(positions) {
+    this.ubsAdminEmployeeService.employeePositionsAuthorities$.pipe(takeUntil(this.destroy$)).subscribe((rights) => {
+      if (rights.authorities.length) {
+        this.definedIsEmployeeCanEditOrder(positions, rights.authorities);
+      }
+    });
+  }
+
+  private definedIsEmployeeCanEditOrder(positions: string[], authorities: string[]) {
+    this.employeeAuthorities = authorities;
+    this.employeePositions = positions;
+    const positionsForEditOrder: string[] = [
+      employeePositionsName.SuperAdmin,
+      employeePositionsName.Admin,
+      employeePositionsName.CallManager,
+      employeePositionsName.ServiceManager
+    ];
+    let isThisPositionCanEdit = false;
+    let isThisRoleCanEdit = false;
+    if (this.employeePositions) {
+      isThisPositionCanEdit =
+        this.employeePositions.filter((positionsItem: string) => positionsForEditOrder.includes(positionsItem)).length > 0;
+    }
+
+    if (this.employeeAuthorities) {
+      isThisRoleCanEdit =
+        this.employeeAuthorities.filter((authoritiesItem) => authoritiesItem === abilityEditAuthorities.orders).length > 0;
+    }
+
+    if (isThisPositionCanEdit || isThisRoleCanEdit) {
+      this.isEmployeeCanEditOrder = true;
+    }
   }
 
   public onCancelOrder(): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-responsible-persons/ubs-admin-responsible-persons.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-responsible-persons/ubs-admin-responsible-persons.component.html
@@ -24,7 +24,7 @@
     <div class="form-row">
       <div class="form-group col-md-4">
         <label class="form__label">{{ 'responsible-persons.call-manager' | translate }}</label>
-        <select formControlName="responsibleCaller" class="form-control form__select">
+        <select formControlName="responsibleCaller" class="form-control form__select" disabled="!isEmployeeCanEditOrder">
           <option *ngFor="let employee of allCallManagers" [value]="employee">
             {{ employee }}
           </option>
@@ -34,7 +34,7 @@
     <div class="form-row">
       <div class="form-group col-md-4">
         <label class="form__label">{{ 'responsible-persons.logistician' | translate }}</label>
-        <select formControlName="responsibleLogicMan" class="form-control form__select">
+        <select formControlName="responsibleLogicMan" class="form-control form__select" disabled="!isEmployeeCanEditOrder">
           <option *ngFor="let employee of allLogisticians" [value]="employee">
             {{ employee }}
           </option>
@@ -44,7 +44,7 @@
     <div class="form-row">
       <div class="form-group col-md-4">
         <label class="form__label">{{ 'responsible-persons.navigator' | translate }}</label>
-        <select formControlName="responsibleNavigator" class="form-control form__select">
+        <select formControlName="responsibleNavigator" class="form-control form__select" disabled="!isEmployeeCanEditOrder">
           <option *ngFor="let employee of allNavigators" [value]="employee">
             {{ employee }}
           </option>
@@ -54,7 +54,7 @@
     <div class="form-row">
       <div class="form-group col-md-4">
         <label class="form__label">{{ 'responsible-persons.driver' | translate }}</label>
-        <select formControlName="responsibleDriver" class="form-control form__select">
+        <select formControlName="responsibleDriver" class="form-control form__select" disabled="!isEmployeeCanEditOrder">
           <option *ngFor="let employee of allDrivers" [value]="employee">
             {{ employee }}
           </option>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-responsible-persons/ubs-admin-responsible-persons.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-responsible-persons/ubs-admin-responsible-persons.component.html
@@ -24,7 +24,11 @@
     <div class="form-row">
       <div class="form-group col-md-4">
         <label class="form__label">{{ 'responsible-persons.call-manager' | translate }}</label>
-        <select formControlName="responsibleCaller" class="form-control form__select" disabled="!isEmployeeCanEditOrder">
+        <select
+          formControlName="responsibleCaller"
+          class="form-control form__select"
+          [ngClass]="isEmployeeCanEditOrder ? 'form-control form__select' : 'form-control form__select readonly'"
+        >
           <option *ngFor="let employee of allCallManagers" [value]="employee">
             {{ employee }}
           </option>
@@ -34,7 +38,10 @@
     <div class="form-row">
       <div class="form-group col-md-4">
         <label class="form__label">{{ 'responsible-persons.logistician' | translate }}</label>
-        <select formControlName="responsibleLogicMan" class="form-control form__select" disabled="!isEmployeeCanEditOrder">
+        <select
+          formControlName="responsibleLogicMan"
+          [ngClass]="isEmployeeCanEditOrder ? 'form-control form__select' : 'form-control form__select readonly'"
+        >
           <option *ngFor="let employee of allLogisticians" [value]="employee">
             {{ employee }}
           </option>
@@ -44,7 +51,10 @@
     <div class="form-row">
       <div class="form-group col-md-4">
         <label class="form__label">{{ 'responsible-persons.navigator' | translate }}</label>
-        <select formControlName="responsibleNavigator" class="form-control form__select" disabled="!isEmployeeCanEditOrder">
+        <select
+          formControlName="responsibleNavigator"
+          [ngClass]="isEmployeeCanEditOrder ? 'form-control form__select' : 'form-control form__select readonly'"
+        >
           <option *ngFor="let employee of allNavigators" [value]="employee">
             {{ employee }}
           </option>
@@ -54,7 +64,10 @@
     <div class="form-row">
       <div class="form-group col-md-4">
         <label class="form__label">{{ 'responsible-persons.driver' | translate }}</label>
-        <select formControlName="responsibleDriver" class="form-control form__select" disabled="!isEmployeeCanEditOrder">
+        <select
+          formControlName="responsibleDriver"
+          [ngClass]="isEmployeeCanEditOrder ? 'form-control form__select' : 'form-control form__select readonly'"
+        >
           <option *ngFor="let employee of allDrivers" [value]="employee">
             {{ employee }}
           </option>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-responsible-persons/ubs-admin-responsible-persons.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-responsible-persons/ubs-admin-responsible-persons.component.scss
@@ -72,3 +72,7 @@
     width: 340px;
   }
 }
+
+.readonly {
+  pointer-events: none;
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-responsible-persons/ubs-admin-responsible-persons.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-responsible-persons/ubs-admin-responsible-persons.component.ts
@@ -13,6 +13,7 @@ export class UbsAdminResponsiblePersonsComponent implements OnInit, OnDestroy, O
   @Input() responsiblePersonInfo: IResponsiblePersons;
   @Input() responsiblePersonsForm: FormGroup;
   @Input() orderStatus: string;
+  @Input() isEmployeeCanEditOrder: boolean;
 
   public allCallManagers: string[];
   public allLogisticians: string[];

--- a/src/app/ubs/ubs-admin/components/ubs-admin-sidebar/ubs-admin-sidebar.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-sidebar/ubs-admin-sidebar.component.spec.ts
@@ -1,0 +1,202 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { UbsAdminSidebarComponent } from './ubs-admin-sidebar.component';
+import { UbsAdminEmployeeService } from '../../services/ubs-admin-employee.service';
+import { BehaviorSubject } from 'rxjs';
+import { employeePositionsName, SideMenuElementsNames } from '../../models/ubs-admin.interface';
+import { listElementsAdmin } from 'src/app/ubs/ubs/models/ubs-sidebar-links';
+
+describe('UbsAdminSidebarComponent', () => {
+  let component: UbsAdminSidebarComponent;
+  let fixture: ComponentFixture<UbsAdminSidebarComponent>;
+
+  const employeePositionsMock = [
+    employeePositionsName.CallManager,
+    employeePositionsName.ServiceManager,
+    employeePositionsName.Logistician
+  ];
+
+  const employeePositionsAuthorities = {
+    authorities: ['SEE_BIG_ORDER_TABLE', 'SEE_CLIENTS_PAGE', 'SEE_CERTIFICATES', 'SEE_EMPLOYEES_PAGE', 'SEE_TARIFFS'],
+    positionId: [3, 4, 5]
+  };
+
+  const viewersArrMock = [
+    employeePositionsName.SuperAdmin,
+    employeePositionsName.Admin,
+    employeePositionsName.CallManager,
+    employeePositionsName.ServiceManager,
+    employeePositionsName.Logistician,
+    employeePositionsName.Navigator
+  ];
+
+  const listElementsAdminMock: object[] = [
+    {
+      link: 'assets/img/sidebarIcons/shopping-cart_icon.svg',
+      name: 'ubs-sidebar.orders',
+      routerLink: 'orders'
+    },
+    {
+      link: './assets/img/sidebarIcons/achievement_icon.svg',
+      name: 'ubs-sidebar.certificates',
+      routerLink: 'certificates'
+    },
+    {
+      link: 'assets/img/sidebarIcons/workers_icon.svg',
+      name: 'ubs-sidebar.employees',
+      routerLink: 'employee/1'
+    },
+    {
+      link: 'assets/img/sidebarIcons/statistic_icon.svg',
+      name: 'ubs-sidebar.tariffs',
+      routerLink: 'tariffs'
+    },
+    {
+      link: 'assets/img/sidebarIcons/none_notification_Bell.svg',
+      name: 'ubs-sidebar.notifications',
+      routerLink: 'notifications'
+    }
+  ];
+
+  const ubsAdminEmployeeServiceMock = jasmine.createSpyObj('ubsAdminEmployeeServiceMock', [
+    'employeePositions$',
+    'employeePositionsAuthorities$'
+  ]);
+  ubsAdminEmployeeServiceMock.employeePositions$ = new BehaviorSubject(employeePositionsMock);
+  ubsAdminEmployeeServiceMock.employeePositionsAuthorities$ = new BehaviorSubject(employeePositionsAuthorities);
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [UbsAdminSidebarComponent],
+      imports: [TranslateModule.forRoot(), HttpClientTestingModule],
+      providers: [{ provide: UbsAdminEmployeeService, useValue: ubsAdminEmployeeServiceMock }]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UbsAdminSidebarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('authoritiesSubscription expect will be invoke at onInit', () => {
+    const spy = spyOn(component as any, 'authoritiesSubscription');
+    component.ngOnInit();
+    ubsAdminEmployeeServiceMock.employeePositions$.subscribe((positions) => {
+      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(positions);
+    });
+  });
+
+  it('changeListElementsDependOnPermissions expect will be invoke at authoritiesSubscription', () => {
+    const spy = spyOn(component as any, 'changeListElementsDependOnPermissions');
+    (component as any).authoritiesSubscription(employeePositionsMock);
+    ubsAdminEmployeeServiceMock.employeePositionsAuthorities$.subscribe((rights) => {
+      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(employeePositionsMock, employeePositionsAuthorities.authorities);
+    });
+  });
+
+  it('listElenenChangetUtil should called in changeListElementsDependOnPermissions()', () => {
+    const spy = spyOn(component as any, 'listElenenChangetUtil');
+    spyOnProperty(component as any, 'customerViewer', 'get').and.returnValue(false);
+    (component as any).changeListElementsDependOnPermissions(employeePositionsMock, employeePositionsAuthorities.authorities);
+    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(SideMenuElementsNames.customers);
+  });
+
+  it('listElenenChangetUtil should called in changeListElementsDependOnPermissions()', () => {
+    const spy = spyOn(component as any, 'listElenenChangetUtil');
+    spyOnProperty(component as any, 'certificatesViewer', 'get').and.returnValue(false);
+    (component as any).changeListElementsDependOnPermissions(employeePositionsMock, employeePositionsAuthorities.authorities);
+    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(SideMenuElementsNames.certificates);
+  });
+
+  it('notificationsViewer method should call', () => {
+    const spy = spyOnProperty(component, 'notificationsViewer').and.callThrough();
+    const spy2 = spyOn(component as any, 'positionFilterUtil');
+    const spy3 = spyOn(component as any, 'authoritiesFilterUtil');
+    (component as any).changeListElementsDependOnPermissions(employeePositionsMock, employeePositionsAuthorities.authorities);
+    expect(spy).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+    expect(spy3).toHaveBeenCalled();
+  });
+
+  it('certificatesViewer method should call', () => {
+    const spy = spyOnProperty(component, 'certificatesViewer').and.callThrough();
+    const spy2 = spyOn(component as any, 'positionFilterUtil');
+    const spy3 = spyOn(component as any, 'authoritiesFilterUtil');
+    (component as any).changeListElementsDependOnPermissions(employeePositionsMock, employeePositionsAuthorities.authorities);
+    expect(spy).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+    expect(spy3).toHaveBeenCalled();
+  });
+
+  it('tariffsViewer method should call', () => {
+    const spy = spyOnProperty(component, 'tariffsViewer').and.callThrough();
+    const spy2 = spyOn(component as any, 'positionFilterUtil');
+    const spy3 = spyOn(component as any, 'authoritiesFilterUtil');
+    (component as any).changeListElementsDependOnPermissions(employeePositionsMock, employeePositionsAuthorities.authorities);
+    expect(spy).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalledWith(viewersArrMock);
+    expect(spy3).toHaveBeenCalled();
+  });
+
+  it('employeesViewer method should call', () => {
+    const spy = spyOnProperty(component, 'employeesViewer').and.callThrough();
+    const spy2 = spyOn(component as any, 'positionFilterUtil');
+    const spy3 = spyOn(component as any, 'authoritiesFilterUtil');
+    (component as any).changeListElementsDependOnPermissions(employeePositionsMock, employeePositionsAuthorities.authorities);
+    expect(spy).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+    expect(spy3).toHaveBeenCalled();
+  });
+
+  it('customerViewer method should call', () => {
+    const spy = spyOnProperty(component, 'customerViewer').and.callThrough();
+    const spy2 = spyOn(component as any, 'positionFilterUtil');
+    const spy3 = spyOn(component as any, 'authoritiesFilterUtil');
+    (component as any).changeListElementsDependOnPermissions(employeePositionsMock, employeePositionsAuthorities.authorities);
+    expect(spy).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalledWith(viewersArrMock);
+    expect(spy3).toHaveBeenCalled();
+  });
+
+  it('ordersViewer method should call', () => {
+    const spy = spyOnProperty(component, 'ordersViewer').and.callThrough();
+    const spy2 = spyOn(component as any, 'positionFilterUtil');
+    const spy3 = spyOn(component as any, 'authoritiesFilterUtil');
+    (component as any).changeListElementsDependOnPermissions(employeePositionsMock, employeePositionsAuthorities.authorities);
+    expect(spy).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalledWith(viewersArrMock);
+    expect(spy3).toHaveBeenCalled();
+  });
+
+  it('positionFilterUtil method should call', () => {
+    component.employeePositions = employeePositionsMock;
+    const spy = spyOn(component as any, 'positionFilterUtil').and.callThrough();
+    expect(spy).toBeTruthy();
+  });
+
+  it('authoritiesFilterUtil method should call', () => {
+    component.employeeAuthorities = employeePositionsAuthorities.authorities;
+    const spy = spyOn(component as any, 'authoritiesFilterUtil').and.callThrough();
+    expect(spy).toBeTruthy();
+  });
+
+  it('listElenenChangetUtil method should call', () => {
+    component.listElementsAdmin = listElementsAdmin;
+    (component as any).listElenenChangetUtil(SideMenuElementsNames.customers);
+    expect(component.listElementsAdmin).toEqual(listElementsAdminMock);
+  });
+});

--- a/src/app/ubs/ubs-admin/components/ubs-admin-sidebar/ubs-admin-sidebar.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-sidebar/ubs-admin-sidebar.component.ts
@@ -26,22 +26,16 @@ export class UbsAdminSidebarComponent extends UbsBaseSidebarComponent implements
   public positionName: Array<string>;
   public destroySub: Subject<boolean> = new Subject<boolean>();
 
-  private viewersArr = [
+  private notificationsViewerArr = [
     employeePositionsName.SuperAdmin,
     employeePositionsName.Admin,
     employeePositionsName.CallManager,
-    employeePositionsName.ServiceManager,
-    employeePositionsName.Logistician,
-    employeePositionsName.Navigator
+    employeePositionsName.ServiceManager
   ];
 
-  private employeesCertViewerArr = [
-    employeePositionsName.SuperAdmin,
-    employeePositionsName.Admin,
-    employeePositionsName.CallManager,
-    employeePositionsName.ServiceManager,
-    employeePositionsName.Logistician
-  ];
+  private employeesCertViewerArr = [...this.notificationsViewerArr, employeePositionsName.Logistician];
+
+  private viewersArr = [...this.employeesCertViewerArr, employeePositionsName.Navigator];
 
   constructor(
     public ubsAdminEmployeeService: UbsAdminEmployeeService,
@@ -60,7 +54,7 @@ export class UbsAdminSidebarComponent extends UbsBaseSidebarComponent implements
     });
   }
 
-  private authoritiesSubscription(positions) {
+  private authoritiesSubscription(positions: Array<string>) {
     this.ubsAdminEmployeeService.employeePositionsAuthorities$.pipe(takeUntil(this.destroySub)).subscribe((rights) => {
       if (rights.authorities.length) {
         this.changeListElementsDependOnPermissions(positions, rights.authorities);
@@ -71,14 +65,14 @@ export class UbsAdminSidebarComponent extends UbsBaseSidebarComponent implements
   private positionFilterUtil(posArr: Array<string>): boolean {
     if (this.employeePositions) {
       const result = this.employeePositions.filter((positionsItem) => posArr.includes(positionsItem));
-      return result.length > 0;
+      return !!result.length;
     }
   }
 
   private authoritiesFilterUtil(authority: string): boolean {
     if (this.employeeAuthorities) {
       const result = this.employeeAuthorities.filter((authoritiesItem) => authoritiesItem === authority);
-      return result.length > 0;
+      return !!result.length;
     }
   }
 
@@ -100,13 +94,7 @@ export class UbsAdminSidebarComponent extends UbsBaseSidebarComponent implements
   }
 
   get notificationsViewer() {
-    const notificationsViewerArr = [
-      employeePositionsName.SuperAdmin,
-      employeePositionsName.Admin,
-      employeePositionsName.CallManager,
-      employeePositionsName.ServiceManager
-    ];
-    return this.positionFilterUtil(notificationsViewerArr) || this.authoritiesFilterUtil(EnablingAuthorities.notifications);
+    return this.positionFilterUtil(this.notificationsViewerArr) || this.authoritiesFilterUtil(EnablingAuthorities.notifications);
   }
 
   get tariffsViewer() {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-sidebar/ubs-admin-sidebar.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-sidebar/ubs-admin-sidebar.component.ts
@@ -1,19 +1,153 @@
-import { AfterViewInit, Component } from '@angular/core';
+import { AfterViewInit, Component, OnInit } from '@angular/core';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { UserMessagesService } from '../../../../ubs/ubs-user/services/user-messages.service';
 import { UbsBaseSidebarComponent } from 'src/app/shared/ubs-base-sidebar/ubs-base-sidebar.component';
 import { JwtService } from '@global-service/jwt/jwt.service';
 import { listElementsAdmin } from '../../../ubs/models/ubs-sidebar-links';
+import { UbsAdminEmployeeService } from 'src/app/ubs/ubs-admin/services/ubs-admin-employee.service';
+import {
+  employeePositionsName,
+  AdminSideBarMenu,
+  EnablingAuthorities,
+  SideMenuElementsNames
+} from 'src/app/ubs/ubs-admin/models/ubs-admin.interface';
+import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
 
 // @ts-ignore
 @Component({
   selector: 'app-ubs-admin-sidebar',
   templateUrl: './ubs-admin-sidebar.component.html'
 })
-export class UbsAdminSidebarComponent extends UbsBaseSidebarComponent implements AfterViewInit {
+export class UbsAdminSidebarComponent extends UbsBaseSidebarComponent implements AfterViewInit, OnInit {
   public listElementsAdmin = listElementsAdmin;
+  public employeeAuthorities: string[];
+  public employeePositions: string[];
+  public positionName: Array<string>;
+  public destroySub: Subject<boolean> = new Subject<boolean>();
 
-  constructor(public service: UserMessagesService, public breakpointObserver: BreakpointObserver, public jwtService: JwtService) {
+  constructor(
+    public ubsAdminEmployeeService: UbsAdminEmployeeService,
+    public service: UserMessagesService,
+    public breakpointObserver: BreakpointObserver,
+    public jwtService: JwtService
+  ) {
     super(service, breakpointObserver, jwtService);
+  }
+
+  ngOnInit() {
+    this.ubsAdminEmployeeService.employeePositions$.pipe(takeUntil(this.destroySub)).subscribe((employeePositions) => {
+      if (employeePositions.length) {
+        this.authoritiesSubscription(employeePositions);
+      }
+    });
+  }
+
+  private authoritiesSubscription(positions) {
+    this.ubsAdminEmployeeService.employeePositionsAuthorities$.pipe(takeUntil(this.destroySub)).subscribe((rights) => {
+      if (rights.authorities.length) {
+        this.changeListElementsDependOnPermissions(positions, rights.authorities);
+      }
+    });
+  }
+
+  private positionFilterUtil(posArr: Array<string>): boolean {
+    if (this.employeePositions) {
+      const result = this.employeePositions.filter((positionsItem) => posArr.includes(positionsItem));
+      return result.length > 0;
+    }
+  }
+
+  private authoritiesFilterUtil(authority: string): boolean {
+    if (this.employeeAuthorities) {
+      const result = this.employeeAuthorities.filter((authoritiesItem) => authoritiesItem === authority);
+      return result.length > 0;
+    }
+  }
+
+  private listElenenChangetUtil(elementName: string) {
+    this.listElementsAdmin = this.listElementsAdmin.filter((listItem: AdminSideBarMenu) => listItem.name !== elementName);
+    return this.listElementsAdmin;
+  }
+
+  get customerViewer() {
+    const viewersArr = [
+      employeePositionsName.SuperAdmin,
+      employeePositionsName.Admin,
+      employeePositionsName.CallManager,
+      employeePositionsName.ServiceManager,
+      employeePositionsName.Logistician,
+      employeePositionsName.Navigator
+    ];
+
+    return this.positionFilterUtil(viewersArr) || this.authoritiesFilterUtil(EnablingAuthorities.customers);
+  }
+
+  get employeesViewer() {
+    const employeesArr = [
+      employeePositionsName.SuperAdmin,
+      employeePositionsName.Admin,
+      employeePositionsName.CallManager,
+      employeePositionsName.ServiceManager,
+      employeePositionsName.Logistician
+    ];
+    return this.positionFilterUtil(employeesArr) || this.authoritiesFilterUtil(EnablingAuthorities.employees);
+  }
+
+  get certificatesViewer() {
+    const certificatesArr = [
+      employeePositionsName.SuperAdmin,
+      employeePositionsName.Admin,
+      employeePositionsName.CallManager,
+      employeePositionsName.ServiceManager,
+      employeePositionsName.Logistician
+    ];
+    return this.positionFilterUtil(certificatesArr) || this.authoritiesFilterUtil(EnablingAuthorities.certificates);
+  }
+
+  get notificationsViewer() {
+    const notificationsArr = [
+      employeePositionsName.SuperAdmin,
+      employeePositionsName.Admin,
+      employeePositionsName.CallManager,
+      employeePositionsName.ServiceManager
+    ];
+    return this.positionFilterUtil(notificationsArr) || this.authoritiesFilterUtil(EnablingAuthorities.notifications);
+  }
+
+  get tariffsViewer() {
+    const viewersArr = [
+      employeePositionsName.SuperAdmin,
+      employeePositionsName.Admin,
+      employeePositionsName.CallManager,
+      employeePositionsName.ServiceManager,
+      employeePositionsName.Logistician,
+      employeePositionsName.Navigator
+    ];
+    return this.positionFilterUtil(viewersArr) || this.authoritiesFilterUtil(EnablingAuthorities.tariffs);
+  }
+
+  private changeListElementsDependOnPermissions(positions: string[], authorities: string[]) {
+    this.employeeAuthorities = authorities;
+    this.employeePositions = positions;
+    if (!this.customerViewer) {
+      this.listElenenChangetUtil(SideMenuElementsNames.customers);
+    }
+
+    if (!this.employeesViewer) {
+      this.listElenenChangetUtil(SideMenuElementsNames.employees);
+    }
+
+    if (!this.certificatesViewer) {
+      this.listElenenChangetUtil(SideMenuElementsNames.certificates);
+    }
+
+    if (!this.notificationsViewer) {
+      this.listElenenChangetUtil(SideMenuElementsNames.notifications);
+    }
+
+    if (!this.tariffsViewer) {
+      this.listElenenChangetUtil(SideMenuElementsNames.tariffs);
+    }
   }
 }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-sidebar/ubs-admin-sidebar.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-sidebar/ubs-admin-sidebar.component.ts
@@ -114,7 +114,7 @@ export class UbsAdminSidebarComponent extends UbsBaseSidebarComponent implements
   }
 
   get ordersViewer() {
-    return this.positionFilterUtil(this.viewersArr) || this.authoritiesFilterUtil(EnablingAuthorities.tariffs);
+    return this.positionFilterUtil(this.viewersArr) || this.authoritiesFilterUtil(EnablingAuthorities.orders);
   }
 
   private changeListElementsDependOnPermissions(positions: string[], authorities: string[]) {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-sidebar/ubs-admin-sidebar.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-sidebar/ubs-admin-sidebar.component.ts
@@ -26,6 +26,23 @@ export class UbsAdminSidebarComponent extends UbsBaseSidebarComponent implements
   public positionName: Array<string>;
   public destroySub: Subject<boolean> = new Subject<boolean>();
 
+  private viewersArr = [
+    employeePositionsName.SuperAdmin,
+    employeePositionsName.Admin,
+    employeePositionsName.CallManager,
+    employeePositionsName.ServiceManager,
+    employeePositionsName.Logistician,
+    employeePositionsName.Navigator
+  ];
+
+  private employeesCertViewerArr = [
+    employeePositionsName.SuperAdmin,
+    employeePositionsName.Admin,
+    employeePositionsName.CallManager,
+    employeePositionsName.ServiceManager,
+    employeePositionsName.Logistician
+  ];
+
   constructor(
     public ubsAdminEmployeeService: UbsAdminEmployeeService,
     public service: UserMessagesService,
@@ -71,60 +88,33 @@ export class UbsAdminSidebarComponent extends UbsBaseSidebarComponent implements
   }
 
   get customerViewer() {
-    const viewersArr = [
-      employeePositionsName.SuperAdmin,
-      employeePositionsName.Admin,
-      employeePositionsName.CallManager,
-      employeePositionsName.ServiceManager,
-      employeePositionsName.Logistician,
-      employeePositionsName.Navigator
-    ];
-
-    return this.positionFilterUtil(viewersArr) || this.authoritiesFilterUtil(EnablingAuthorities.customers);
+    return this.positionFilterUtil(this.viewersArr) || this.authoritiesFilterUtil(EnablingAuthorities.customers);
   }
 
   get employeesViewer() {
-    const employeesArr = [
-      employeePositionsName.SuperAdmin,
-      employeePositionsName.Admin,
-      employeePositionsName.CallManager,
-      employeePositionsName.ServiceManager,
-      employeePositionsName.Logistician
-    ];
-    return this.positionFilterUtil(employeesArr) || this.authoritiesFilterUtil(EnablingAuthorities.employees);
+    return this.positionFilterUtil(this.employeesCertViewerArr) || this.authoritiesFilterUtil(EnablingAuthorities.employees);
   }
 
   get certificatesViewer() {
-    const certificatesArr = [
-      employeePositionsName.SuperAdmin,
-      employeePositionsName.Admin,
-      employeePositionsName.CallManager,
-      employeePositionsName.ServiceManager,
-      employeePositionsName.Logistician
-    ];
-    return this.positionFilterUtil(certificatesArr) || this.authoritiesFilterUtil(EnablingAuthorities.certificates);
+    return this.positionFilterUtil(this.employeesCertViewerArr) || this.authoritiesFilterUtil(EnablingAuthorities.certificates);
   }
 
   get notificationsViewer() {
-    const notificationsArr = [
+    const notificationsViewerArr = [
       employeePositionsName.SuperAdmin,
       employeePositionsName.Admin,
       employeePositionsName.CallManager,
       employeePositionsName.ServiceManager
     ];
-    return this.positionFilterUtil(notificationsArr) || this.authoritiesFilterUtil(EnablingAuthorities.notifications);
+    return this.positionFilterUtil(notificationsViewerArr) || this.authoritiesFilterUtil(EnablingAuthorities.notifications);
   }
 
   get tariffsViewer() {
-    const viewersArr = [
-      employeePositionsName.SuperAdmin,
-      employeePositionsName.Admin,
-      employeePositionsName.CallManager,
-      employeePositionsName.ServiceManager,
-      employeePositionsName.Logistician,
-      employeePositionsName.Navigator
-    ];
-    return this.positionFilterUtil(viewersArr) || this.authoritiesFilterUtil(EnablingAuthorities.tariffs);
+    return this.positionFilterUtil(this.viewersArr) || this.authoritiesFilterUtil(EnablingAuthorities.tariffs);
+  }
+
+  get ordersViewer() {
+    return this.positionFilterUtil(this.viewersArr) || this.authoritiesFilterUtil(EnablingAuthorities.tariffs);
   }
 
   private changeListElementsDependOnPermissions(positions: string[], authorities: string[]) {
@@ -148,6 +138,10 @@ export class UbsAdminSidebarComponent extends UbsBaseSidebarComponent implements
 
     if (!this.tariffsViewer) {
       this.listElenenChangetUtil(SideMenuElementsNames.tariffs);
+    }
+
+    if (!this.ordersViewer) {
+      this.listElenenChangetUtil(SideMenuElementsNames.orders);
     }
   }
 }

--- a/src/app/ubs/ubs-admin/models/ubs-admin.interface.ts
+++ b/src/app/ubs/ubs-admin/models/ubs-admin.interface.ts
@@ -569,6 +569,10 @@ export enum EnablingAuthorities {
   notifications = 'SEE_MESSAGES_PAGE'
 }
 
+export enum abilityEditAuthorities {
+  orders = 'EDIT_ORDER'
+}
+
 export enum SideMenuElementsNames {
   orders = 'ubs-sidebar.orders',
   customers = 'ubs-sidebar.customers',

--- a/src/app/ubs/ubs-admin/models/ubs-admin.interface.ts
+++ b/src/app/ubs/ubs-admin/models/ubs-admin.interface.ts
@@ -543,3 +543,42 @@ export enum ordersStatuses {
   CancelUA = 'Скасовано',
   CancelEN = 'Canceled'
 }
+
+export interface AdminSideBarMenu {
+  link: string;
+  name: string;
+  routerLink: string;
+}
+
+export enum employeePositionsName {
+  ServiceManager = 'Менеджер послуги',
+  CallManager = 'Менеджер обдзвону',
+  Logistician = 'Логіст',
+  Navigator = 'Штурман',
+  Driver = 'Водій',
+  SuperAdmin = 'Супер адмін',
+  Admin = 'Адмін'
+}
+
+export enum EnablingAuthorities {
+  orders = 'SEE_BIG_ORDER_TABLE',
+  customers = 'SEE_CLIENTS_PAGE',
+  certificates = 'SEE_CERTIFICATES',
+  employees = 'SEE_EMPLOYEES_PAGE',
+  tariffs = 'SEE_TARIFFS',
+  notifications = 'SEE_MESSAGES_PAGE'
+}
+
+export enum SideMenuElementsNames {
+  orders = 'ubs-sidebar.orders',
+  customers = 'ubs-sidebar.customers',
+  certificates = 'ubs-sidebar.certificates',
+  employees = 'ubs-sidebar.employees',
+  tariffs = 'ubs-sidebar.tariffs',
+  notifications = 'ubs-sidebar.notifications'
+}
+
+export interface EmployeePositionsAuthorities {
+  authorities: string[];
+  positionId: number[];
+}

--- a/src/app/ubs/ubs-admin/services/ubs-admin-employee.service.ts
+++ b/src/app/ubs/ubs-admin/services/ubs-admin-employee.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { ubsAdminEmployeeLink, ubsAdminStationLink } from 'src/app/main/links';
 import { FilterData } from '../models/tariffs.interface';
+import { EmployeePositionsAuthorities } from '../models/ubs-admin.interface';
 
 @Injectable({
   providedIn: 'root'
@@ -12,7 +13,11 @@ export class UbsAdminEmployeeService {
   public getAllEmployees = `${ubsAdminEmployeeLink}/getAll-employees`;
   public searchValue: BehaviorSubject<string> = new BehaviorSubject<string>('');
   public filterDataSubject$: Subject<FilterData> = new Subject<FilterData>();
-
+  public employeePositionsAuthorities$: BehaviorSubject<EmployeePositionsAuthorities> = new BehaviorSubject<EmployeePositionsAuthorities>({
+    authorities: [],
+    positionId: []
+  });
+  public employeePositions$: BehaviorSubject<Array<string>> = new BehaviorSubject<Array<string>>([]);
   constructor(private http: HttpClient) {}
 
   getEmployees(

--- a/src/app/ubs/ubs-admin/services/ubs-admin-employee.service.ts
+++ b/src/app/ubs/ubs-admin/services/ubs-admin-employee.service.ts
@@ -1,10 +1,9 @@
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
-import { Employees, EmployeePositions } from '../models/ubs-admin.interface';
+import { Employees, EmployeePositions, EmployeePositionsAuthorities } from '../models/ubs-admin.interface';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { ubsAdminEmployeeLink, ubsAdminStationLink } from 'src/app/main/links';
 import { FilterData } from '../models/tariffs.interface';
-import { EmployeePositionsAuthorities } from '../models/ubs-admin.interface';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/ubs/ubs-user/ubs-user-sidebar/ubs-user-sidebar.component.ts
+++ b/src/app/ubs/ubs-user/ubs-user-sidebar/ubs-user-sidebar.component.ts
@@ -4,6 +4,7 @@ import { UbsBaseSidebarComponent } from 'src/app/shared/ubs-base-sidebar/ubs-bas
 import { UserMessagesService } from '../services/user-messages.service';
 import { JwtService } from '@global-service/jwt/jwt.service';
 import { listElementsUser, listElementsUserMobile } from '../../ubs/models/ubs-sidebar-links';
+import { UbsAdminEmployeeService } from '../../ubs-admin/services/ubs-admin-employee.service';
 
 @Component({
   selector: 'app-ubs-user-sidebar',
@@ -13,7 +14,12 @@ export class UbsUserSidebarComponent extends UbsBaseSidebarComponent {
   public listElementsUser = listElementsUser;
   public listElementsUserMobile = listElementsUserMobile;
 
-  constructor(public service: UserMessagesService, public breakpointObserver: BreakpointObserver, public jwtService: JwtService) {
+  constructor(
+    public ubsAdminEmployeeService: UbsAdminEmployeeService,
+    public service: UserMessagesService,
+    public breakpointObserver: BreakpointObserver,
+    public jwtService: JwtService
+  ) {
     super(service, breakpointObserver, jwtService);
   }
 }


### PR DESCRIPTION
#6074,#6075,#6077,#6078 - Changing the access to elements of admin sidemenu according to employees positions and roles
#6076 - Remove opportunity to edit order if employee Driver, Navigator or Logistician