### PR TITLE
Bugfix/#6554#6556#6557#6506#6558#6553/If user chooses a habit with a very long name, button 'Edit' in 'My Space' page disappears

### DIFF
--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.html
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.html
@@ -3,7 +3,7 @@
   <div class="content-container">
     <a [routerLink]="routedFromProfile ? [backRoute, { tabId: 2 }] : [backRoute]">
       <div class="button-arrow">
-        <img [src]="images.arrowLeft" aria-hidden="true" alt="arrow" class="button-arrow-img" />
+        <img [src]="images.arrowLeft" aria-hidden="true" alt="arrow" />
         <div class="back-button">{{ 'homepage.events.btn.back-route' | translate }}</div>
       </div>
     </a>

--- a/src/app/main/component/user/components/habit/add-edit-custom-habit/add-edit-custom-habit.component.html
+++ b/src/app/main/component/user/components/habit/add-edit-custom-habit/add-edit-custom-habit.component.html
@@ -64,7 +64,6 @@
               formControlName="description"
               (dragover)="(false)"
               [placeholder]="'user.habit.add-new-habit.description-placeholder' | translate"
-              (onEditorChanged)="changeEditor($event)"
             ></quill-editor>
             <div [style.visibility]="getControl('description').touched && getControl('description').invalid ? 'visible' : 'hidden'">
               <p class="habit-tooltip warning">

--- a/src/app/main/component/user/components/habit/add-edit-custom-habit/add-edit-custom-habit.component.spec.ts
+++ b/src/app/main/component/user/components/habit/add-edit-custom-habit/add-edit-custom-habit.component.spec.ts
@@ -134,16 +134,6 @@ describe('AddEditCustomHabitComponent', () => {
     expect(titleControl.value).toBe('ab');
   });
 
-  it('should set editor value to form controll', () => {
-    const editorEvent = {
-      event: 'text-change',
-      text: '   from editor   '
-    };
-    component.changeEditor(editorEvent as EditorChangeContent);
-    const descriptionControl = component.habitForm.get('description');
-    expect(descriptionControl.value).toBe('from editor');
-  });
-
   it('should set TagList after get it from child component', () => {
     (component as any).initForm();
     component.getTagsList(tagsMock);

--- a/src/app/main/component/user/components/habit/add-edit-custom-habit/add-edit-custom-habit.component.ts
+++ b/src/app/main/component/user/components/habit/add-edit-custom-habit/add-edit-custom-habit.component.ts
@@ -16,7 +16,6 @@ import { quillConfig } from 'src/app/main/component/events/components/create-edi
 import { ShoppingList } from '../../../models/shoppinglist.interface';
 import { FileHandle } from '@eco-news-models/create-news-interface';
 import { UserFriendsService } from '@global-user/services/user-friends.service';
-import { EditorChangeContent, EditorChangeSelection } from 'ngx-quill';
 import { Store } from '@ngrx/store';
 import { IAppState } from 'src/app/store/state/app.state';
 

--- a/src/app/main/component/user/components/habit/add-edit-custom-habit/add-edit-custom-habit.component.ts
+++ b/src/app/main/component/user/components/habit/add-edit-custom-habit/add-edit-custom-habit.component.ts
@@ -150,13 +150,6 @@ export class AddEditCustomHabitComponent extends FormBaseComponent implements On
     this.habitForm.patchValue({ complexity: i + 1 });
   }
 
-  changeEditor(event: EditorChangeContent | EditorChangeSelection): void {
-    this.getControl('description').markAsTouched();
-    if (event.event !== 'selection-change') {
-      this.getControl('description').setValue(event.text.trim());
-    }
-  }
-
   private subscribeToLangChange(): void {
     this.localStorageService.languageBehaviourSubject.pipe(takeUntil(this.destroyed$)).subscribe((lang) => {
       this.translate.setDefaultLang(lang);
@@ -180,7 +173,6 @@ export class AddEditCustomHabitComponent extends FormBaseComponent implements On
         text: item.text
       };
     });
-    console.log(this.newList, 'new list');
     this.getControl('shopList').setValue(this.newList);
   }
 

--- a/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.html
+++ b/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.html
@@ -1,7 +1,9 @@
 <div class="wrapper">
   <div class="back-to-my-habits" (click)="onGoBack()">
-    <div class="arrow"></div>
-    <div class="text">{{ 'user.habit.btn.back-to-habit' | translate }}</div>
+    <div class="button-arrow">
+      <img [src]="images.arrowLeft" aria-hidden="true" alt="arrow" class="button-arrow-img" />
+      <div class="back-button">{{ 'user.habit.btn.back-to-habit' | translate }}</div>
+    </div>
   </div>
   <div class="habit-container" *ngIf="habitResponse">
     <div class="habit-info">

--- a/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.scss
+++ b/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.scss
@@ -9,16 +9,19 @@
     flex-direction: row;
     align-items: flex-start;
     margin: 28px 0 40px 0;
-    padding: 4px 0 0 4px;
-    color: var(--secondary-dark-green);
+    padding-top: 4px;
+    color: var(--ubs-primary-grey);
     cursor: pointer;
 
-    .arrow {
-      width: 5px;
-      height: 7px;
-      margin-right: 6px;
-      align-self: center;
-      background: url('~/assets/img/profile/icons/back-arrow.svg') no-repeat;
+    .button-arrow {
+      display: flex;
+      align-items: center;
+
+      .back-button {
+        margin: 6px;
+        margin-top: 9px;
+        color: var(--ubs-primary-grey);
+      }
     }
 
     .text {
@@ -26,7 +29,6 @@
       line-height: 22px;
       display: flex;
       align-self: center;
-      text-decoration-line: underline;
     }
   }
 
@@ -43,6 +45,7 @@
       display: flex;
       flex-direction: column;
       width: 60%;
