### PR TITLE
Bugfix/#6917/fix comment like icon

### DIFF
--- a/src/app/main/component/comments/components/like-comment/like-comment.component.spec.ts
+++ b/src/app/main/component/comments/components/like-comment/like-comment.component.spec.ts
@@ -124,6 +124,7 @@ describe('LikeCommentComponent', () => {
       liked: true,
       userId: 1111
     };
+    (component as any).userId = 1111;
     // @ts-ignore
     spyOn(component.socketService, 'onMessage').and.returnValue(of(msg));
     const spy = spyOn(component, 'changeLkeBtn');

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -129,7 +129,7 @@
             </li>
             <!-- Chat icon -->
             <li
-              *ngIf="!isAllSearchOpen && !isUBS"
+              *ngIf="!isAllSearchOpen && !isUBS && isLoggedIn"
               aria-label="site search"
               class="chat-icon"
               role="chat"


### PR DESCRIPTION
[6917](https://github.com/ita-social-projects/GreenCity/issues/6917) - An unauthorized user can open a chat
fix comment like icon - If one user clicks comment-like button all other users see that button changes the collor. The colour should be changed only for current user