### PR TITLE
Bugfix/#5709/#6124#6098/#5970/habit isn't marked as done  in Calendar after click mark done button Edit Habit

### DIFF
--- a/src/app/main/component/shared/components/calendar-base/calendar-base.component.spec.ts
+++ b/src/app/main/component/shared/components/calendar-base/calendar-base.component.spec.ts
@@ -223,13 +223,6 @@ describe('CalendarBaseComponent', () => {
     });
   });
 
-  describe('formatSelectedDate', () => {
-    it('should return date: jan 11 2020', () => {
-      const result = component.formatSelectedDate(true, calendarMock);
-      expect(result).toEqual('jan 11, 2020');
-    });
-  });
-
   it('should return true when isActiveMonth', () => {
     component.isActiveMonth();
     expect(component.isActiveMonth).toBeTruthy();

--- a/src/app/main/component/shared/components/calendar-base/calendar-base.component.ts
+++ b/src/app/main/component/shared/components/calendar-base/calendar-base.component.ts
@@ -236,17 +236,6 @@ export class CalendarBaseComponent implements OnDestroy {
     }
   }
 
-  formatSelectedDate(isMonthCalendar, dayItem: CalendarInterface) {
-    if (isMonthCalendar) {
-      return `${this.months[dayItem.month]} ${dayItem.numberOfDate}, ${dayItem.year}`;
-    } else {
-      const month = dayItem.date.toLocaleDateString(this.language, { month: 'long' });
-      const day = dayItem.date.getDate();
-      const year = dayItem.date.getFullYear();
-      return `${month} ${day}, ${year}`;
-    }
-  }
-
   getHabitsForDay(habitsList, date) {
     return habitsList.find((list) => list.enrollDate === date);
   }
@@ -354,7 +343,7 @@ export class CalendarBaseComponent implements OnDestroy {
       return createDateTime(b) - createDateTime(a);
     });
     dialogConfig.data = {
-      habitsCalendarSelectedDate: this.formatSelectedDate(isMonthCalendar, dayItem),
+      habitsCalendarSelectedDate: this.formatDate(isMonthCalendar, dayItem),
       isHabitListEditable: this.isHabitListEditable,
       habits: dayHabitsSortedByDate
     };

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-edit-shopping-list/habit-edit-shopping-list.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-edit-shopping-list/habit-edit-shopping-list.component.ts
@@ -57,6 +57,7 @@ export class HabitEditShoppingListComponent implements OnInit, AfterViewChecked,
     if (this.shopList && this.isEditing) {
       this.shopList.forEach((el) => (el.selected = el.status === TodoStatus.inprogress));
     }
+    this.placeItemInOrder();
     this.cdr.detectChanges();
   }
 
@@ -105,6 +106,7 @@ export class HabitEditShoppingListComponent implements OnInit, AfterViewChecked,
     }
     this.item.setValue('');
     this.placeItemInOrder();
+    this.newList.emit(this.shopList);
   }
 
   public selectItem(item: ShoppingList): void {
@@ -121,6 +123,7 @@ export class HabitEditShoppingListComponent implements OnInit, AfterViewChecked,
       this.shopList = [item, ...this.shopList];
     }
     this.placeItemInOrder();
+    this.newList.emit(this.shopList);
   }
 
   private placeItemInOrder(): void {
@@ -130,7 +133,6 @@ export class HabitEditShoppingListComponent implements OnInit, AfterViewChecked,
       const orderCustom = a.custom && !b.custom ? -1 : 1;
       return statusDifference ? statusDifference : orderCustom;
     });
