### PR TITLE
Bugfix/added auth window for order button

### DIFF
--- a/src/app/ubs/ubs/components/ubs-main-page/ubs-main-page.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-main-page/ubs-main-page.component.spec.ts
@@ -11,6 +11,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { OrderService } from '../../services/order.service';
 import { JwtService } from '@global-service/jwt/jwt.service';
 import { activeCouriersMock } from 'src/app/ubs/ubs-admin/services/orderInfoMock';
+import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component';
 
 describe('UbsMainPageComponent', () => {
   let component: UbsMainPageComponent;
@@ -80,11 +81,26 @@ describe('UbsMainPageComponent', () => {
     expect(routerMock.navigate).toHaveBeenCalledWith(['ubs', 'order']);
   });
 
-  it('should make expected calls inside redirectToOrder', () => {
-    const spy = spyOn(component, 'getLocations');
+  it('should make expected calls inside redirectToOrder when userId is truthy', () => {
+    (component as any).userId = 333;
+    spyOn(component, 'getLocations').and.stub();
     component.redirectToOrder();
+
     expect(localeStorageServiceMock.setUbsRegistration).toHaveBeenCalledWith(true);
-    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should open auth modal window inside redirectToOrder when userId is falsy', () => {
+    (component as any).userId = null;
+    component.redirectToOrder();
+
+    expect(matDialogMock.open).toHaveBeenCalledWith(AuthModalComponent, {
+      hasBackdrop: true,
+      closeOnNavigation: true,
+      panelClass: ['custom-dialog-container'],
+      data: {
+        popUpName: 'sign-in'
+      }
+    });
   });
 
   describe('findCourierByName', () => {

--- a/src/app/ubs/ubs/components/ubs-main-page/ubs-main-page.component.ts
+++ b/src/app/ubs/ubs/components/ubs-main-page/ubs-main-page.component.ts
@@ -10,6 +10,7 @@ import { AllLocationsDtos, CourierLocations } from '../../models/ubs.interface';
 import { OrderService } from '../../services/order.service';
 import { UbsOrderLocationPopupComponent } from '../ubs-order-details/ubs-order-location-popup/ubs-order-location-popup.component';
 import { JwtService } from '@global-service/jwt/jwt.service';
+import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component';
 
 @Component({
   selector: 'app-ubs-main-page',
@@ -160,8 +161,23 @@ export class UbsMainPageComponent implements OnInit, OnDestroy, AfterViewChecked
   }
 
   redirectToOrder() {
-    this.localStorageService.setUbsRegistration(true);
-    this.getLocations(this.ubsCourierName);
+    if (this.userId) {
+      this.localStorageService.setUbsRegistration(true);
+      this.getLocations(this.ubsCourierName);
+    } else {
+      this.openAuthModalWindow();
+    }
+  }
+
+  public openAuthModalWindow(): void {
+    this.dialog.open(AuthModalComponent, {
+      hasBackdrop: true,
+      closeOnNavigation: true,
+      panelClass: ['custom-dialog-container'],
+      data: {
+        popUpName: 'sign-in'
+      }
+    });
   }
 
   public checkIsAdmin(): boolean {
@@ -170,7 +186,7 @@ export class UbsMainPageComponent implements OnInit, OnDestroy, AfterViewChecked
   }
 
   findCourierByName(name) {
-    return this.activeCouriers.find((courier) => courier.nameEn.includes(name));
+    return this.activeCouriers?.find((courier) => courier.nameEn.includes(name));
   }
 
   getActiveCouriers() {


### PR DESCRIPTION
**Before**
When an unregistered user clicks on the "Order" button, nothing happens

**After**
When an unregistered user clicks on the "Order" button, the window for sign-in/sign-up is opened
