### PR TITLE
bugfix/#6145-cursor-for-togglers-while-not-editing

### DIFF
--- a/src/app/ubs/ubs-user/ubs-user-profile-page/ubs-switcher/ubs-switcher.component.html
+++ b/src/app/ubs/ubs-user/ubs-user-profile-page/ubs-switcher/ubs-switcher.component.html
@@ -1,4 +1,4 @@
 <label class="switch">
   <input type="checkbox" [checked]="isChecked" [disabled]="isEditing" (change)="onChange($event.target.checked)" />
-  <span class="slider round"></span>
+  <span class="slider round" [ngStyle]="{ cursor: isEditing ? 'not-allowed' : 'pointer' }"></span>
 </label>


### PR DESCRIPTION
**Before**
The mouse cursor changes to hand when hovers over the Telegram or Viber toggled when it is not editing the profile.

**After**
The mouse cursor is changed to forbidden to make changes when it is not editing profile mode
