### PR TITLE
Bugfix 6450 cannot select text in description of event

### DIFF
--- a/src/app/shared/events-description-transforn/safe-html-transform.pipe.ts
+++ b/src/app/shared/events-description-transforn/safe-html-transform.pipe.ts
@@ -1,10 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { SafeHtml, DomSanitizer } from '@angular/platform-browser';
 
-@Pipe({
-  name: 'safeHtmlTransform',
-  pure: false
-})
+@Pipe({ name: 'safeHtmlTransform' })
 export class SafeHtmlTransformPipe implements PipeTransform {
   constructor(protected sanitizer: DomSanitizer) {}
   transform(items): SafeHtml {


### PR DESCRIPTION
Fixed the ability to highlight and copy text from event description 
#[6450](https://github.com/ita-social-projects/GreenCity/issues/6450)