### PR TITLE
Bugfix/#6504 "delete" button for the past event only for admin

### DIFF
--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
@@ -22,6 +22,7 @@ import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
 import { UserFriendsService } from '@global-user/services/user-friends.service';
 import { MaxTextLengthPipe } from 'src/app/shared/max-text-length-pipe/max-text-length.pipe';
+import { JwtService } from '@global-service/jwt/jwt.service';
 
 @Injectable()
 class TranslationServiceStub {
@@ -60,6 +61,9 @@ describe('EventsListItemComponent', () => {
   let component: EventsListItemComponent;
   let fixture: ComponentFixture<EventsListItemComponent>;
   let translate: TranslateService;
+  const jwtServiceMock = jasmine.createSpyObj('jwtService', ['getUserRole']);
+  jwtServiceMock.getUserRole = () => 'true';
+  jwtServiceMock.userRole$ = new BehaviorSubject('ROLE_UBS_EMPLOYEE');
 
   const MatSnackBarMock = jasmine.createSpyObj('MatSnackBarComponent', ['openSnackBar']);
   const styleBtnMock = {
@@ -119,7 +123,8 @@ describe('EventsListItemComponent', () => {
     isRelevant: true,
     open: true,
     likes: 5,
-    countComments: 7
+    countComments: 7,
+    isAdmin: false
   };
 
   const fakeItemTags: TagObj[] = [
@@ -221,7 +226,8 @@ describe('EventsListItemComponent', () => {
         { provide: LanguageService, useValue: languageServiceMock },
         { provide: TranslateService, useClass: TranslationServiceStub },
         { provide: UserOwnAuthService, useValue: userOwnAuthServiceMock },
-        { provide: MatSnackBarComponent, useValue: MatSnackBarMock }
+        { provide: MatSnackBarComponent, useValue: MatSnackBarMock },
+        { provide: JwtService, useValue: jwtServiceMock }
       ],
       imports: [
         RouterTestingModule,
@@ -364,8 +370,7 @@ describe('EventsListItemComponent', () => {
 
     it('should set btnStyle and nameBtn correctly when user is owner and event is unactive', () => {
       component.event = eventMock;
-      component.userId = eventMock.organizer.id;
-      component.event.isSubscribed = false;
+      spyOn(jwtServiceMock, 'getUserRole').and.returnValue('ROLE_UBS_EMPLOYEE');
       spyOn(component, 'checkIsActive').and.returnValue(false);
       component.checkButtonStatus();
       expect(component.btnStyle).toEqual(component.styleBtn.secondary);

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
@@ -26,6 +26,7 @@ import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
 import { userAssignedCardsIcons } from 'src/app/main/image-pathes/profile-icons';
 import { FriendModel } from '@global-user/models/friend.model';
+import { JwtService } from '@global-service/jwt/jwt.service';
 
 @Component({
   selector: 'app-events-list-item',
@@ -71,6 +72,8 @@ export class EventsListItemComponent implements OnChanges, OnInit, OnDestroy {
   public isOnline: string;
   isOwner: boolean;
   isActive: boolean;
+  public adminRoleValue = 'ROLE_UBS_EMPLOYEE';
+  public isAdmin: boolean;
 
   attendees = [];
   attendeesAvatars = [];
@@ -108,7 +111,8 @@ export class EventsListItemComponent implements OnChanges, OnInit, OnDestroy {
     private store: Store,
     private eventService: EventsService,
     private translate: TranslateService,
-    private snackBar: MatSnackBarComponent
+    private snackBar: MatSnackBarComponent,
+    private jwtService: JwtService
   ) {}
 
   ngOnChanges() {
@@ -156,12 +160,13 @@ export class EventsListItemComponent implements OnChanges, OnInit, OnDestroy {
     const isSubscribe = this.event.isSubscribed;
     this.isOwner = +this.userId === this.event.organizer.id;
     this.isActive = this.checkIsActive();
+    this.isAdmin = this.jwtService.getUserRole() === this.adminRoleValue;
     if (this.isOwner && this.isActive && !isSubscribe) {
       this.btnStyle = this.styleBtn.secondary;
       this.nameBtn = this.btnName.edit;
       return;
     }
-    if (this.isOwner && !this.isActive && !isSubscribe) {
+    if (this.isAdmin && !this.isActive) {
       this.btnStyle = this.styleBtn.secondary;
       this.nameBtn = this.btnName.delete;
       return;

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
@@ -72,7 +72,6 @@ export class EventsListItemComponent implements OnChanges, OnInit, OnDestroy {
   public isOnline: string;
   isOwner: boolean;
   isActive: boolean;
-  public adminRoleValue = 'ROLE_UBS_EMPLOYEE';
   public isAdmin: boolean;
 
   attendees = [];
@@ -160,7 +159,7 @@ export class EventsListItemComponent implements OnChanges, OnInit, OnDestroy {
     const isSubscribe = this.event.isSubscribed;
     this.isOwner = +this.userId === this.event.organizer.id;
     this.isActive = this.checkIsActive();
-    this.isAdmin = this.jwtService.getUserRole() === this.adminRoleValue;
+    this.isAdmin = this.jwtService.getUserRole() === 'ROLE_UBS_EMPLOYEE';
     if (this.isOwner && this.isActive && !isSubscribe) {
       this.btnStyle = this.styleBtn.secondary;
       this.nameBtn = this.btnName.edit;


### PR DESCRIPTION
# GreenCityClient PR

## Summary Of Changes :fire:
Added verification "isAdmin" to the event-list-item
Added changes to test file

## Issue Link :clipboard:
[#6504](https://github.com/ita-social-projects/GreenCity/issues/6504)

## Added

## Changed
Conditions to appear delete button on the past event

## Deleted

## How to test :clipboard:
Log in as a user, create event, wait for event end. Delete button not appear
Log in as an Admin. Delete button appear on the all past events
# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers