### PR TITLE
Bugfix/#6468#6563#6525/User is not able to change the location of an event after creation of the event. Some events' locations contain null-s

### DIFF
--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.ts
@@ -266,7 +266,6 @@ export class CreateEditEventsComponent extends FormBaseComponent implements OnIn
 
   public getImageTosend(imageArr: Array<File>): void {
     this.imgArray = [...imageArr];
-    this.checkFileExtensionAndSize(imageArr);
   }
 
   public getImagesToDelete(imagesSrc: Array<string>): void {
@@ -445,11 +444,6 @@ export class CreateEditEventsComponent extends FormBaseComponent implements OnIn
 
   private getUserId() {
     this.userId = this.localStorageService.getUserId();
-  }
-
-  private checkFileExtensionAndSize(file: any): void {
-    this.isImageSizeError = file.size >= 10485760;
-    this.isImageTypeError = !(file.type === 'image/jpeg' || file.type === 'image/png');
   }
 
   public getLangValue(uaValue: string, enValue: string): string {

--- a/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.spec.ts
+++ b/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.spec.ts
@@ -22,19 +22,22 @@ describe('EventDateTimePickerComponent', () => {
   localStorageServiceMock.getCurrentLanguage = () => 'en' as Language;
   localStorageServiceMock.languageBehaviourSubject = new BehaviorSubject('en');
 
-  const languageServiceMock = jasmine.createSpyObj('languageService', ['getLangValue']);
+  const languageServiceMock = jasmine.createSpyObj('languageService', ['getLangValue', 'getCurrentLangObs']);
   languageServiceMock.getLangValue.and.returnValue(['fakeValue']);
+  languageServiceMock.getCurrentLangObs.and.returnValue(of('fakeValue'));
 
   const EventsServiceMock = jasmine.createSpyObj('EventsService', [
-    'createAdresses',
+    'createAddresses',
     'setArePlacesFilled',
     'getCheckedPlacesObservable',
-    'setInitialValueForPlaces'
+    'setInitialValueForPlaces',
+    'getFormattedAddress'
   ]);
-  EventsServiceMock.createAdresses = () => of('');
+  EventsServiceMock.createAddresses = () => of('');
   EventsServiceMock.setArePlacesFilled = () => of('');
   EventsServiceMock.setInitialValueForPlaces = () => of('');
   EventsServiceMock.getCheckedPlacesObservable = () => of([]);
+  EventsServiceMock.getFormattedAddress = () => of('Mocked formatted address');
 
   const editDateMock = {
     coordinates: {
@@ -48,7 +51,9 @@ describe('EventDateTimePickerComponent', () => {
       regionEn: 'Lvivska oblast',
       regionUa: 'Львівська область',
       streetEn: 'Svobody Ave',
-      streetUa: 'Свободи'
+      streetUa: 'Свободи',
+      formattedAddressEn: 'Свободи, 55, Львів, Львівська область, Україна',
+      formattedAddressUa: 'Svobody Ave, 55, Lviv, Lvivska oblast, Ukraine'
     },
     event: 'event',
     finishDate: '2023-05-27T15:23:59+03:00',

--- a/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.ts
+++ b/src/app/main/component/events/components/event-date-time-picker/event-date-time-picker.component.ts
@@ -163,7 +163,7 @@ export class EventDateTimePickerComponent implements OnInit, OnChanges, OnDestro
       this.zoom = 8;
 
       this.dateForm.patchValue({
-        place: this.eventsService.getFormattedAdress(this.editDate.coordinates),
+        place: this.eventsService.getFormattedAddress(this.editDate.coordinates),
         coordinatesDto: { latitude: this.editDate.coordinates.latitude, longitude: this.editDate.coordinates.longitude }
       });
 
@@ -183,7 +183,7 @@ export class EventDateTimePickerComponent implements OnInit, OnChanges, OnDestro
 
   public getCoordinates(): void {
     if (this.editDate) {
-      this.dateForm.patchValue({ place: this.eventsService.getFormattedAdress(this.editDate.coordinates) });
+      this.dateForm.patchValue({ place: this.eventsService.getFormattedAddress(this.editDate.coordinates) });
     }
   }
 
@@ -270,7 +270,6 @@ export class EventDateTimePickerComponent implements OnInit, OnChanges, OnDestro
     this.mapsAPILoader.load().then(() => {
       this.setCurrentLocation();
       this.autocomplete = new google.maps.places.Autocomplete(this.placesRef.nativeElement, this.regionOptions);
-
       this.autocomplete.addListener('place_changed', () => {
         const locationName = this.autocomplete.getPlace();
         if (locationName.formatted_address) {

--- a/src/app/main/component/events/components/event-details/event-details.component.html
+++ b/src/app/main/component/events/components/event-details/event-details.component.html
@@ -93,10 +93,10 @@
                   <img [src]="icons.location" alt="" />
                 </div>
                 <div>
-                  {{ locationAddress ? locationAddress : locationLink }}
+                  {{ locationCoordinates ? getAddress() : locationLink }}
                 </div>
               </div>
-              <div *ngIf="locationAddress && locationLink" class="event-link">
+              <div *ngIf="locationCoordinates && locationLink" class="event-link">
                 <div class="event-link-icon">
                   <img [src]="icons.link" alt="" />
                 </div>

--- a/src/app/main/component/events/components/event-details/event-details.component.spec.ts
+++ b/src/app/main/component/events/components/event-details/event-details.component.spec.ts
@@ -80,11 +80,18 @@ describe('EventDetailsComponent', () => {
   const storeMock = jasmine.createSpyObj('store', ['select', 'dispatch']);
   storeMock.select = () => of(MockData);
 
-  const EventsServiceMock = jasmine.createSpyObj('eventService', ['getEventById ', 'deleteEvent', 'getAllAttendees', 'createAdresses']);
+  const EventsServiceMock = jasmine.createSpyObj('eventService', [
+    'getEventById ',
+    'deleteEvent',
+    'getAllAttendees',
+    'createAddresses',
+    'getFormattedAddress'
+  ]);
   EventsServiceMock.getEventById = () => of(eventMock);
   EventsServiceMock.deleteEvent = () => of(true);
   EventsServiceMock.getAllAttendees = () => of([]);
-  EventsServiceMock.createAdresses = () => of('');
+  EventsServiceMock.createAddresses = () => of('');
+  EventsServiceMock.getFormattedAddress = () => of('');
 
   const jwtServiceFake = jasmine.createSpyObj('jwtService', ['getUserRole']);
   jwtServiceFake.getUserRole = () => '123';
@@ -177,13 +184,10 @@ describe('EventDetailsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should call methods on ngOnInit', () => {
-    const spy1 = spyOn(component as any, 'bindLang');
-    const spy2 = spyOn(component as any, 'verifyRole');
+  it('should call verifyRole on ngOnInit', () => {
+    const spy1 = spyOn(component as any, 'verifyRole');
     component.ngOnInit();
     expect(spy1).toHaveBeenCalled();
-    expect(spy1).toHaveBeenCalledWith('ua');
-    expect(spy2).toHaveBeenCalled();
   });
 
   it('should verify unauthenticated role', () => {

--- a/src/app/main/component/events/components/event-details/event-details.component.ts
+++ b/src/app/main/component/events/components/event-details/event-details.component.ts
@@ -13,7 +13,7 @@ import {
   EventsActions,
   RemoveAttenderEcoEventsByIdAction
 } from 'src/app/store/actions/ecoEvents.actions';
-import { EventPageResponceDto } from '../../models/events.interface';
+import { Coordinates, EventPageResponceDto } from '../../models/events.interface';
 import { EventsService } from '../../services/events.service';
 import { MapEventComponent } from '../map-event/map-event.component';
 import { JwtService } from '@global-service/jwt/jwt.service';
@@ -74,7 +74,7 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
   public isAdmin = false;
   public event: EventPageResponceDto;
   public locationLink: string;
-  public locationAddress: string;
+  public locationCoordinates: Coordinates;
   public addressUa: string;
   public addressEn: string;
 
@@ -99,7 +99,6 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
   public address = 'Should be adress';
 
   public maxRating = 5;
-  public currentLang: string;
   private destroy: Subject<boolean> = new Subject<boolean>();
 
   public backRoute: string;
@@ -143,9 +142,7 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
     this.eventService.getEventById(this.eventId).subscribe((res: EventPageResponceDto) => {
       this.event = res;
       this.locationLink = this.event.dates[this.event.dates.length - 1].onlineLink;
-      this.addressUa = this.eventService.createAdresses(this.event.dates[this.event.dates.length - 1].coordinates, 'Ua');
-      this.addressEn = this.eventService.createAdresses(this.event.dates[this.event.dates.length - 1].coordinates, 'En');
-      this.locationAddress = this.getLangValue(this.addressUa, this.addressEn);
+      this.locationCoordinates = this.event.dates[this.event.dates.length - 1].coordinates;
       this.images = [res.titleImage, ...res.additionalImages];
       this.rate = Math.round(this.event.organizer.organizerRating);
       this.mapDialogData = {
@@ -162,13 +159,6 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
       });
     });
 
-    this.currentLang = this.localStorageService.getCurrentLanguage();
-    this.localStorageService.languageBehaviourSubject.pipe(takeUntil(this.destroy)).subscribe((lang: string) => {
-      this.currentLang = lang;
-      this.bindLang(this.currentLang);
-      this.locationAddress = this.getLangValue(this.addressUa, this.addressEn);
-    });
-
     this.localStorageService.setEditMode('canUserEdit', true);
 
     this.eventService.getAllAttendees(this.eventId).subscribe((attendees) => {
@@ -182,8 +172,8 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
     this.backRoute = this.localStorageService.getPreviousPage();
   }
 
-  private bindLang(lang: string): void {
-    this.translate.setDefaultLang(lang);
+  public getAddress(): string {
+    return this.eventService.getFormattedAdress(this.locationCoordinates);
   }
 
   private verifyRole(): string {
@@ -238,7 +228,7 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
       });
   }
 
-  public getLangValue(uaValue, enValue): string {
+  public getLangValue(uaValue: string, enValue: string): string {
     return this.langService.getLangValue(uaValue, enValue) as string;
   }
 

--- a/src/app/main/component/events/components/event-details/event-details.component.ts
+++ b/src/app/main/component/events/components/event-details/event-details.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { ofType } from '@ngrx/effects';
 import { ActionsSubject, Store } from '@ngrx/store';
-import { take, takeUntil } from 'rxjs/operators';
+import { take } from 'rxjs/operators';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { DialogPopUpComponent } from 'src/app/shared/dialog-pop-up/dialog-pop-up.component';
 import {

--- a/src/app/main/component/events/components/event-details/event-details.component.ts
+++ b/src/app/main/component/events/components/event-details/event-details.component.ts
@@ -173,7 +173,7 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
   }
 
   public getAddress(): string {
-    return this.eventService.getFormattedAdress(this.locationCoordinates);
+    return this.eventService.getFormattedAddress(this.locationCoordinates);
   }
 
   private verifyRole(): string {

--- a/src/app/main/component/events/components/events-list/events-list.component.spec.ts
+++ b/src/app/main/component/events/components/events-list/events-list.component.spec.ts
@@ -61,7 +61,9 @@ describe('EventsListComponent', () => {
             regionEn: 'Lvivska oblast',
             regionUa: 'Львівська область',
             streetEn: 'Svobody Ave',
-            streetUa: 'Свободи'
+            streetUa: 'Свободи',
+            formattedAddressEn: 'Свободи, 55, Львів, Львівська область, Україна',
+            formattedAddressUa: 'Svobody Ave, 55, Lviv, Lvivska oblast, Ukraine'
           }
         }
       ],
@@ -115,7 +117,9 @@ describe('EventsListComponent', () => {
             regionEn: 'Lvivska oblast',
             regionUa: 'Львівська область',
             streetEn: 'Svobody Ave',
-            streetUa: 'Свободи'
+            streetUa: 'Свободи',
+            formattedAddressEn: 'Свободи, 55, Львів, Львівська область, Україна',
+            formattedAddressUa: 'Svobody Ave, 55, Lviv, Lvivska oblast, Ukraine'
           }
         }
       ],
@@ -191,8 +195,8 @@ describe('EventsListComponent', () => {
   const statusFilterControl = new FormControl();
   const typeFilterControl = new FormControl();
 
-  const EventsServiceMock = jasmine.createSpyObj('EventsService', ['createAdresses', 'getAddreses']);
-  EventsServiceMock.createAdresses = () => of('');
+  const EventsServiceMock = jasmine.createSpyObj('EventsService', ['createAddresses', 'getAddreses']);
+  EventsServiceMock.createAddresses = () => of('');
   EventsServiceMock.getAddreses = () => of(addressesMock);
 
   const UserOwnAuthServiceMock = jasmine.createSpyObj('UserOwnAuthService', ['getDataFromLocalStorage', 'credentialDataSubject']);

--- a/src/app/main/component/events/components/images-container/images-container.component.spec.ts
+++ b/src/app/main/component/events/components/images-container/images-container.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { TranslateService } from '@ngx-translate/core';
 import { ImagesContainerComponent } from './images-container.component';
 import { CUSTOM_ELEMENTS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
 import { FileHandle } from 'src/app/ubs/ubs-admin/models/file-handle.model';
@@ -17,6 +17,11 @@ describe('ImagesContainerComponent', () => {
   let component: ImagesContainerComponent;
   let fixture: ComponentFixture<ImagesContainerComponent>;
 
+  const translateServiceMock = {
+    setDefaultLang: () => {},
+    use: () => {}
+  };
+
   const files: FileHandle[] = [
     { url: 'http://', file: new File(['some content'], 'text-file.jpeg', { type: 'image/jpeg' }) },
     { url: 'http://', file: new File(['some content'], 'text-file.jpeg', { type: 'image/jpeg' }) }
@@ -31,7 +36,10 @@ describe('ImagesContainerComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ImagesContainerComponent, TranslatePipeMock],
       imports: [HttpClientTestingModule],
-      providers: [{ provide: MatSnackBarComponent, useValue: MatSnackBarMock }],
+      providers: [
+        { provide: MatSnackBarComponent, useValue: MatSnackBarMock },
+        { provide: TranslateService, useValue: translateServiceMock }
+      ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
   });
@@ -78,7 +86,6 @@ describe('ImagesContainerComponent', () => {
     component.editMode = true;
 
     expect((component as any).imgArray.length).toBe(1);
-    console.log(component.editMode);
   });
 
   it('assignImage expect images.src to be imageSrc', () => {

--- a/src/app/main/component/events/components/images-container/images-container.component.ts
+++ b/src/app/main/component/events/components/images-container/images-container.component.ts
@@ -74,10 +74,7 @@ export class ImagesContainerComponent implements OnInit, OnChanges {
   }
 
   private initImages(): void {
-    for (let i = 0; i < this.maxImages; i++) {
-      this.images.push({ src: null, label: this.dragAndDropLabel, isLabel: false });
-    }
-    this.images[0].isLabel = true;
+    this.images = Array.from({ length: this.maxImages }, (_, i) => ({ src: null, label: this.dragAndDropLabel, isLabel: i === 0 }));
   }
 
   public chooseImage(img: string) {
@@ -112,7 +109,6 @@ export class ImagesContainerComponent implements OnInit, OnChanges {
 
   private checkFileExtension(file: any): void {
     this.isImageSizeError = file.size >= 10000000;
-
     this.isImageTypeError = !(file.type === 'image/jpeg' || file.type === 'image/png');
   }
 
@@ -140,16 +136,11 @@ export class ImagesContainerComponent implements OnInit, OnChanges {
   }
 
   private assignImage(result: any): void {
-    for (let i = 0; i < this.images.length; i++) {
-      if (!this.images[i].src) {
-        this.images[i].src = result;
-        if (this.images[i + 1]) {
-          this.images[i + 1].isLabel = true;
-        }
-        this.images[i].isLabel = false;
-        this.imageCount++;
-        break;
-      }
+    const imageToAssign = this.images.find((img) => !img.src);
+    if (imageToAssign) {
+      imageToAssign.src = result;
+      imageToAssign.isLabel = false;
+      this.imageCount += 1;
     }
   }
 

--- a/src/app/main/component/events/models/events.interface.ts
+++ b/src/app/main/component/events/models/events.interface.ts
@@ -114,6 +114,8 @@ export interface Coordinates {
   regionUa: string;
   streetEn: string;
   streetUa: string;
+  formattedAddressEn: string;
+  formattedAddressUa: string;
 }
 
 export interface DateEventResponceDto {

--- a/src/app/main/component/events/services/events.service.spec.ts
+++ b/src/app/main/component/events/services/events.service.spec.ts
@@ -4,6 +4,7 @@ import { EventsService } from 'src/app/main/component/events/services/events.ser
 import { environment } from '@environment/environment';
 import { EventFilterCriteriaIntarface } from '../models/events.interface';
 import { EventFilterCriteria } from '../models/event-consts';
+import { TranslateService } from '@ngx-translate/core';
 
 describe('EventsService', () => {
   let service: EventsService;
@@ -68,7 +69,7 @@ describe('EventsService', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [EventsService]
+      providers: [EventsService, { provide: TranslateService, useValue: {} }]
     })
   );
 

--- a/src/app/main/component/events/services/events.service.ts
+++ b/src/app/main/component/events/services/events.service.ts
@@ -132,20 +132,20 @@ export class EventsService implements OnDestroy {
     return this.http.get<any>(`${this.backEnd}events/getAllSubscribers/${id}`);
   }
 
-  public getFormattedAdress(coordinates: Coordinates): string {
+  public getFormattedAddress(coordinates: Coordinates): string {
     return this.getLangValue(
-      coordinates.streetUa ? this.createAdresses(coordinates, 'Ua') : coordinates.formattedAddressUa,
-      coordinates.streetEn ? this.createAdresses(coordinates, 'En') : coordinates.formattedAddressEn
+      coordinates.streetUa ? this.createAddresses(coordinates, 'Ua') : coordinates.formattedAddressUa,
+      coordinates.streetEn ? this.createAddresses(coordinates, 'En') : coordinates.formattedAddressEn
     );
   }
 
-  public getFormattedAdressEventsList(coordinates: Coordinates) {
+  public getFormattedAddressEventsList(coordinates: Coordinates) {
     return this.getLangValue(
       coordinates.streetUa
-        ? this.createEventsListAdresses(coordinates, 'Ua')
+        ? this.createEventsListAddresses(coordinates, 'Ua')
         : coordinates.formattedAddressUa.split(', ').slice(0, 2).reverse().join(', '),
       coordinates.streetEn
-        ? this.createEventsListAdresses(coordinates, 'En')
+        ? this.createEventsListAddresses(coordinates, 'En')
         : coordinates.formattedAddressEn.split(', ').slice(0, 2).reverse().join(', ')
     );
   }
@@ -154,7 +154,7 @@ export class EventsService implements OnDestroy {
     return this.langService.getLangValue(uaValue, enValue) as string;
   }
 
-  public createAdresses(coord: Coordinates | null, lang: string): string {
+  public createAddresses(coord: Coordinates | null, lang: string): string {
     if (!coord) {
       return '';
     }
@@ -163,7 +163,7 @@ export class EventsService implements OnDestroy {
     }`;
   }
 
-  public createEventsListAdresses(coord: Coordinates | null, lang: string): string {
+  public createEventsListAddresses(coord: Coordinates | null, lang: string): string {
     if (!coord) {
       return '';
     }

--- a/src/app/main/component/events/services/events.service.ts
+++ b/src/app/main/component/events/services/events.service.ts
@@ -158,16 +158,16 @@ export class EventsService implements OnDestroy {
     if (!coord) {
       return '';
     }
-    return `${coord[`country${lang}`]}${this.divider}${coord[`city${lang}`]}${this.divider}${coord[`street${lang}`]}${this.divider}${
-      coord.houseNumber
-    }`;
+    const parts = [coord[`country${lang}`], coord[`city${lang}`], coord[`street${lang}`], coord.houseNumber];
+    return parts.join(this.divider);
   }
 
   public createEventsListAddresses(coord: Coordinates | null, lang: string): string {
     if (!coord) {
       return '';
     }
-    return `${coord[`city${lang}`]}${this.divider}${coord[`street${lang}`]}${this.divider}${coord.houseNumber}`;
+    const addressParts = [coord[`city${lang}`], coord[`street${lang}`], coord.houseNumber];
+    return addressParts.join(this.divider);
   }
 
   ngOnDestroy(): void {

--- a/src/app/main/component/events/services/events.service.ts
+++ b/src/app/main/component/events/services/events.service.ts
@@ -139,7 +139,7 @@ export class EventsService implements OnDestroy {
     );
   }
 
-  public getFormattedAddressEventsList(coordinates: Coordinates) {
+  public getFormattedAddressEventsList(coordinates: Coordinates): string {
     return this.getLangValue(
       coordinates.streetUa
         ? this.createEventsListAddresses(coordinates, 'Ua')

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.html
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.html
@@ -12,7 +12,7 @@
     </div>
     <div class="event-participants" *ngIf="attendees.length">
       <div class="event-participants-avatars">
-        <div class="event-participants-avatar" *ngFor="let avatar of attendeesAvatars | slice: 0:2">
+        <div class="event-participants-avatar" *ngFor="let avatar of attendeesAvatars | slice : 0 : 2">
           <img [src]="avatar" alt="" />
         </div>
       </div>
@@ -37,13 +37,12 @@
         {{ event.dates[event.dates.length - 1].startDate | dateLocalisation }}
       </div>
       <span class="time-divider">|</span>
-      <div class="time">{{ event.dates[event.dates.length - 1].startDate | date: 'shortTime' }}</div>
+      <div class="time">{{ event.dates[event.dates.length - 1].startDate | date : 'shortTime' }}</div>
     </div>
     <div class="date-container">
       <span class="place"></span>
       <p *ngIf="address">
-        {{ getLangValue(address.cityUa, address.cityEn) }}, {{ getLangValue(address.streetUa, address.streetEn) }},
-        {{ address.houseNumber }}
+        {{ getAddress() }}
       </p>
       <p *ngIf="isOnline && !address">
         <a href="{{ isOnline }}" target="_blank" rel="noopener">{{ 'homepage.events.my-space.event-type-online' | translate }}</a>
@@ -54,9 +53,9 @@
       <div class="event-status">{{ (event.open ? 'homepage.events.open' : 'homepage.events.completed') | translate }}</div>
     </div>
     <div class="event-title">
-      <p class="event-name" [innerHTML]="event.title | maxTextLength: 30"></p>
+      <p class="event-name" [innerHTML]="event.title | maxTextLength : 30"></p>
     </div>
-    <div class="description" [innerHTML]="event.description | maxTextLength: 90"></div>
+    <div class="description" [innerHTML]="event.description | maxTextLength : 90"></div>
   </div>
 
   <div class="btn-group">
@@ -93,7 +92,7 @@
       <img class="event-assign__image-container-image" src="{{ event.titleImage }}" alt="event" />
       <div class="event-assign__image-container__participants" *ngIf="attendees.length">
         <div class="event-assign__image-container__participants__avatars">
-          <div class="event-assign__image-container__participants__avatars__avatar" *ngFor="let avatar of attendeesAvatars | slice: 0:2">
+          <div class="event-assign__image-container__participants__avatars__avatar" *ngFor="let avatar of attendeesAvatars | slice : 0 : 2">
             <img [src]="avatar" alt="" />
           </div>
         </div>
@@ -110,7 +109,7 @@
             {{ event.dates[event.dates.length - 1].startDate | dateLocalisation }}
           </p>
           <span class="time-divider">|</span>
-          <p class="time">{{ event.dates[event.dates.length - 1].startDate | date: 'shortTime' }}</p>
+          <p class="time">{{ event.dates[event.dates.length - 1].startDate | date : 'shortTime' }}</p>
         </div>
         <div class="event-assign__content__date-container__event-flags" *ngIf="event.open">
           <span [ngClass]="event.isFavorite ? 'flag-active' : 'flag'" (click)="addToFavourite($event)"></span>

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
@@ -98,7 +98,9 @@ describe('EventsListItemComponent', () => {
           regionEn: 'Lvivska oblast',
           regionUa: 'Львівська область',
           streetEn: 'Svobody Ave',
-          streetUa: 'Свободи'
+          streetUa: 'Свободи',
+          formattedAddressEn: 'Свободи, 55, Львів, Львівська область, Україна',
+          formattedAddressUa: 'Svobody Ave, 55, Lviv, Lvivska oblast, Ukraine'
         },
         id: null,
         event: null,
@@ -154,10 +156,16 @@ describe('EventsListItemComponent', () => {
   const routerSpy = { navigate: jasmine.createSpy('navigate') };
   const mockLang = 'ua';
   const bsModalRefMock = jasmine.createSpyObj('bsModalRef', ['hide']);
-  const EventsServiceMock = jasmine.createSpyObj('EventsService', ['getEventById ', 'deleteEvent', 'getAllAttendees']);
+  const EventsServiceMock = jasmine.createSpyObj('EventsService', [
+    'getEventById ',
+    'deleteEvent',
+    'getAllAttendees',
+    'getFormattedAddressEventsList'
+  ]);
   EventsServiceMock.getEventById = () => of(eventMock);
   EventsServiceMock.getAllAttendees = () => of([]);
   EventsServiceMock.deleteEvent = () => of(true);
+  EventsServiceMock.getFormattedAddressEventsList = () => of('');
 
   let localStorageServiceMock: LocalStorageService;
   localStorageServiceMock = jasmine.createSpyObj('LocalStorageService', [

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
@@ -277,7 +277,7 @@ export class EventsListItemComponent implements OnChanges, OnInit, OnDestroy {
 
   public getAddress(): string {
     if (this.address) {
-      return this.eventService.getFormattedAdressEventsList(this.address);
+      return this.eventService.getFormattedAddressEventsList(this.address);
     }
   }
 

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
@@ -130,6 +130,7 @@ export class EventsListItemComponent implements OnChanges, OnInit, OnDestroy {
     this.ecoEvents$.subscribe((res: IEcoEventsState) => {
       this.addAttenderError = res.error;
     });
+    this.getAddress();
   }
 
   public routeToEvent(): void {
@@ -267,11 +268,17 @@ export class EventsListItemComponent implements OnChanges, OnInit, OnDestroy {
     });
   }
 
-  getAllAttendees() {
+  getAllAttendees(): void {
     this.eventService.getAllAttendees(this.event.id).subscribe((attendees) => {
       this.attendees = attendees;
       this.attendeesAvatars = attendees.filter((attendee) => attendee.imagePath).map((attendee) => attendee.imagePath);
     });
+  }
+
+  public getAddress(): string {
+    if (this.address) {
+      return this.eventService.getFormattedAdressEventsList(this.address);
+    }
   }
 
   public getLangValue(uaValue: string, enValue: string): string {

--- a/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.spec.ts
+++ b/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.spec.ts
@@ -66,7 +66,9 @@ describe('ProfileDashboardComponent', () => {
               regionEn: 'Lvivska oblast',
               regionUa: 'Львівська область',
               streetEn: 'Svobody Ave',
-              streetUa: 'Свободи'
+              streetUa: 'Свободи',
+              formattedAddressEn: 'Свободи, 55, Львів, Львівська область, Україна',
+              formattedAddressUa: 'Svobody Ave, 55, Lviv, Lvivska oblast, Ukraine'
             },
             event: 'event',
             finishDate: '2022-06-29T04:00:00Z',

--- a/src/app/main/service/localstorage/local-storage.service.spec.ts
+++ b/src/app/main/service/localstorage/local-storage.service.spec.ts
@@ -25,7 +25,9 @@ describe('LocalStorageService', () => {
           regionEn: 'Lvivska oblast',
           regionUa: 'Львівська область',
           streetEn: 'Svobody Ave',
-          streetUa: 'Свободи'
+          streetUa: 'Свободи',
+          formattedAddressEn: 'Свободи, 55, Львів, Львівська область, Україна',
+          formattedAddressUa: 'Svobody Ave, 55, Lviv, Lvivska oblast, Ukraine'
         },
         event: 'event',
         finishDate: 'finishDate',


### PR DESCRIPTION
Fixed events' locations that contained nulls. Now the user has the possibility to change location on the edit page
[6468](https://github.com/ita-social-projects/GreenCity/issues/6468)
[6563](https://github.com/ita-social-projects/GreenCity/issues/6563)
[6525](https://github.com/ita-social-projects/GreenCity/issues/6525)