### PR TITLE
Bugfix/#6840 Confirmation pop-up on cancelling comment editing

### DIFF
--- a/src/app/main/component/comments/components/comments-list/comments-list.component.spec.ts
+++ b/src/app/main/component/comments/components/comments-list/comments-list.component.spec.ts
@@ -9,7 +9,7 @@ import { CommentsService } from '../../services/comments.service';
 import { of } from 'rxjs';
 import { DateLocalisationPipe } from '@pipe/date-localisation-pipe/date-localisation.pipe';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 
 describe('CommentsListComponent', () => {
   let component: CommentsListComponent;
@@ -25,6 +25,9 @@ describe('CommentsListComponent', () => {
       };
     }
   };
+
+  const matDialogRefMock = jasmine.createSpyObj(['close', 'afterClosed']);
+  matDialogRefMock.afterClosed.and.returnValue(of(true));
 
   const commentData = {
     author: {
@@ -50,7 +53,8 @@ describe('CommentsListComponent', () => {
       providers: [
         { provide: CommentsService, useValue: commentsServiceMock },
         { provide: Renderer2, useValue: {} },
-        { provide: MatDialog, useValue: matDialogMock }
+        { provide: MatDialog, useValue: matDialogMock },
+        { provide: MatDialogRef, useValue: matDialogRefMock }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -102,6 +106,24 @@ describe('CommentsListComponent', () => {
   it('should cancel edit comment', () => {
     component.cancelEditedComment(commentData);
     expect(commentData.isEdit).toBeFalsy();
+  });
+
+  it('should cancel edited comment when user confirms', () => {
+    spyOn((component as any).dialog, 'open').and.returnValue({ afterClosed: () => of(true) });
+
+    component.cancelEditedComment(commentData);
+
+    expect((component as any).isEdit).toBeFalsy();
+  });
+
+  it('should not cancel edited comment when user cancels', () => {
+    (component as any).isEdit = true;
+    spyOn((component as any).dialog, 'open').and.returnValue({
+      afterClosed: () => of(false)
+    } as any);
+    component.cancelEditedComment(commentData);
+
+    expect((component as any).isEdit).toBeTruthy();
   });
 
   it('should change counter if user clicks like', () => {

--- a/src/app/main/component/comments/components/comments-list/comments-list.component.spec.ts
+++ b/src/app/main/component/comments/components/comments-list/comments-list.component.spec.ts
@@ -2,16 +2,14 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { NgxPaginationModule } from 'ngx-pagination';
-import { CUSTOM_ELEMENTS_SCHEMA, ElementRef, QueryList, Renderer2, SimpleChanges } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, ElementRef, Renderer2, SimpleChanges } from '@angular/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CommentsListComponent } from './comments-list.component';
 import { CommentsService } from '../../services/comments.service';
 import { of } from 'rxjs';
 import { DateLocalisationPipe } from '@pipe/date-localisation-pipe/date-localisation.pipe';
 import { RouterTestingModule } from '@angular/router/testing';
-import { toArray } from 'rxjs/operators';
-import { CommentDto } from '@global-models/comment/commentDto';
-import { CommentsDTO } from '../../models/comments-model';
+import { MatDialog } from '@angular/material/dialog';
 
 describe('CommentsListComponent', () => {
   let component: CommentsListComponent;
@@ -20,6 +18,13 @@ describe('CommentsListComponent', () => {
   let commentsServiceMock: CommentsService;
   commentsServiceMock = jasmine.createSpyObj('CommentsService', ['editComment']);
   commentsServiceMock.editComment = () => of();
+  const matDialogMock = {
+    open() {
+      return {
+        afterClosed: () => of(true)
+      };
+    }
+  };
 
   const commentData = {
     author: {
@@ -44,7 +49,8 @@ describe('CommentsListComponent', () => {
       imports: [HttpClientTestingModule, NgxPaginationModule, ReactiveFormsModule, TranslateModule.forRoot(), RouterTestingModule],
       providers: [
         { provide: CommentsService, useValue: commentsServiceMock },
-        { provide: Renderer2, useValue: {} }
+        { provide: Renderer2, useValue: {} },
+        { provide: MatDialog, useValue: matDialogMock }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();

--- a/src/app/main/component/comments/components/comments-list/comments-list.component.ts
+++ b/src/app/main/component/comments/components/comments-list/comments-list.component.ts
@@ -16,6 +16,8 @@ import { CommentsService } from '../../services/comments.service';
 import { CommentsDTO, dataTypes, PaginationConfig } from '../../models/comments-model';
 import { take } from 'rxjs/operators';
 import { Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { WarningPopUpComponent } from '@shared/components';
 
 @Component({
   selector: 'app-comments-list',
@@ -39,10 +41,21 @@ export class CommentsListComponent implements OnChanges, AfterViewInit {
   public cancelIcon = 'assets/img/comments/cancel-comment-edit.png';
   public likeImg = 'assets/img/comments/like.png';
   public isEditTextValid: boolean;
+  private confirmDialogConfig = {
+    hasBackdrop: true,
+    closeOnNavigation: true,
+    disableClose: true,
+    panelClass: 'popup-dialog-container',
+    data: {
+      popupTitle: `homepage.eco-news.comment.comment-popup-cancel-edit.title`,
+      popupConfirm: `homepage.eco-news.comment.comment-popup-cancel-edit.confirm`,
+      popupCancel: `homepage.eco-news.comment.comment-popup-cancel-edit.cancel`
+    }
+  };
 
   @ViewChildren('commentText') commentText: QueryList<ElementRef>;
 
-  constructor(private commentsService: CommentsService, private renderer: Renderer2, private router: Router) {}
+  constructor(private commentsService: CommentsService, private renderer: Renderer2, private router: Router, private dialog: MatDialog) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.elementsList && !changes.elementsList.firstChange) {
@@ -115,7 +128,15 @@ export class CommentsListComponent implements OnChanges, AfterViewInit {
   }
 
   public cancelEditedComment(element: CommentsDTO): void {
-    element.isEdit = false;
+    const dialogRef = this.dialog.open(WarningPopUpComponent, this.confirmDialogConfig);
+    dialogRef
+      .afterClosed()
+      .pipe(take(1))
+      .subscribe((confirm) => {
+        if (confirm) {
+          element.isEdit = false;
+        }
+      });
   }
 
   public changeCounter(counter: number, id: number, key: string): void {

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.scss
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.scss
@@ -24,6 +24,7 @@
   line-height: 20px;
   text-align: left;
   color: var(--quaternary-grey);
+  white-space: nowrap;
 
   div {
     display: flex;
@@ -37,6 +38,13 @@
     p {
       margin: 0;
     }
+  }
+
+  .author p {
+    max-width: 120px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   }
 }
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -68,6 +68,11 @@
           "confirm": "Yes, delete",
           "cancel": "Cancel"
         },
+        "comment-popup-cancel-edit": {
+          "title": "Do you really want to cancel editing a comment?",
+          "confirm": "Yes",
+          "cancel": "No"
+        },
         "reply": "Reply",
         "replies": {
           "zero-reply": "reply",

--- a/src/assets/i18n/ua.json
+++ b/src/assets/i18n/ua.json
@@ -68,6 +68,11 @@
           "confirm": "Так, видалити",
           "cancel": "Скасувати"
         },
+        "comment-popup-cancel-edit": {
+          "title": "Ви дійсно бажаєте відмінити редагування",
+          "confirm": "Так",
+          "cancel": "Ні"
+        },
         "reply": "Відповісти",
         "replies": {
           "zero-reply": "відповідей",


### PR DESCRIPTION
[#6840](https://github.com/ita-social-projects/GreenCity/issues/6840)

-added confirmation pop-up when user wants to cancel editing comment