### PR TITLE
Bugfix/#5700 Events. join button is visible for close event (only organizer's friends can join)

### DIFF
--- a/src/app/main/component/events/components/event-details/event-details.component.html
+++ b/src/app/main/component/events/components/event-details/event-details.component.html
@@ -120,7 +120,7 @@
         <div class="save-join-event-block" *ngIf="role === roles.USER">
           <button *ngIf="!isOver" class="secondary-global-button">{{ 'homepage.events.btn.save-btn' | translate }}</button>
           <button
-            *ngIf="!isUserCanRate && !isOver"
+            *ngIf="!isUserCanRate && !isOver && (isEventOrginizerFriend || event.open)"
             [ngClass]="isUserCanJoin ? 'primary-global-button' : 'secondary-global-button'"
             (click)="buttonAction()"
           >

--- a/src/app/main/component/events/components/event-details/event-details.component.spec.ts
+++ b/src/app/main/component/events/components/event-details/event-details.component.spec.ts
@@ -14,6 +14,7 @@ import { ActionsSubject, Store } from '@ngrx/store';
 import { Language } from 'src/app/main/i18n/Language';
 import { LanguageService } from 'src/app/main/i18n/language.service';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
+import { UserFriendsService } from '@global-user/services/user-friends.service';
 
 export function mockPipe(options: Pipe): Pipe {
   const metadata: Pipe = {
@@ -128,6 +129,9 @@ describe('EventDetailsComponent', () => {
   translateServiceMock.setDefaultLang = (lang: string) => of();
   translateServiceMock.get = () => of(true);
 
+  const userFriendsServiceMock = jasmine.createSpyObj('UserFriendsService', ['getAllFriendsByUserId']);
+  userFriendsServiceMock.getAllFriendsByUserId = () => of();
+
   const MatSnackBarMock = jasmine.createSpyObj('MatSnackBarComponent', ['openSnackBar']);
 
   const actionSub: ActionsSubject = new ActionsSubject();
@@ -148,7 +152,8 @@ describe('EventDetailsComponent', () => {
         { provide: ActionsSubject, useValue: actionSub },
         { provide: BsModalRef, useValue: bsModalRefMock },
         { provide: MatSnackBarComponent, useValue: MatSnackBarMock },
-        { provide: BsModalService, useValue: bsModalBsModalServiceMock }
+        { provide: BsModalService, useValue: bsModalBsModalServiceMock },
+        { provide: UserFriendsService, useValue: userFriendsServiceMock }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -168,12 +173,12 @@ describe('EventDetailsComponent', () => {
   });
 
   it('should call methods on ngOnInit', () => {
-  const spy1 = spyOn(component as any, 'bindLang');
-  const spy2 = spyOn(component as any, 'verifyRole');
-  component.ngOnInit();
-  expect(spy1).toHaveBeenCalled();
-  expect(spy1).toHaveBeenCalledWith('ua');
-  expect(spy2).toHaveBeenCalled();
+    const spy1 = spyOn(component as any, 'bindLang');
+    const spy2 = spyOn(component as any, 'verifyRole');
+    component.ngOnInit();
+    expect(spy1).toHaveBeenCalled();
+    expect(spy1).toHaveBeenCalledWith('ua');
+    expect(spy2).toHaveBeenCalled();
   });
 
   it('should verify unauthenticated role', () => {

--- a/src/app/main/component/events/components/event-details/event-details.component.ts
+++ b/src/app/main/component/events/components/event-details/event-details.component.ts
@@ -25,6 +25,7 @@ import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar
 import { IEcoEventsState } from 'src/app/store/state/ecoEvents.state';
 import { IAppState } from 'src/app/store/state/app.state';
 import { EventsListItemModalComponent } from '@shared/components/events-list-item/events-list-item-modal/events-list-item-modal.component';
+import { UserFriendsService } from '@global-user/services/user-friends.service';
 
 @Component({
   selector: 'app-event-details',
@@ -108,6 +109,7 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
   public addAttenderError: string;
   public isRegistered: boolean;
   public isReadonly = false;
+  public isEventOrginizerFriend: boolean;
 
   constructor(
     private route: ActivatedRoute,
@@ -121,7 +123,8 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
     private actionsSubj: ActionsSubject,
     private jwtService: JwtService,
     private snackBar: MatSnackBarComponent,
-    private modalService: BsModalService
+    private modalService: BsModalService,
+    private userFriendsService: UserFriendsService
   ) {}
 
   ngOnInit(): void {
@@ -133,7 +136,9 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
     this.localStorageService.userIdBehaviourSubject.subscribe((id) => {
       this.userId = Number(id);
     });
-
+    this.userFriendsService.getAllFriendsByUserId(this.userId).subscribe((res) => {
+      this.isEventOrginizerFriend = res.some((el) => el.id === this.userId);
+    });
     this.eventService.getEventById(this.eventId).subscribe((res: EventPageResponceDto) => {
       this.event = res;
       this.locationLink = this.event.dates[this.event.dates.length - 1].onlineLink;

--- a/src/app/main/component/events/components/events-list/events-list.component.html
+++ b/src/app/main/component/events/components/events-list/events-list.component.html
@@ -100,7 +100,7 @@
     </div>
     <div class="event-list">
       <mat-card class="event-list-item" *ngFor="let eventItem of eventsList">
-        <app-events-list-item [event]="eventItem" [userId]="userId"></app-events-list-item>
+        <app-events-list-item [event]="eventItem" [userId]="userId" [userFriends]="userFriends"></app-events-list-item>
       </mat-card>
     </div>
     <app-spinner *ngIf="elementsArePresent"></app-spinner>

--- a/src/app/main/component/events/components/events-list/events-list.component.ts
+++ b/src/app/main/component/events/components/events-list/events-list.component.ts
@@ -15,6 +15,9 @@ import { MatDialog } from '@angular/material/dialog';
 import { FormControl } from '@angular/forms';
 import { MatSelect } from '@angular/material/select';
 import { MatOption } from '@angular/material/core';
+import { UserFriendsService } from '@global-user/services/user-friends.service';
+import { FriendModel } from '@global-user/models/friend.model';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-events-list',
@@ -55,6 +58,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
   public scroll: boolean;
   public userId: number;
   private dialog: MatDialog;
+  private userFriendsList: FriendModel[];
 
   constructor(
     private store: Store,
@@ -62,7 +66,8 @@ export class EventsListComponent implements OnInit, OnDestroy {
     private languageService: LanguageService,
     private localStorageService: LocalStorageService,
     private router: Router,
-    public injector: Injector
+    public injector: Injector,
+    private userFriendsService: UserFriendsService
   ) {
     this.dialog = injector.get(MatDialog);
   }
@@ -86,6 +91,17 @@ export class EventsListComponent implements OnInit, OnDestroy {
         this.eventLocationList = this.getUniqueCities(this.eventsList);
       }
     });
+    this.getUserFriendsList();
+  }
+
+  getUserFriendsList() {
+    this.userFriendsService
+      .getAllFriendsByUserID(this.userId)
+      .pipe(takeUntil(this.destroyed$))
+      .subscribe((res) => {
+        this.userFriendsList = res;
+        this.userFriendsService.allUserFriends = res;
+      });
   }
 
   updateSelectedFilters(value: any, event): void {

--- a/src/app/main/component/events/components/events-list/events-list.component.ts
+++ b/src/app/main/component/events/components/events-list/events-list.component.ts
@@ -96,7 +96,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
 
   getUserFriendsList() {
     this.userFriendsService
-      .getAllFriendsByUserID(this.userId)
+      .getAllFriendsByUserId(this.userId)
       .pipe(takeUntil(this.destroyed$))
       .subscribe((res) => {
         this.userFriendsList = res;

--- a/src/app/main/component/events/components/events-list/events-list.component.ts
+++ b/src/app/main/component/events/components/events-list/events-list.component.ts
@@ -58,7 +58,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
   public scroll: boolean;
   public userId: number;
   private dialog: MatDialog;
-  private userFriendsList: FriendModel[];
+  userFriends: FriendModel[];
 
   constructor(
     private store: Store,
@@ -94,13 +94,12 @@ export class EventsListComponent implements OnInit, OnDestroy {
     this.getUserFriendsList();
   }
 
-  getUserFriendsList() {
+  getUserFriendsList(): void {
     this.userFriendsService
       .getAllFriendsByUserId(this.userId)
       .pipe(takeUntil(this.destroyed$))
       .subscribe((res) => {
-        this.userFriendsList = res;
-        this.userFriendsService.allUserFriends = res;
+        this.userFriends = res;
       });
   }
 

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
@@ -20,6 +20,7 @@ import { LanguageService } from 'src/app/main/i18n/language.service';
 import { AddAttenderEcoEventsByIdAction, RemoveAttenderEcoEventsByIdAction } from 'src/app/store/actions/ecoEvents.actions';
 import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
+import { UserFriendsService } from '@global-user/services/user-friends.service';
 
 @Injectable()
 class TranslationServiceStub {
@@ -207,7 +208,8 @@ describe('EventsListItemComponent', () => {
         { provide: LanguageService, useValue: languageServiceMock },
         { provide: TranslateService, useClass: TranslationServiceStub },
         { provide: UserOwnAuthService, useValue: userOwnAuthServiceMock },
-        { provide: MatSnackBarComponent, useValue: MatSnackBarMock }
+        { provide: MatSnackBarComponent, useValue: MatSnackBarMock },
+        { provide: UserFriendsService, useValue: { allUserFriends: [] } }
       ],
       imports: [
         RouterTestingModule,

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
@@ -115,6 +115,10 @@ describe('EventsListItemComponent', () => {
     open: true
   };
 
+  const userFriendsServiceMock = {
+    allUserFriends: [{ id: 7, name: 'friend', email: 'friend@friend.com' }]
+  };
+
   const fakeItemTags: TagObj[] = [
     {
       nameEn: 'Environmental',
@@ -209,7 +213,7 @@ describe('EventsListItemComponent', () => {
         { provide: TranslateService, useClass: TranslationServiceStub },
         { provide: UserOwnAuthService, useValue: userOwnAuthServiceMock },
         { provide: MatSnackBarComponent, useValue: MatSnackBarMock },
-        { provide: UserFriendsService, useValue: { allUserFriends: [] } }
+        { provide: UserFriendsService, useValue: userFriendsServiceMock }
       ],
       imports: [
         RouterTestingModule,
@@ -328,6 +332,20 @@ describe('EventsListItemComponent', () => {
       component.ngOnInit();
       expect(component.bindLang).toHaveBeenCalled();
     });
+
+    it('should call checkCanUserJoinEvent', () => {
+      spyOn(component, 'checkCanUserJoinEvent');
+      component.ngOnInit();
+      expect(component.checkCanUserJoinEvent).toHaveBeenCalled();
+    });
+  });
+
+  describe('checkCanUserJoinEvent', () => {
+    it('it should check is organizer of close event a user"s friend', () => {
+      component.event = { ...eventMock, ...{ open: false } };
+      component.checkCanUserJoinEvent();
+      expect(component.canUserJoinEvent).toBe(false);
+    });
   });
 
   describe('CheckButtonStatus', () => {
@@ -369,6 +387,16 @@ describe('EventsListItemComponent', () => {
       component.checkButtonStatus();
       expect(component.btnStyle).toEqual(component.styleBtn.primary);
       expect(component.nameBtn).toEqual(component.btnName.join);
+    });
+
+    it('should set btnStyle  correctly when user can"t joint close event', () => {
+      eventMock.isSubscribed = false;
+      component.event = eventMock;
+      component.event.organizer.id = 56;
+      component.canUserJoinEvent = false;
+      spyOn(component, 'checkIsActive').and.returnValue(false);
+      component.checkButtonStatus();
+      expect(component.btnStyle).toEqual(component.styleBtn.hiden);
     });
 
     it('should set btnStyle and nameBtn correctly when user is subscribed and event is unactive', () => {

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
@@ -114,10 +114,8 @@ describe('EventsListItemComponent', () => {
     isActive: true,
     open: true
   };
-
-  const userFriendsServiceMock = {
-    allUserFriends: [{ id: 7, name: 'friend', email: 'friend@friend.com' }]
-  };
+  const userFriendsServiceMock = jasmine.createSpyObj('UserFriendsService', ['getAllFriendsByUserId']);
+  userFriendsServiceMock.getAllFriendsByUserId = () => of([]);
 
   const fakeItemTags: TagObj[] = [
     {
@@ -332,19 +330,14 @@ describe('EventsListItemComponent', () => {
       component.ngOnInit();
       expect(component.bindLang).toHaveBeenCalled();
     });
-
-    it('should call checkCanUserJoinEvent', () => {
-      spyOn(component, 'checkCanUserJoinEvent');
-      component.ngOnInit();
-      expect(component.checkCanUserJoinEvent).toHaveBeenCalled();
-    });
   });
 
   describe('checkCanUserJoinEvent', () => {
     it('it should check is organizer of close event a user"s friend', () => {
       component.event = { ...eventMock, ...{ open: false } };
-      component.checkCanUserJoinEvent();
-      expect(component.canUserJoinEvent).toBe(false);
+      component.userFriends = [];
+      component.ngOnChanges();
+      expect(component.canUserJoinCloseEvent).toBe(false);
     });
   });
 
@@ -384,6 +377,7 @@ describe('EventsListItemComponent', () => {
       component.event = eventMock;
       component.event.organizer.id = 56;
       spyOn(component, 'checkIsActive').and.returnValue(true);
+      component.canUserJoinCloseEvent = true;
       component.checkButtonStatus();
       expect(component.btnStyle).toEqual(component.styleBtn.primary);
       expect(component.nameBtn).toEqual(component.btnName.join);
@@ -393,7 +387,7 @@ describe('EventsListItemComponent', () => {
       eventMock.isSubscribed = false;
       component.event = eventMock;
       component.event.organizer.id = 56;
-      component.canUserJoinEvent = false;
+      component.canUserJoinCloseEvent = false;
       spyOn(component, 'checkIsActive').and.returnValue(false);
       component.checkButtonStatus();
       expect(component.btnStyle).toEqual(component.styleBtn.hiden);

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
@@ -114,8 +114,6 @@ describe('EventsListItemComponent', () => {
     isActive: true,
     open: true
   };
-  const userFriendsServiceMock = jasmine.createSpyObj('UserFriendsService', ['getAllFriendsByUserId']);
-  userFriendsServiceMock.getAllFriendsByUserId = () => of([]);
 
   const fakeItemTags: TagObj[] = [
     {
@@ -210,8 +208,7 @@ describe('EventsListItemComponent', () => {
         { provide: LanguageService, useValue: languageServiceMock },
         { provide: TranslateService, useClass: TranslationServiceStub },
         { provide: UserOwnAuthService, useValue: userOwnAuthServiceMock },
-        { provide: MatSnackBarComponent, useValue: MatSnackBarMock },
-        { provide: UserFriendsService, useValue: userFriendsServiceMock }
+        { provide: MatSnackBarComponent, useValue: MatSnackBarMock }
       ],
       imports: [
         RouterTestingModule,

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
@@ -25,7 +25,6 @@ import { LanguageService } from 'src/app/main/i18n/language.service';
 import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
 import { MaxTextLengthPipe } from 'src/app/ubs/ubs-admin/components/shared/max-text-length/max-text-length.pipe';
-import { UserFriendsService } from '@global-user/services/user-friends.service';
 import { FriendModel } from '@global-user/models/friend.model';
 
 @Component({
@@ -111,8 +110,7 @@ export class EventsListItemComponent implements OnChanges, OnInit, OnDestroy {
     private eventService: EventsService,
     private translate: TranslateService,
     private snackBar: MatSnackBarComponent,
-    private maxTextLengthPipe: MaxTextLengthPipe,
-    private userFriendsService: UserFriendsService
+    private maxTextLengthPipe: MaxTextLengthPipe
   ) {}
 
   ngOnChanges() {

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
@@ -25,6 +25,7 @@ import { LanguageService } from 'src/app/main/i18n/language.service';
 import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
 import { MaxTextLengthPipe } from 'src/app/ubs/ubs-admin/components/shared/max-text-length/max-text-length.pipe';
+import { UserFriendsService } from '@global-user/services/user-friends.service';
 
 @Component({
   selector: 'app-events-list-item',
@@ -79,6 +80,7 @@ export class EventsListItemComponent implements OnInit, OnDestroy {
     popupCancel: 'homepage.events.delete-no',
     style: 'red'
   };
+  canUserJoinEvent: boolean;
 
   @Output() public isLoggedIn: boolean;
 
@@ -107,7 +109,8 @@ export class EventsListItemComponent implements OnInit, OnDestroy {
     private eventService: EventsService,
     private translate: TranslateService,
     private snackBar: MatSnackBarComponent,
-    private maxTextLengthPipe: MaxTextLengthPipe
+    private maxTextLengthPipe: MaxTextLengthPipe,
+    private userFriendsService: UserFriendsService
   ) {}
 
   ngOnInit(): void {
@@ -121,12 +124,18 @@ export class EventsListItemComponent implements OnInit, OnDestroy {
     this.getAllAttendees();
     this.bindLang(this.localStorageService.getCurrentLanguage());
     this.initAllStatusesOfEvent();
+    this.checkCanUserJoinEvent();
     this.checkButtonStatus();
     this.address = this.event.dates[this.event.dates.length - 1].coordinates;
     this.isOnline = this.event.dates[this.event.dates.length - 1].onlineLink;
     this.ecoEvents$.subscribe((res: IEcoEventsState) => {
       this.addAttenderError = res.error;
     });
+  }
+
+  checkCanUserJoinEvent() {
+    const friends = this.userFriendsService.allUserFriends;
+    this.canUserJoinEvent = friends.some((el) => el.id === this.event.organizer.id) || this.event.open;
   }
 
   public routeToEvent(): void {
@@ -168,7 +177,7 @@ export class EventsListItemComponent implements OnInit, OnDestroy {
       return;
     }
     if (!isSubscribe && this.isActive && !this.isOwner) {
-      this.btnStyle = this.styleBtn.primary;
+      this.btnStyle = this.canUserJoinEvent ? this.styleBtn.primary : this.styleBtn.hiden;
       this.nameBtn = this.btnName.join;
       return;
     }

--- a/src/app/main/component/user/models/friend.model.ts
+++ b/src/app/main/component/user/models/friend.model.ts
@@ -9,6 +9,9 @@ export interface FriendModel {
   mutualFriends?: number | string;
   friendStatus: string;
   chatId?: number;
+  role?: string;
+  userCredo?: string;
+  userStatus?: string;
 }
 
 export interface FriendArrayModel {

--- a/src/app/main/component/user/services/user-friends.service.spec.ts
+++ b/src/app/main/component/user/services/user-friends.service.spec.ts
@@ -56,6 +56,25 @@ describe('UserFriendsService', () => {
     });
   });
 
+  describe('getAllFriendsByUserId', () => {
+    it('should return an FriendArrayModel', () => {
+      const allFriendsriends = [
+        {
+          id: 5,
+          name: 'friend',
+          emal: 'friend@friend.com'
+        }
+      ];
+      userFriendsService.getAllFriendsByUserId(5).subscribe((users) => {
+        expect(users.length).toBe(1);
+      });
+
+      const req = httpMock.expectOne(`${userFriendsService.urlFriend}friends/user/5`);
+      expect(req.request.method).toBe('GET');
+      req.flush(allFriendsriends);
+    });
+  });
+
   describe('getNewFriends', () => {
     it('should return an object on calling getNewFriends', () => {
       const possibleFriends = {

--- a/src/app/main/component/user/services/user-friends.service.ts
+++ b/src/app/main/component/user/services/user-friends.service.ts
@@ -11,6 +11,7 @@ import { Observable } from 'rxjs';
 })
 export class UserFriendsService {
   addedFriends: FriendModel[] = [];
+  allUserFriends: FriendModel[] = [];
   private size = 10;
   public url: string = environment.backendUserLink;
   public urlFriend: string = environment.backendLink;
@@ -40,6 +41,10 @@ export class UserFriendsService {
 
   public getAllFriends(page = 0, size = this.size): Observable<FriendArrayModel> {
     return this.http.get<FriendArrayModel>(`${this.urlFriend}friends?page=${page}&size=${size}`);
+  }
+
+  public getAllFriendsByUserID(userId: number): Observable<FriendModel[]> {
+    return this.http.get<FriendModel[]>(`${this.urlFriend}friends/user/${userId}`);
   }
 
   public getNewFriends(name = '', page = 0, size = this.size): Observable<FriendArrayModel> {

--- a/src/app/main/component/user/services/user-friends.service.ts
+++ b/src/app/main/component/user/services/user-friends.service.ts
@@ -43,7 +43,7 @@ export class UserFriendsService {
     return this.http.get<FriendArrayModel>(`${this.urlFriend}friends?page=${page}&size=${size}`);
   }
 
-  public getAllFriendsByUserID(userId: number): Observable<FriendModel[]> {
+  public getAllFriendsByUserId(userId: number): Observable<FriendModel[]> {
     return this.http.get<FriendModel[]>(`${this.urlFriend}friends/user/${userId}`);
   }
 


### PR DESCRIPTION
# Bugfix/#5700 Events. join button is visible for a close event (only organizer's friends can join)


## Summary Of Changes :fire:
Added list of user's friends to check if the organizer is a friend

## Issue Link :clipboard:
[Bug 5700](https://github.com/ita-social-projects/GreenCity/issues/5700)

## Added
* method getAllFriendsByUserId in UserFriendService
* method which checks can user join a close event
*  join button is hidden if an event is close and the user and organizer aren't friends 

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