-    this.newList.emit(this.shopList);
   }
 
   public deleteItem(text: string): void {

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-progress/habit-progress.component.html
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-progress/habit-progress.component.html
@@ -16,8 +16,10 @@
   </div>
 </div>
 <div class="calendar">
-  <app-habit-calendar class="calendar-container"></app-habit-calendar>
-  <app-calendar-week class="app-calendar-week"></app-calendar-week>
+  <app-habit-calendar class="calendar-container" *ngIf="isDesktopWidth; else mobileView"></app-habit-calendar>
+  <ng-template #mobileView>
+    <app-calendar-week class="app-calendar-week"></app-calendar-week>
+  </ng-template>
   <div class="days-duration">
     <div class="thumb-label" [style.bottom.%]="indicator - heightThumbLabel" *ngIf="isHidden && indicator">{{ indicator }}%</div>
     <div class="indicator" (mouseenter)="isHidden = !isHidden" (mouseleave)="isHidden = !isHidden" [style.height.%]="indicator"></div>

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-progress/habit-progress.component.scss
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-progress/habit-progress.component.scss
@@ -60,10 +60,6 @@
     width: calc(100% - 66px);
   }
 
-  .app-calendar-week {
-    display: none;
-  }
-
   .days-duration {
     position: relative;
     display: flex;
@@ -122,10 +118,6 @@
   .calendar {
     flex-direction: column;
     gap: 24px;
-
-    .calendar-container {
-      display: none;
-    }
 
     .app-calendar-week {
       display: flex;

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-progress/habit-progress.component.spec.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-progress/habit-progress.component.spec.ts
@@ -8,7 +8,7 @@ import { of } from 'rxjs';
 import { MatDialogModule } from '@angular/material/dialog';
 import { Pipe, PipeTransform } from '@angular/core';
 import { DatePipe } from '@angular/common';
-import { DEFAULTFULLINFOHABIT } from '../../mocks/habit-assigned-mock';
+import { DEFAULTFULLINFOHABIT, DEFAULTFULLINFOHABIT_2 } from '../../mocks/habit-assigned-mock';
 
 @Pipe({ name: 'datePipe' })
 class DatePipeMock implements PipeTransform {
@@ -69,6 +69,33 @@ describe('HabitProgressComponent', () => {
   it('ngOnChanges', () => {
     const spy = spyOn(component, 'countProgressBar');
     component.ngOnChanges();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('ngOnInit should call updateHabitSteak and countProgressBar', () => {
+    const spy1 = spyOn(component, 'updateHabitSteak');
+    const spy2 = spyOn(component, 'countProgressBar');
+    component.ngOnInit();
+    expect(spy1).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+  });
+
+  it('should call isDeskWidth while ngOnInit', () => {
+    const spy = spyOn(component, 'isDeskWidth');
+    component.ngOnInit();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should update habitSteak', () => {
+    const spy = spyOn(component, 'countDifferenceInDays');
+    component.currentDate = '2023-04-16';
+    component.habit = DEFAULTFULLINFOHABIT_2 as any;
+    component.updateHabitSteak({ date: '2023-04-16', isEnrolled: true });
+    expect(component.habit.workingDays).toBe(3);
+    expect(component.habit.habitStreak).toBe(1);
+    component.updateHabitSteak({ date: '2023-04-14', isEnrolled: false });
+    expect(component.habit.workingDays).toBe(2);
+    expect(component.habit.habitStreak).toBe(1);
     expect(spy).toHaveBeenCalled();
   });
 

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-progress/habit-progress.component.spec.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-progress/habit-progress.component.spec.ts
@@ -23,8 +23,22 @@ describe('HabitProgressComponent', () => {
   const habitAssignServiceMock = jasmine.createSpyObj('HabitAssignService', [
     'getAssignHabitsByPeriod',
     'enrollByHabit',
-    'unenrollByHabit'
+    'unenrollByHabit',
+    'habitChangesFromCalendarSubj'
   ]);
+  habitAssignServiceMock.habitsFromDashBoard = JSON.parse(
+    JSON.stringify([
+      {
+        enrollDate: '2022-02-10',
+        habitAssigns: [
+          {
+            habitId: 123,
+            enrolled: false
+          }
+        ]
+      }
+    ])
+  );
 
   const fakeHabitAcquired = { ...DEFAULTFULLINFOHABIT, status: 'ACQUIRED' };
 
@@ -44,6 +58,7 @@ describe('HabitProgressComponent', () => {
     component = fixture.componentInstance;
     component.habit = fakeHabitAcquired as any;
     habitAssignServiceMock.getAssignHabitsByPeriod.and.returnValue(of());
+    habitAssignServiceMock.habitChangesFromCalendarSubj = of({});
     fixture.detectChanges();
   });
 

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-progress/habit-progress.component.spec.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-progress/habit-progress.component.spec.ts
@@ -70,6 +70,7 @@ describe('HabitProgressComponent', () => {
     const spy = spyOn(component, 'countProgressBar');
     component.ngOnChanges();
     expect(spy).toHaveBeenCalled();
+    expect(habitAssignServiceMock.habitForEdit).toEqual(component.habit);
   });
 
   it('ngOnInit should call updateHabitSteak and countProgressBar', () => {

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-progress/habit-progress.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-progress/habit-progress.component.ts
@@ -4,7 +4,11 @@ import { HabitStatus } from '@global-models/habit/HabitStatus.enum';
 import { HabitAssignService } from '@global-service/habit-assign/habit-assign.service';
 import { HabitMark } from '@global-user/components/habit/models/HabitMark.enum';
 import { take } from 'rxjs/operators';
-import { HabitAssignInterface } from '../../models/interfaces/habit-assign.interface';
+import {
+  HabitAssignInterface,
+  ChangesFromCalendarToProgress,
+  HabitStatusCalendarListInterface
+} from '../../models/interfaces/habit-assign.interface';
 
 @Component({
   selector: 'app-habit-progress',
@@ -73,7 +77,13 @@ export class HabitProgressComponent implements OnChanges, OnInit {
     return (new Date(date1).getTime() - new Date(date2).getTime()) / this.millisecondsOfDay;
   }
 
-  updateHabitSteak(changes): void {
+  sortHabitStatusCalendarDtoListByDate() {
+    return this.habit.habitStatusCalendarDtoList.sort((a: HabitStatusCalendarListInterface, b: HabitStatusCalendarListInterface) => {
+      return new Date(b.enrollDate).getTime() - new Date(a.enrollDate).getTime();
+    });
+  }
+
+  updateHabitSteak(changes: ChangesFromCalendarToProgress): void {
     if (changes.isEnrolled) {
       this.habit.habitStatusCalendarDtoList.push({
         enrollDate: changes.date,
@@ -84,14 +94,12 @@ export class HabitProgressComponent implements OnChanges, OnInit {
         return habit.enrollDate !== changes.date;
       });
     }
-    const sortedCalendarDtoList = this.habit.habitStatusCalendarDtoList.sort((a, b) => {
-      return new Date(b.enrollDate).getTime() - new Date(a.enrollDate).getTime();
-    });
+    const sortedCalendarDtoList = this.sortHabitStatusCalendarDtoListByDate();
     if (sortedCalendarDtoList[0]?.enrollDate !== this.currentDate) {
       this.habit.habitStreak = 0;
     } else {
       this.habit.habitStreak = sortedCalendarDtoList.filter((el, index, arr) => {
-        return index > 0 ? this.countDifferenceInDays(arr[0].enrollDate, el.enrollDate) === index : true;
+        return index ? this.countDifferenceInDays(arr[0].enrollDate, el.enrollDate) === index : true;
       }).length;
     }
     this.habit.workingDays = this.habit.habitStatusCalendarDtoList.length;

--- a/src/app/main/component/user/components/habit/mocks/habit-assigned-mock.ts
+++ b/src/app/main/component/user/components/habit/mocks/habit-assigned-mock.ts
@@ -140,3 +140,28 @@ export const HABITSFORDATE: HabitsForDateInterface[] = [
     ]
   }
 ];
+
+export const DEFAULTFULLINFOHABIT_2: HabitAssignInterface = {
+  id: 1,
+  status: 'INPROGRESS',
+  createDateTime: new Date('2023-04-14'),
+  habit: DEFAULTHABIT,
+  enrolled: true,
+  userId: 17,
+  duration: 8,
+  workingDays: 2,
+  habitStreak: 1,
+  lastEnrollmentDate: new Date(2021, 5, 23),
+  habitStatusCalendarDtoList: [
+    { enrollDate: '2023-04-14', id: 2 },
+    { enrollDate: '2023-04-10', id: 3 }
+  ],
+  shoppingListItems: [
+    {
+      id: 6,
+      status: 'ACTIVE',
+      text: 'TEST'
+    }
+  ],
+  progressNotificationHasDisplayed: false
+};

--- a/src/app/main/component/user/components/habit/models/interfaces/habit-assign.interface.ts
+++ b/src/app/main/component/user/components/habit/models/interfaces/habit-assign.interface.ts
@@ -35,3 +35,7 @@ export interface ResponseInterface {
   habitStreak: number;
   lastEnrollmentDate: Date;
 }
+export interface ChangesFromCalendarToProgress {
+  isEnrolled: boolean;
+  date: string;
+}

--- a/src/app/main/component/user/components/profile/calendar/habit-popup-interface.ts
+++ b/src/app/main/component/user/components/profile/calendar/habit-popup-interface.ts
@@ -9,3 +9,8 @@ export interface HabitsForDateInterface {
   enrollDate: string;
   habitAssigns: Array<HabitPopupInterface>;
 }
+
+export enum HabitPopUpRoutes {
+  EditHabit = 'edithabit',
+  CreateHabit = 'create-habit'
+}

--- a/src/app/main/component/user/components/profile/calendar/habits-popup/habits-popup.component.spec.ts
+++ b/src/app/main/component/user/components/profile/calendar/habits-popup/habits-popup.component.spec.ts
@@ -88,7 +88,7 @@ describe('HabitsPopupComponent', () => {
     spyOn(component, 'formatSelectedDate').and.returnValue('02 20 2022');
     component.loadPopup();
     expect(component.language).toBe('ua');
-    expect(component.habitsCalendarSelectedDate).toBe('2022-02-20');
+    expect(component.habitsCalendarSelectedDate).toBe('02 20 2022');
     expect(component.isHabitListEditable).toBeTruthy();
     expect(component.popupHabits).toEqual(mockPopupHabits);
     expect(component.today).toBe('02 20 2022');

--- a/src/app/main/component/user/components/profile/calendar/habits-popup/habits-popup.component.ts
+++ b/src/app/main/component/user/components/profile/calendar/habits-popup/habits-popup.component.ts
@@ -1,9 +1,9 @@
-import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit, Output } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { calendarIcons } from 'src/app/main/image-pathes/calendar-icons';
-import { HabitPopupInterface } from '../habit-popup-interface';
+import { HabitPopupInterface, HabitPopUpRoutes } from '../habit-popup-interface';
 import { HabitAssignService } from '@global-service/habit-assign/habit-assign.service';
 import { LanguageService } from '../../../../../../i18n/language.service';
 import { DatePipe } from '@angular/common';
@@ -11,6 +11,7 @@ import {
   HabitAssignInterface,
   HabitStatusCalendarListInterface
 } from '@global-user/components/habit/models/interfaces/habit-assign.interface';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-habits-popup',
@@ -30,12 +31,14 @@ export class HabitsPopupComponent implements OnInit, OnDestroy {
   arrayOfDay: any;
   habitStreak = 0;
   currentDate: Date;
+  currentPage: 'editHabit' | 'createHabit' | 'profileHabits';
 
   constructor(
     public dialogRef: MatDialogRef<HabitsPopupComponent>,
     public habitAssignService: HabitAssignService,
     public datePipe: DatePipe,
     public languageService: LanguageService,
+    public router: Router,
     @Inject(MAT_DIALOG_DATA)
     public data: {
       habitsCalendarSelectedDate: string;
@@ -47,6 +50,7 @@ export class HabitsPopupComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.loadPopup();
     this.closePopup();
+    this.checkCurrentPage();
   }
 
   ngOnDestroy() {
@@ -56,7 +60,7 @@ export class HabitsPopupComponent implements OnInit, OnDestroy {
 
   loadPopup() {
     this.language = this.languageService.getCurrentLanguage();
-    this.habitsCalendarSelectedDate = this.data.habitsCalendarSelectedDate;
+    this.habitsCalendarSelectedDate = this.formatSelectedDate(this.data.habitsCalendarSelectedDate);
     this.isHabitListEditable = this.data.isHabitListEditable;
     this.popupHabits = this.data.habits.map((habit) => Object.assign({}, habit));
     this.today = this.formatSelectedDate().toString();
@@ -69,12 +73,12 @@ export class HabitsPopupComponent implements OnInit, OnDestroy {
       .subscribe(() => this.dialogRef.close(this.popupHabits));
   }
 
-  formatSelectedDate() {
-    const today = new Date();
-    const monthLow = today.toLocaleDateString(this.language === 'ua' ? 'uk' : this.language, { month: 'long' });
+  formatSelectedDate(dateString?: string) {
+    const date = dateString ? new Date(dateString) : new Date();
+    const monthLow = date.toLocaleDateString(this.language === 'ua' ? 'uk' : this.language, { month: 'long' });
     const month = monthLow.charAt(0).toUpperCase() + monthLow.slice(1);
-    const day = today.getDate();
-    const year = today.getFullYear();
+    const day = date.getDate();
+    const year = date.getFullYear();
     return `${month} ${day}, ${year}`;
   }
 
@@ -160,7 +164,25 @@ export class HabitsPopupComponent implements OnInit, OnDestroy {
   toggleEnrollHabit(id: number) {
     const habitIndex = this.popupHabits.findIndex((habit) => habit.habitAssignId === id);
     this.popupHabits[habitIndex].enrolled = !this.popupHabits[habitIndex].enrolled;
-    this.setCircleFromPopUpToCards(id, this.popupHabits[habitIndex].enrolled);
+    if (this.currentPage === 'editHabit' && id === this.habitAssignService.habitForEdit.id) {
+      this.habitAssignService.setCircleFromPopUpToProgress({
+        date: this.datePipe.transform(this.data.habitsCalendarSelectedDate, 'yyyy-MM-dd'),
+        isEnrolled: this.popupHabits[habitIndex].enrolled
+      });
+    }
+    if (this.currentPage === 'profileHabits') {
+      this.setCircleFromPopUpToCards(id, this.popupHabits[habitIndex].enrolled);
+    }
+  }
+
+  checkCurrentPage() {
+    if (this.router.url.includes(HabitPopUpRoutes.EditHabit)) {
+      this.currentPage = 'editHabit';
+    } else if (this.router.url.includes(HabitPopUpRoutes.CreateHabit)) {
+      this.currentPage = 'createHabit';
+    } else {
+      this.currentPage = 'profileHabits';
+    }
   }
 
   showTooltip(habit) {

--- a/src/app/main/component/user/components/profile/calendar/habits-popup/habits-popup.component.ts
+++ b/src/app/main/component/user/components/profile/calendar/habits-popup/habits-popup.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -165,10 +165,11 @@ export class HabitsPopupComponent implements OnInit, OnDestroy {
     const habitIndex = this.popupHabits.findIndex((habit) => habit.habitAssignId === id);
     this.popupHabits[habitIndex].enrolled = !this.popupHabits[habitIndex].enrolled;
     if (this.currentPage === 'editHabit' && id === this.habitAssignService.habitForEdit.id) {
-      this.habitAssignService.setCircleFromPopUpToProgress({
+      const changes = {
         date: this.datePipe.transform(this.data.habitsCalendarSelectedDate, 'yyyy-MM-dd'),
         isEnrolled: this.popupHabits[habitIndex].enrolled
-      });
+      };
+      this.habitAssignService.setCircleFromPopUpToProgress(changes);
     }
     if (this.currentPage === 'profileHabits') {
       this.setCircleFromPopUpToCards(id, this.popupHabits[habitIndex].enrolled);

--- a/src/app/main/service/habit-assign/habit-assign.service.ts
+++ b/src/app/main/service/habit-assign/habit-assign.service.ts
@@ -1,12 +1,16 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, ReplaySubject } from 'rxjs';
+import { Observable, ReplaySubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { habitAssignLink } from '../../links';
 import { HabitsForDateInterface } from '@global-user/components/profile/calendar/habit-popup-interface';
-import { HabitAssignInterface, ResponseInterface } from '@global-user/components/habit/models/interfaces/habit-assign.interface';
+import {
+  HabitAssignInterface,
+  ResponseInterface,
+  ChangesFromCalendarToProgress
+} from '@global-user/components/habit/models/interfaces/habit-assign.interface';
 
 @Injectable({
   providedIn: 'root'
@@ -18,6 +22,8 @@ export class HabitAssignService implements OnDestroy {
   habitsFromDashBoard: any;
   habitsInProgressToView: Array<HabitAssignInterface> = [];
   habitsInProgress: Array<HabitAssignInterface> = [];
+  habitForEdit: HabitAssignInterface;
+  habitChangesFromCalendarSubj: Subject<ChangesFromCalendarToProgress> = new Subject<ChangesFromCalendarToProgress>();
   countOfResult: number;
   habitDate: any;
   mapOfArrayOfAllDate = new Map();
@@ -72,6 +78,10 @@ export class HabitAssignService implements OnDestroy {
 
   progressNotificationHasDisplayed(habitAssignId: number): Observable<object> {
     return this.http.put<object>(`${habitAssignLink}/${habitAssignId}/updateProgressNotificationHasDisplayed`, {});
+  }
+
+  setCircleFromPopUpToProgress(changesFromCalendar: ChangesFromCalendarToProgress) {
+    this.habitChangesFromCalendarSubj.next(changesFromCalendar);
   }
 
   ngOnDestroy(): void {

--- a/src/app/ubs/ubs-user/ubs-user-profile-page/ubs-user-profile-page.component.scss
+++ b/src/app/ubs/ubs-user/ubs-user-profile-page/ubs-user-profile-page.component.scss
@@ -214,7 +214,7 @@ $inputwidth: 260px;
   top: 5px;
   left: 4px;
   height: 16px;
-  width: 16px;
+  width: 15px;
   margin-right: 10px;
   background-color: var(--ubs-primary-white);
   border-radius: 50%;


### PR DESCRIPTION
# Bugfix Transfering data from calendar pop-up to habit edit page and vice versa 

## Summary Of Changes :fire:
added functionality for sending data from the calendar pop-up to Edit habit page and vice versa;


## Issue Link :clipboard:
_&lt;[#5709](https://github.com/ita-social-projects/GreenCity/issues/5709)&gt;_
_&lt;[#6124](https://github.com/ita-social-projects/GreenCity/issues/6124)&gt;_
_&lt;[#6098](https://github.com/ita-social-projects/GreenCity/issues/6098)&gt;_
_&lt;[#5970](https://github.com/ita-social-projects/GreenCity/issues/5970)&gt;_


## Added
* _&lt;subscription  on changes from calendar pop up in edit habit page&gt;_
* _&lt;function which change green circle in calendar&gt;_
* _&lt;detail item of what was added&gt;_

## Changed
* _&lt;shopping-list items order&gt;_

## Deleted
* _&lt;method for formatting date in calendar component. The same method is in the pop-up component&gt;_

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
