### PR TITLE
Feature&Bugs/#5899#6156 #6164/Default display in "set start time" field current time + one hour is not shown. "All day" option doesn't set 00 am to 12 pm. The end time of the event disappears when the userre-select the "All Day" check box 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "prettier.enable": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "prettier.enable": true
-}

--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.html
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.html
@@ -62,6 +62,7 @@
                 [editDate]="editEvent?.dates[i]"
                 [isDateDuplicate]="isDateDuplicate"
                 [editDates]="editDates"
+                [firstFormIsSucceed]="firstFormIsSucceed"
               >
               </app-event-date-time-picker>
               <div *ngIf="i === duplindx" class="tag-error">{{ 'create-event.duplicate-event-date' | translate }}</div>

--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
@@ -91,7 +91,7 @@ export class CreateEditEventsComponent extends FormBaseComponent implements OnIn
       popupCancel: 'homepage.events.events-popup.cancel'
     }
   };
-
+  public firstFormIsSucceed = true;
   public backRoute: string;
   public routedFromProfile: boolean;
   public duplindx: number;
@@ -218,6 +218,7 @@ export class CreateEditEventsComponent extends FormBaseComponent implements OnIn
   }
 
   public setDateCount(value: number): void {
+    this.firstFormIsSucceed = false;
     if ((this.dates.length === 1 && !this.dates[0].date) || this.editMode) {
       this.dates = Array(value)
         .fill(null)

--- a/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.html
+++ b/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.html
@@ -7,7 +7,7 @@
       <mat-datepicker #picker></mat-datepicker>
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="time-item">
+    <mat-form-field appearance="outline" class="time-item" (click)="canUpdateTimeArrays()">
       <mat-label>{{ 'create-event.set-start-time' | translate }}</mat-label>
       <mat-select ngDefaultControl formControlName="startTime">
         <mat-option *ngFor="let time of timeArrStart" [value]="time">

--- a/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.spec.ts
+++ b/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.spec.ts
@@ -108,9 +108,10 @@ describe('EventDateTimePickerComponent', () => {
   });
 
   it('component should initialize from with correct parameters', () => {
+    const startTime = new Date().getHours() + 1 !== 24 ? (new Date().getHours() + 1).toLocaleString() + ':00' : '0:00';
     component.ngOnInit();
-    expect(component.dateForm.get('date').value).toEqual('');
-    expect(component.dateForm.get('startTime').value).toEqual('');
+    expect(component.dateForm.get('date').value).toEqual(new Date());
+    expect(component.dateForm.get('startTime').value).toEqual(startTime);
     expect(component.dateForm.get('endTime').value).toEqual('');
   });
 

--- a/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.spec.ts
+++ b/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.spec.ts
@@ -176,8 +176,8 @@ describe('EventDateTimePickerComponent', () => {
     expect(component.timeArrStart.length).toBe(21);
   });
 
-  it('checkStartTime expect timeArrEnd length to be 2', () => {
+  it('checkStartTime expect timeArrEnd length to be 3', () => {
     (component as any).checkStartTime('21:00');
-    expect(component.timeArrEnd.length).toBe(2);
+    expect(component.timeArrEnd.length).toBe(3);
   });
 });

--- a/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.ts
+++ b/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.ts
@@ -304,8 +304,10 @@ export class EventDateTimePickerComponent implements OnInit, OnChanges {
 
   private checkEndTime(time: string, curTime?: number): void {
     const checkTime = time.split(':')[0] === '00' ? 24 : Number(time.split(':')[0]);
-    if (curTime === 23) curTime -= 1;
-    if (!time || (!curTime && checkTime[0] === '00')) return;
+    curTime === 23 ? (curTime -= 1) : null;
+    if (!time || (!curTime && checkTime[0] === '00')) {
+      return;
+    }
     this.timeArrStart = curTime !== null ? [...this.timeArr.slice(curTime + 1, checkTime)] : [...this.timeArr.slice(0, checkTime)];
   }
 
@@ -331,7 +333,9 @@ export class EventDateTimePickerComponent implements OnInit, OnChanges {
 
   private updateTimeArrays(startTime: string, endTime: string): void {
     this.fillTimeArray();
-    if (this.checkAllDay) return;
+    if (this.checkAllDay) {
+      return;
+    }
     if (this.checkDay()) {
       const curTime = new Date().getHours();
       this.timeArrStart = curTime === 23 ? ['23:00'] : [...this.timeArr.slice(curTime + 1, 24)];

--- a/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.ts
+++ b/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.ts
@@ -49,6 +49,7 @@ export class EventDateTimePickerComponent implements OnInit, OnChanges {
   @Input() editDate: DateEventResponceDto;
   @Input() isDateDuplicate: boolean;
   @Input() editDates: boolean;
+  @Input() firstFormIsSucceed: boolean = true;
 
   @Output() status = new EventEmitter<boolean>();
   @Output() datesForm = new EventEmitter<DateFormObj>();
@@ -75,9 +76,23 @@ export class EventDateTimePickerComponent implements OnInit, OnChanges {
     this.minDate.setDate(curDay);
     this.fillTimeArray();
 
+    let initialDate: any = '';
+    let initialStartTime: any = '';
+
+    if (this.firstFormIsSucceed) {
+      initialDate = new Date();
+
+      const currentHour = initialDate.getHours();
+      if (currentHour + 1 !== 24) {
+        initialStartTime = (currentHour + 1).toLocaleString() + ':00';
+      } else {
+        initialStartTime = '0:00';
+      }
+    }
+
     this.dateForm = new FormGroup({
-      date: new FormControl('', [Validators.required]),
-      startTime: new FormControl('', [Validators.required]),
+      date: new FormControl(initialDate, [Validators.required]),
+      startTime: new FormControl(initialStartTime, [Validators.required]),
       endTime: new FormControl('', [Validators.required])
     });
 

--- a/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.ts
+++ b/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.ts
@@ -49,7 +49,7 @@ export class EventDateTimePickerComponent implements OnInit, OnChanges {
   @Input() editDate: DateEventResponceDto;
   @Input() isDateDuplicate: boolean;
   @Input() editDates: boolean;
-  @Input() firstFormIsSucceed: boolean = true;
+  @Input() firstFormIsSucceed = true;
 
   @Output() status = new EventEmitter<boolean>();
   @Output() datesForm = new EventEmitter<DateFormObj>();

--- a/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.ts
+++ b/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.ts
@@ -304,9 +304,11 @@ export class EventDateTimePickerComponent implements OnInit, OnChanges {
 
   private checkEndTime(time: string, curTime?: number): void {
     const checkTime = time.split(':')[0] === '00' ? 24 : Number(time.split(':')[0]);
-    curTime === 23 ? (curTime -= 1) : null;
     if (!time || (!curTime && checkTime[0] === '00')) {
       return;
+    }
+    if (curTime === 23) {
+      curTime -= 1;
     }
     this.timeArrStart = curTime !== null ? [...this.timeArr.slice(curTime + 1, checkTime)] : [...this.timeArr.slice(0, checkTime)];
   }

--- a/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.ts
+++ b/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.ts
@@ -118,10 +118,9 @@ export class EventDateTimePickerComponent implements OnInit, OnChanges {
   private initialStartTime(): any {
     let initialDate: Date;
     let initialStartTime = '';
-    let currentHour;
     if (this.firstFormIsSucceed) {
       initialDate = new Date();
-      currentHour = new Date().getHours();
+      const currentHour = new Date().getHours();
       if (currentHour + 1 !== 24) {
         initialStartTime = `${currentHour + 1}:00`;
       } else {

--- a/src/app/main/component/events/models/events.interface.ts
+++ b/src/app/main/component/events/models/events.interface.ts
@@ -141,12 +141,6 @@ export interface DateFormObj {
   startTime?: string;
 }
 
-export interface PaginationInterface {
-  itemsPerPage: number;
-  currentPage: number;
-  totalItems: number;
-}
-
 export interface PagePreviewDTO {
   title: string;
   description: string;
@@ -155,4 +149,9 @@ export interface PagePreviewDTO {
   tags: Array<string>;
   imgArray: any[];
   location: DateFormObj;
+}
+
+export interface InitialStartDate {
+  initialDate: Date;
+  initialStartTime: string;
 }


### PR DESCRIPTION
Made default display in "set start time" field current time + one hour. By default date is current date
[#5899](https://github.com/ita-social-projects/GreenCity/issues/5899)
[#6156](https://github.com/ita-social-projects/GreenCity/issues/6156)
[#6164](https://www.google.com/url?q=https://github.com/ita-social-projects/GreenCity/issues/6164&sa=D&source=editors&ust=1695907308316125&usg=AOvVaw2LFR_DwyDNy72LHFFtX6SQ)