### PR TITLE
bugfix/#6845 - add no-space validation to create event description

### DIFF
--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.html
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.html
@@ -108,11 +108,11 @@
         <div class="textarea-wrapper">
           <div class="title-container">
             <h3 class="textarea-title">{{ 'create-event.textarea-title' | translate }}</h3>
-            <p class="textarea-description" [class.error]="description?.touched && description?.invalid">
+            <p class="textarea-description" [class.error]="description?.touched && editorText?.invalid">
               {{ 'create-event.content-tooltip' | translate }}
             </p>
           </div>
-          <div [class.content-error]="description?.touched && description?.invalid" class="content">
+          <div [class.content-error]="description?.touched && editorText?.invalid" class="content">
             <quill-editor
               class="editor"
               ngDefaultControl
@@ -122,8 +122,9 @@
               placeholder="{{ 'create-event.content-placeholder' | translate }}"
             ></quill-editor>
           </div>
-          <p [ngClass]="{ 'counter-description': true, error: description?.invalid, hidden: !editorText }">
-            {{ 'create-event.counter' | translate }} {{ editorText.length }} {{ 'create-event.symbols' | translate }}
+          <p [ngClass]="{ 'counter-description': true, error: editorText?.invalid, hidden: !editorText.value.length }">
+            {{ 'create-event.counter' | translate }} {{ editorText.value.length }}
+            {{ 'create-event.symbols' | translate }}
           </p>
         </div>
 

--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.html
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.html
@@ -108,13 +108,12 @@
         <div class="textarea-wrapper">
           <div class="title-container">
             <h3 class="textarea-title">{{ 'create-event.textarea-title' | translate }}</h3>
-            <div [class.error]="description?.touched && description?.invalid">
-              <p class="textarea-description">{{ 'create-event.content-tooltip' | translate }}</p>
-            </div>
+            <p class="textarea-description" [class.error]="description?.touched && description?.invalid">
+              {{ 'create-event.content-tooltip' | translate }}
+            </p>
           </div>
           <div [class.content-error]="description?.touched && description?.invalid" class="content">
             <quill-editor
-              minlength="20"
               class="editor"
               ngDefaultControl
               formControlName="description"
@@ -123,11 +122,9 @@
               placeholder="{{ 'create-event.content-placeholder' | translate }}"
             ></quill-editor>
           </div>
-          <div [class.counter-error]="description?.invalid">
-            <p *ngIf="editorText" [ngClass]="handleErrorClass('counter-error') || 'counter-description'">
-              {{ 'create-event.counter' | translate }} {{ editorText.length }} {{ 'create-event.symbols' | translate }}
-            </p>
-          </div>
+          <p [ngClass]="{ 'counter-description': true, error: description?.invalid, hidden: !editorText }">
+            {{ 'create-event.counter' | translate }} {{ editorText.length }} {{ 'create-event.symbols' | translate }}
+          </p>
         </div>
 
         <app-images-container

--- a/src/app/main/component/events/components/create-edit-events/create-edit-events.component.scss
+++ b/src/app/main/component/events/components/create-edit-events/create-edit-events.component.scss
@@ -226,8 +226,7 @@
   align-items: flex-end;
 }
 
-.counter-description,
-.counter-error {
+.counter-description {
   margin-top: 5px;
   margin-bottom: -5px;
   font-size: 12px;
@@ -235,12 +234,12 @@
   justify-content: flex-end;
 }
 
-.counter-error {
+.error {
   color: var(--error-red);
 }
 
-.error {
-  color: var(--error-red);
+.hidden {
+  visibility: hidden;
 }
 
 @media (max-width: 1199px) {

--- a/src/app/main/component/events/components/event-details/event-details.component.ts
+++ b/src/app/main/component/events/components/event-details/event-details.component.ts
@@ -125,7 +125,7 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    if (!this.eventService.getForm()) {
+    if (this.route.snapshot.params.id) {
       this.eventId = this.route.snapshot.params.id;
       this.localStorageService.userIdBehaviourSubject.subscribe((id) => {
         this.userId = Number(id);


### PR DESCRIPTION
[#6845](https://github.com/ita-social-projects/GreenCity/issues/6845) - [Create Event] a user can publish an event by entering only a space in the 'Event Description' field 