### PR TITLE
 bugfix/#6892#6891#6884 The 'Edit Profile' page is not shown on the background after clicking the 'Edit photo' icon when expanding the screen is 576

### DIFF
--- a/src/app/main/component/shared/components/edit-photo-pop-up/edit-photo-pop-up.component.html
+++ b/src/app/main/component/shared/components/edit-photo-pop-up/edit-photo-pop-up.component.html
@@ -48,7 +48,9 @@
         <p *ngIf="isWarning" class="warning">{{ 'user.edit-profile.picture-tooltip' | translate }}</p>
         <p *ngIf="!isWarning">{{ 'user.edit-profile.would-you-like' | translate }}</p>
         <div class="buttons">
-          <button type="button" class="tertiary-global-button m-btn" (click)="closeEditPhoto()">Cancel</button>
+          <button type="button" class="tertiary-global-button m-btn" (click)="closeEditPhoto()">
+            {{ 'user.edit-profile.btn.cancel' | translate }}
+          </button>
           <button class="secondary-global-button m-btn" (click)="selectedPhoto = false; files.pop()">
             {{ 'user.edit-profile.btn.change-photo' | translate }}
           </button>

--- a/src/app/main/component/shared/components/edit-photo-pop-up/edit-photo-pop-up.component.scss
+++ b/src/app/main/component/shared/components/edit-photo-pop-up/edit-photo-pop-up.component.scss
@@ -147,7 +147,7 @@
   }
 }
 
-@media screen and (max-width: 576px) {
+@media screen and (max-width: 575px) {
   .main-container {
     width: 100vw;
     height: 100vh;


### PR DESCRIPTION
[#6892](https://github.com/ita-social-projects/GreenCity/issues/6892)
[#6891](https://github.com/ita-social-projects/GreenCity/issues/6891)
[#6884](https://github.com/ita-social-projects/GreenCity/issues/6884)