### PR TITLE
Bugfix/#6921/6924 event button/open link in the same tab

### DIFF
--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.spec.ts
@@ -5,7 +5,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BsModalRef, ModalModule } from 'ngx-bootstrap/modal';
 import { typeFiltersData } from '../../../events/models/event-consts';
-import { Store } from '@ngrx/store';
+import { ActionsSubject, Store } from '@ngrx/store';
 import { EventsListItemComponent } from './events-list-item.component';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { Router } from '@angular/router';
@@ -17,10 +17,9 @@ import { BehaviorSubject, Subject } from 'rxjs';
 import { UserOwnAuthService } from '@auth-service/user-own-auth.service';
 import { TagObj } from '../../../events/models/events.interface';
 import { LanguageService } from 'src/app/main/i18n/language.service';
-import { AddAttenderEcoEventsByIdAction, RemoveAttenderEcoEventsByIdAction } from 'src/app/store/actions/ecoEvents.actions';
+import { AddAttenderEcoEventsByIdAction, EventsActions, RemoveAttenderEcoEventsByIdAction } from 'src/app/store/actions/ecoEvents.actions';
 import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
-import { UserFriendsService } from '@global-user/services/user-friends.service';
 import { MaxTextLengthPipe } from 'src/app/shared/max-text-length-pipe/max-text-length.pipe';
 import { JwtService } from '@global-service/jwt/jwt.service';
 
