### PR TITLE
Bugfix/#5766#5900fixes for tariff page

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
@@ -88,6 +88,7 @@
         />
         <mat-autocomplete
           #autoCity="matAutocomplete"
+          (opened)="onOpenDropdown($event)"
           (optionSelected)="onSelectCity($event, autocompleteTriggerCity)"
           autoActiveFirstOption
         >

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.spec.ts
@@ -278,6 +278,9 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
   });
 
   it('should call method for selecting one city', () => {
+    const panelMock = { scrollTop: 100 } as any;
+    spyOn(document, 'querySelector').and.returnValue(panelMock);
+
     const eventMock = {
       option: {
         value: 'First'
@@ -290,6 +293,9 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
   });
 
   it('should call method for selecting all cities', () => {
+    const panelMock = { scrollTop: 100 } as any;
+    spyOn(document, 'querySelector').and.returnValue(panelMock);
+
     const eventMock = {
       option: {
         value: 'all'
@@ -504,6 +510,9 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
   });
 
   it('should call method for filtering card with chosen all cities', () => {
+    const panelMock = { scrollTop: 100 } as any;
+    spyOn(document, 'querySelector').and.returnValue(panelMock);
+
     const eventMock = {
       option: {
         value: 'all'
@@ -519,6 +528,9 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
   });
 
   it('should call method for filtering card with chosen cities', () => {
+    const panelMock = { scrollTop: 100 } as any;
+    spyOn(document, 'querySelector').and.returnValue(panelMock);
+
     component.locations = [fakeLocations];
     const eventMock = {
       option: {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -70,6 +70,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
   isCardExist = false;
   currentLang;
   deactivateCardObj: DeactivateCard;
+  private scrollPosition = 0;
 
   private destroy: Subject<boolean> = new Subject<boolean>();
 
@@ -251,7 +252,15 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
     }
   }
 
+  public onOpenDropdown(event: Event): void {
+    const panel = document.querySelector('.mat-autocomplete-panel');
+    panel.scrollTop = this.scrollPosition;
+  }
+
   public onSelectCity(event: MatAutocompleteSelectedEvent, trigger?: MatAutocompleteTrigger): void {
+    const panel = document.querySelector('.mat-autocomplete-panel');
+    this.scrollPosition = panel.scrollTop;
+
     if (event.option.value === 'all') {
       this.toggleSelectAllCity();
       const locationsId = this.locations.map((location) => location.locationsDto.map((elem) => elem.locationId)).flat(2);

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.spec.ts
@@ -366,29 +366,6 @@ describe('UbsAdminTariffsLocationPopUpComponent ', () => {
     expect(result).toEqual(['Фейк1']);
   });
 
-  it('should translate and set text to input', () => {
-    component.translate('фейк', component.englishLocation);
-    expect(tariifsServiceMock.getJSON).toHaveBeenCalled();
-    expect(component.englishLocation.value).toEqual('f');
-  });
-
-  it('should call getJSON on translate', () => {
-    component.translate('фейк', component.englishLocation);
-    expect(tariifsServiceMock.getJSON).toHaveBeenCalledWith('фейк', 'uk', 'en');
-  });
-
-  it('should set ua lang on translate', () => {
-    const lang = component.getLangValue('uk', 'en');
-    component.translate('фейк', component.englishLocation);
-    expect(lang).toBe('uk');
-  });
-
-  it('should set ua langTranslate on translate', () => {
-    const langTranslate = component.getLangValue('en', 'uk');
-    component.translate('фейк', component.englishLocation);
-    expect(langTranslate).toBe('en');
-  });
-
   it('should find new region', () => {
     const spy = spyOn(component, 'selectCities');
     component.regionSelected = false;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.ts
@@ -193,14 +193,6 @@ export class UbsAdminTariffsLocationPopUpComponent implements OnInit, AfterViewC
     });
   }
 
-  translate(sourceText: string, input: any): void {
-    const lang = this.getLangValue(Language.UK, Language.EN);
-    const translateTo = this.getLangValue(Language.EN, Language.UK);
-    this.tariffsService.getJSON(sourceText, lang, translateTo).subscribe((data) => {
-      input.setValue(data[0][0][0]);
-    });
-  }
-
   public addCity(): void {
     if (this.location.value && this.englishLocation.value && !this.cities.includes(this.location.value) && this.citySelected) {
       const uaLocation = this.getLangValue(this.location.value, this.englishLocation.value);
@@ -296,11 +288,16 @@ export class UbsAdminTariffsLocationPopUpComponent implements OnInit, AfterViewC
   addEventToAutocomplete(): void {
     this.autocompleteLsr = this.autocomplete.addListener('place_changed', () => {
       this.citySelected = true;
-      const locationName = this.autocomplete.getPlace().name;
       this.currentLatitude = this.autocomplete.getPlace().geometry.location.lat();
       this.currentLongitude = this.autocomplete.getPlace().geometry.location.lng();
-      this.location.setValue(locationName);
-      this.translate(locationName, this.englishLocation);
+
+      const placeId = this.autocomplete.getPlace().place_id;
+      const languages = {
+        current: this.currentLang === Language.UA ? Language.UK : Language.EN,
+        opposite: this.currentLang === Language.UA ? Language.EN : Language.UK
+      };
+      this.setTranslation(placeId, this.location, languages.current);
+      this.setTranslation(placeId, this.englishLocation, languages.opposite);
     });
   }
 


### PR DESCRIPTION
#5766
**Before**:
The drop-down list is scrolled up when the second point is selected 

**After**:
The drop-down list isn't scrolled up when the second point is selected

#5900
**Before**:
A city name in Ukrainian is replaced by an English or Russian name after its selection in the drop-down of the "Місто" field while creating a new location 
**After**:
A city name in Ukrainian isn't replaced by an English name after its selection in the drop-down of the "Місто" field while creating a new location and setting a Ukrainian name

https://github.com/ita-social-projects/GreenCityClient/assets/101433204/c700d97f-d811-44c4-b694-84f816d0cbb1

