### PR TITLE
bugfix 6436/6433/6434/6427 - fix comment editing, add validation to new comment content

### DIFF
--- a/src/app/main/component/comments/components/comments-list/comments-list.component.html
+++ b/src/app/main/component/comments/components/comments-list/comments-list.component.html
@@ -33,7 +33,7 @@
   <div class="comment-main-text">
     <p class="comment-text" *ngIf="!comment.isEdit">{{ comment.text }}</p>
     <div class="comment-edit-text" *ngIf="comment.isEdit">
-      <textarea type="text" [value]="comment.text" [formControl]="content" class="edit-text-input" maxlength="8000"> </textarea>
+      <textarea type="text" [value]="comment.text" (input)="checkTextarea($event)" class="edit-text-input" maxlength="8000"> </textarea>
     </div>
   </div>
   <div class="comments-elements">
@@ -45,7 +45,7 @@
       <div class="save-cancel-wrapper" *ngIf="isLoggedIn && checkCommentAuthor(comment.author.id)">
         <div class="d-flex">
           <div class="main-wrapper">
-            <button (click)="saveEditedComment(comment)" [disabled]="!content.valid" class="cta-btn save-edit">
+            <button (click)="saveEditedComment(comment)" [disabled]="!isEditTextValid" class="cta-btn save-edit">
               <img [src]="editIcon" alt="edit icon" />
               <span class="d-none d-sm-block btn-text">
                 {{ 'homepage.eco-news.comment.btn.save' | translate }}

--- a/src/app/main/component/comments/components/comments-list/comments-list.component.scss
+++ b/src/app/main/component/comments/components/comments-list/comments-list.component.scss
@@ -169,6 +169,10 @@
   white-space: nowrap;
 }
 
+.save-edit:disabled .btn-text {
+  color: var(--quaternary-medium-grey);
+}
+
 .comment-likes {
   .like-amount {
     font-family: var(--primary-font);

--- a/src/app/main/component/comments/components/comments-list/comments-list.component.spec.ts
+++ b/src/app/main/component/comments/components/comments-list/comments-list.component.spec.ts
@@ -92,15 +92,33 @@ describe('CommentsListComponent', () => {
   });
 
   it('should show page elements if user clicks reply', () => {
-    const spy = spyOn(component.elementsList, 'map').and.returnValue([commentData]);
+    const spyMap = spyOn(component.elementsList, 'map').and.returnValue([commentData]);
+    const spyFilter = spyOn(component.elementsList, 'filter').and.returnValue([commentData]);
+    const spyUpdateControl = spyOn(component, 'updateContentControl');
     component.showElements(1, 'showRelyButton');
-    expect(spy).toHaveBeenCalled();
-    expect(spy.length).toBe(1);
+    expect(spyMap).toHaveBeenCalled();
+    expect(spyUpdateControl).toHaveBeenCalledWith(1);
+    expect(spyMap.length).toBe(1);
+  });
+
+  it('should update content form controls when user reply', () => {
+    component.content.setValue('old value');
+    const spyFilter = spyOn(component.elementsList, 'filter').and.returnValue([commentData]);
+    component.showElements(1, 'showRelyButton');
+    expect(component.content.value).toBe(commentData.text);
+    expect(component.isEditTextValid).toBeTruthy();
   });
 
   it('should check is current user an author', () => {
     const userId = 1;
     component.checkCommentAuthor(commentData.author.id);
     expect(commentData.author.id).toEqual(userId);
+  });
+
+  it('should check textarea length', () => {
+    const spyFilter = spyOn(component.elementsList, 'filter').and.returnValue([commentData]);
+    component.updateContentControl(1);
+    expect(component.content.value).toBe(commentData.text);
+    expect(component.isEditTextValid).toBeTruthy();
   });
 });

--- a/src/app/main/component/comments/components/comments-list/comments-list.component.ts
+++ b/src/app/main/component/comments/components/comments-list/comments-list.component.ts
@@ -23,6 +23,7 @@ export class CommentsListComponent {
   public editIcon = 'assets/img/comments/edit.png';
   public cancelIcon = 'assets/img/comments/cancel-comment-edit.png';
   public likeImg = 'assets/img/comments/like.png';
+  public isEditTextValid: boolean;
 
   constructor(private commentsService: CommentsService) {}
 
@@ -60,10 +61,17 @@ export class CommentsListComponent {
   }
 
   public showElements(id: number, key: string): void {
+    this.updateContentControl(id);
     this.elementsList = this.elementsList.map((item) => {
       item[key] = item.id === id && !item[key];
       return item;
     });
+  }
+
+  public updateContentControl(id: number): void {
+    const commentContent = this.elementsList.filter((el) => el.id === id)[0].text;
+    this.content.setValue(commentContent);
+    this.isEditTextValid = true;
   }
 
   public isShowReplies(id: number): boolean {
@@ -77,5 +85,10 @@ export class CommentsListComponent {
 
   public checkCommentAuthor(commentAuthorId: number) {
     return commentAuthorId === Number(this.userId);
+  }
+
+  checkTextarea(event: InputEvent): void {
+    this.content.setValue((event.target as HTMLInputElement).value);
+    this.isEditTextValid = !!(event.target as HTMLInputElement).value.trim().length;
   }
 }

--- a/src/app/main/component/events/components/events-list/events-list.component.ts
+++ b/src/app/main/component/events/components/events-list/events-list.component.ts
@@ -251,7 +251,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
   }
 
   private getStatusesForFilter(): OptionItem[] {
-    return !!this.userId ? eventStatusList : eventStatusList.slice(0, 2);
+    return this.userId ? eventStatusList : eventStatusList.slice(0, 2);
   }
 
   public toggleAllSelection(optionsList: MatSelect, dropdownName: string): void {


### PR DESCRIPTION
[#6436 'Save changes' button for edit comment is active due to only spaces input and empty field](https://github.com/ita-social-projects/GreenCity/issues/6436)
[#6433 Comment text is absent for editing in the edit comment text box ](https://github.com/ita-social-projects/GreenCity/issues/6433)
[#6434  Entered text due to the comment editing appears in all User’s edit comment text boxes clicking on ‘Edit’ buttons ](https://github.com/ita-social-projects/GreenCity/issues/6434)
[#6427 Original reply text for editing is absent in the reply edit text box ](https://github.com/ita-social-projects/GreenCity/issues/6427)