+      word-wrap: break-word;
 
       .header {
         height: 24px;

--- a/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.ts
@@ -26,6 +26,7 @@ import { HabitAssignPropertiesDto } from '@global-models/goal/HabitAssignCustomP
 import { Store } from '@ngrx/store';
 import { SetHabitForEdit } from 'src/app/store/actions/habit.actions';
 import { IAppState } from 'src/app/store/state/app.state';
+import { singleNewsImages } from 'src/app/main/image-pathes/single-news-images';
 
 @Component({
   selector: 'app-add-new-habit',
@@ -69,7 +70,7 @@ export class AddNewHabitComponent implements OnInit {
   private page = 0;
   private size = 3;
   private isCustomHabit = false;
-
+  public images = singleNewsImages;
   private destroyed$: Subject<boolean> = new Subject<boolean>();
 
   constructor(

--- a/src/app/main/component/user/components/habit/all-habits/all-habits.component.html
+++ b/src/app/main/component/user/components/habit/all-habits/all-habits.component.html
@@ -1,9 +1,9 @@
 <div class="habits-wrapper container" (window:resize)="onResize()">
   <div class="habits_header-wrapper">
     <a [routerLink]="['/profile', profileService.userId]">
-      <div class="back-button">
-        <img [src]="images.arrowLeft" alt="arrow" />
-        <div>{{ 'user.habit.all-habits.back-button' | translate }}</div>
+      <div class="button-arrow">
+        <img [src]="images.arrowLeft" aria-hidden="true" alt="arrow" />
+        <div class="back-button">{{ 'user.habit.btn.back-to-habit' | translate }}</div>
       </div>
     </a>
     <div class="habit-header">

--- a/src/app/main/component/user/components/habit/all-habits/all-habits.component.scss
+++ b/src/app/main/component/user/components/habit/all-habits/all-habits.component.scss
@@ -19,6 +19,17 @@ h1 {
   row-gap: 20px;
   margin: 20px 0 3.125rem 0;
 
+  .button-arrow {
+    display: flex;
+    align-items: center;
+
+    .back-button {
+      margin: 6px;
+      margin-top: 9px;
+      color: var(--ubs-primary-grey);
+    }
+  }
+
   .habit-header {
     display: flex;
     flex-direction: column;
@@ -78,22 +89,6 @@ h1 {
       @media (max-width: 400px) {
         flex-direction: column;
       }
-    }
-  }
-
-  a .back-button {
-    height: 30px;
-    font-family: 'Open Sans', sans-serif;
-    font-size: 16px;
-    line-height: 19px;
-    color: #494a49;
-    text-decoration-line: underline;
-    display: flex;
-    align-items: center;
-    padding: 20px 0 40px 0;
-
-    img {
-      margin-right: 6px;
     }
   }
 

--- a/src/app/main/component/user/components/profile/profile-dashboard/one-habit/one-habit.component.scss
+++ b/src/app/main/component/user/components/profile/profile-dashboard/one-habit/one-habit.component.scss
@@ -105,6 +105,8 @@ img {
     padding-right: 12px 24px;
     color: var(--quaternary-dark-grey);
     letter-spacing: 0.002em;
+    width: 320px;
+    word-wrap: break-word;
   }
 }
 
@@ -162,7 +164,7 @@ img {
   }
 }
 
-@media (min-width: 280px) {
+@media (max-width: 479px) {
   .main {
     height: 192px;
     grid-template-columns: 0 auto;
@@ -209,5 +211,51 @@ img {
 
   .third-row {
     grid-area: 2 / 2 / 3 / 3;
+  }
+}
+
+@media (max-width: 1199px) {
+  .description {
+    .second-row {
+      width: 230px;
+      word-wrap: normal;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+}
+
+@media (max-width: 1023px) {
+  .description {
+    .second-row {
+      width: 475px;
+    }
+  }
+}
+
+@media (max-width: 991px) {
+  .description {
+    .second-row {
+      width: 235px;
+    }
+  }
+}
+
+@media (max-width: 767px) {
+  .description {
+    .second-row {
+      width: 305px;
+    }
+  }
+}
+
+@media (max-width: 575px) {
+  .description {
+    width: auto;
+    overflow: hidden;
+    height: 110px;
+    .second-row {
+      width: auto;
+    }
   }
 }

--- a/src/app/main/component/user/components/profile/profile-dashboard/one-habit/one-habit.component.scss
+++ b/src/app/main/component/user/components/profile/profile-dashboard/one-habit/one-habit.component.scss
@@ -254,6 +254,7 @@ img {
     width: auto;
     overflow: hidden;
     height: 110px;
+
     .second-row {
       width: auto;
     }

--- a/src/app/main/component/user/components/shared/components/habits-gallery-view/habits-gallery-view.component.scss
+++ b/src/app/main/component/user/components/shared/components/habits-gallery-view/habits-gallery-view.component.scss
@@ -27,11 +27,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
 
   img {
+    object-fit: cover;
     padding-top: 25px;
-    height: 100%;
-    max-width: 100%;
+    height: 99%;
     width: auto;
     mix-blend-mode: multiply;
   }
@@ -121,10 +122,22 @@
   .habit-info {
     max-width: 210px;
   }
+
+  .habit-picture {
+    img {
+      height: 88%;
+    }
+  }
 }
 
 @media (max-width: 575px) {
   .habit-info {
     max-width: 230px;
+  }
+
+  .habit-picture {
+    img {
+      height: 96%;
+    }
   }
 }


### PR DESCRIPTION
Added correct CSS to add-edit-custom-habit and all-habits pages. The description field on the add habit page is unfrozen. Images on all-habits page have normal width
[#6556](https://github.com/ita-social-projects/GreenCity/issues/6556)
[#6557](https://github.com/ita-social-projects/GreenCity/issues/6557)
[#6558](https://github.com/ita-social-projects/GreenCity/issues/6558)
[#6553](https://github.com/ita-social-projects/GreenCity/issues/6553)
[#6506](https://github.com/ita-social-projects/GreenCity/issues/6506)
[#6554](https://github.com/ita-social-projects/GreenCity/issues/6554)