@@ -223,6 +222,8 @@ describe('EventsListItemComponent', () => {
   userOwnAuthServiceMock.credentialDataSubject = new Subject();
   userOwnAuthServiceMock.isLoginUserSubject = new BehaviorSubject(true);
 
+  const actionsSubj: ActionsSubject = new ActionsSubject();
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [EventsListItemComponent, DatePipeMock, MaxTextLengthPipe],
@@ -236,7 +237,8 @@ describe('EventsListItemComponent', () => {
         { provide: TranslateService, useClass: TranslationServiceStub },
         { provide: UserOwnAuthService, useValue: userOwnAuthServiceMock },
         { provide: MatSnackBarComponent, useValue: MatSnackBarMock },
-        { provide: JwtService, useValue: jwtServiceMock }
+        { provide: JwtService, useValue: jwtServiceMock },
+        { provide: ActionsSubject, useValue: actionsSubj }
       ],
       imports: [
         RouterTestingModule,
@@ -285,6 +287,12 @@ describe('EventsListItemComponent', () => {
   it('should return ua value by getLangValue', () => {
     const value = component.getLangValue('value', 'enValue');
     expect(value).toBe('value');
+  });
+
+  it('shoud update button name after succsess attention for event', () => {
+    const action = { id: 307, type: EventsActions.AddAttenderEcoEventsByIdSuccess };
+    actionsSubj.next(action);
+    expect(component.nameBtn).toEqual(btnNameMock.cancel);
   });
 
   describe('ngOnInit', () => {
@@ -393,7 +401,6 @@ describe('EventsListItemComponent', () => {
       eventMock.isSubscribed = false;
       component.event = eventMock;
       component.event.organizer.id = 56;
-      component.canUserJoinCloseEvent = false;
       component.event.isRelevant = false;
       component.checkButtonStatus();
       expect(component.btnStyle).toEqual(component.styleBtn.hiden);

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
@@ -7,7 +7,7 @@ import {
 import { IAppState } from 'src/app/store/state/app.state';
 import { IEcoEventsState } from 'src/app/store/state/ecoEvents.state';
 import { ActionsSubject, Store } from '@ngrx/store';
-import { take } from 'rxjs/operators';
+import { take, takeUntil } from 'rxjs/operators';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output } from '@angular/core';
 import { Router } from '@angular/router';
@@ -116,7 +116,7 @@ export class EventsListItemComponent implements OnInit, OnDestroy {
     private actionsSubj: ActionsSubject
   ) {
     this.subsOnAttendEvent = this.actionsSubj
-      .pipe(ofType(EventsActions.AddAttenderEcoEventsByIdSuccess))
+      .pipe(ofType(EventsActions.AddAttenderEcoEventsByIdSuccess), takeUntil(this.destroyed$))
       .subscribe((action: { id: number; type: string }) => {
         if (action.id === this.event.id) {
           this.nameBtn = this.btnName.cancel;

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
@@ -118,7 +118,9 @@ export class EventsListItemComponent implements OnInit, OnDestroy {
     this.subsOnAttendEvent = this.actionsSubj
       .pipe(ofType(EventsActions.AddAttenderEcoEventsByIdSuccess))
       .subscribe((action: { id: number; type: string }) => {
-        if (action.id === this.event.id) this.nameBtn = this.btnName.cancel;
+        if (action.id === this.event.id) {
+          this.nameBtn = this.btnName.cancel;
+        }
       });
   }
 

--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.ts
@@ -1,11 +1,12 @@
 import {
   AddAttenderEcoEventsByIdAction,
   DeleteEcoEventAction,
+  EventsActions,
   RemoveAttenderEcoEventsByIdAction
 } from 'src/app/store/actions/ecoEvents.actions';
 import { IAppState } from 'src/app/store/state/app.state';
 import { IEcoEventsState } from 'src/app/store/state/ecoEvents.state';
-import { Store } from '@ngrx/store';
+import { ActionsSubject, Store } from '@ngrx/store';
 import { take } from 'rxjs/operators';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output } from '@angular/core';
@@ -26,6 +27,7 @@ import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
 import { userAssignedCardsIcons } from 'src/app/main/image-pathes/profile-icons';
 import { JwtService } from '@global-service/jwt/jwt.service';
+import { ofType } from '@ngrx/effects';
 
 @Component({
   selector: 'app-events-list-item',
@@ -79,7 +81,7 @@ export class EventsListItemComponent implements OnInit, OnDestroy {
     popupCancel: 'homepage.events.delete-no',
     style: 'green'
   };
-  public canUserJoinCloseEvent: boolean;
+  subsOnAttendEvent = new Subscription();
 
   @Output() public isLoggedIn: boolean;
   @Output() idOfUnFavouriteEvent = new EventEmitter<number>();
@@ -110,8 +112,15 @@ export class EventsListItemComponent implements OnInit, OnDestroy {
     private eventService: EventsService,
     private translate: TranslateService,
     private snackBar: MatSnackBarComponent,
-    private jwtService: JwtService
-  ) {}
+    private jwtService: JwtService,
+    private actionsSubj: ActionsSubject
+  ) {
+    this.subsOnAttendEvent = this.actionsSubj
+      .pipe(ofType(EventsActions.AddAttenderEcoEventsByIdSuccess))
+      .subscribe((action: { id: number; type: string }) => {
+        if (action.id === this.event.id) this.nameBtn = this.btnName.cancel;
+      });
+  }
 
   ngOnInit(): void {
     this.itemTags = typeFiltersData.reduce((ac, cur) => [...ac, { ...cur }], []);

--- a/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.html
+++ b/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.html
@@ -40,7 +40,7 @@
       <p>{{ 'profile.rate' | translate }}: {{ userInfo.rating || mockedUserInfo.rating }}</p>
     </div>
     <div class="social" *ngIf="userSocialNetworks">
-      <a *ngFor="let item of userSocialNetworks" [href]="item.link">
+      <a *ngFor="let item of userSocialNetworks" [href]="item.link" target="_blank" rel="noopener">
         <img [src]="getSocialImage(item.link)" class="social-img" alt="Social image" [matTooltip]="item.link" />
       </a>
     </div>


### PR DESCRIPTION
[#6921](https://github.com/ita-social-projects/GreenCity/issues/6921) - [Events] The 'Join event' button is replaced by the 'Сancel request' button only after the page is refreshed 
[#6924 ](https://github.com/ita-social-projects/GreenCity/issues/6924) - [My Space. Social network] The social network page is opened in the current browser tab when the user clicks on the social network icon