### PR TITLE
Bugfix/#6117 Create-Edit event Tab key focus remains in quills editor and block a11y

### DIFF
--- a/src/app/main/component/eco-news/components/create-edit-news/quillEditorFunc.ts
+++ b/src/app/main/component/eco-news/components/create-edit-news/quillEditorFunc.ts
@@ -1,3 +1,4 @@
+import { QuillModules } from 'ngx-quill';
 import { Patterns } from 'src/assets/patterns/patterns';
 
 export const checkImages = (editorContent: string) => {
@@ -25,7 +26,7 @@ export const dataURLtoFile = (dataUrl) => {
   });
 };
 
-export const quillConfig = {
+export const quillConfig: QuillModules = {
   'emoji-shortname': true,
   'emoji-textarea': false,
   'emoji-toolbar': true,
@@ -50,6 +51,14 @@ export const quillConfig = {
       ['link', 'image', 'video'], // link and image, video
       ['emoji']
     ]
+  },
+  keyboard: {
+    bindings: {
+      tab: {
+        key: 9,
+        handler: () => true
+      }
+    }
   },
   imageResize: true
 };

--- a/src/app/main/component/events/components/create-edit-events/quillEditorFunc.ts
+++ b/src/app/main/component/events/components/create-edit-events/quillEditorFunc.ts
@@ -1,3 +1,4 @@
+import { QuillModules } from 'ngx-quill';
 import { Patterns } from 'src/assets/patterns/patterns';
 
 export const checkImages = (editorContent: string) => {
@@ -8,7 +9,7 @@ export const checkImages = (editorContent: string) => {
   }
 };
 
-export const quillConfig = {
+export const quillConfig: QuillModules = {
   'emoji-shortname': true,
   'emoji-textarea': false,
   'emoji-toolbar': true,
@@ -20,6 +21,14 @@ export const quillConfig = {
       [{ align: [] }],
       [{ size: ['small', false, 'large', 'huge'] }]
     ]
+  },
+  keyboard: {
+    bindings: {
+      tab: {
+        key: 9,
+        handler: () => true
+      }
+    }
   },
   imageResize: true
 };


### PR DESCRIPTION
[#6117](https://github.com/ita-social-projects/GreenCity/issues/6177)