### PR TITLE
bugfix #6465: Changed "all" to my friends and "find a friend" to search

### DIFF
--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-dashboard.component.html
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-dashboard.component.html
@@ -31,7 +31,7 @@
           routerLinkActive="active"
           [routerLinkActiveOptions]="{ exact: true }"
         >
-          {{ 'profile.friends.search-friends' | translate }}
+          {{ 'profile.friends.find-friends' | translate }}
         </a>
         <a [routerLink]="['/profile', userId, 'friends', 'requests']" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
           {{ 'profile.friends.requests' | translate }} <span *ngIf="requestFriendsAmount">{{ requestFriendsAmount }}</span>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1008,8 +1008,9 @@
       "requests": "Requests",
       "request-decline": "Decline",
       "request-accept": "Accept",
-      "all-friends": "All friends",
-      "search-friends": "Find a friend",
+      "all-friends": "My friends",
+      "search-friends": "Search",
+      "find-friends": "Find a friend",
       "found-amount": "of people found"
     }
   },

--- a/src/assets/i18n/ua.json
+++ b/src/assets/i18n/ua.json
@@ -1030,6 +1030,7 @@
       "request-accept": "Прийняти",
       "all-friends": "Всі Друзі",
       "search-friends": "Знайти друга",
+      "find-friends": "Знайти друга",
       "found-amount": "людей знайдено"
     },
     "rate": "Рейтинг",


### PR DESCRIPTION
Changed name of the first tab is "All friends” to "My friends” and the default text in the search field is "Find a friend” to "Search” (user's friends)