### PR TITLE
guard to prevent navigation back if mat dialog is opened

### DIFF
--- a/src/app/shared/guards/prevent-navigation-back.guard.spec.ts
+++ b/src/app/shared/guards/prevent-navigation-back.guard.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { PreventNavigationBackGuard } from './prevent-navigation-back.guard';
+import { MatDialog } from '@angular/material/dialog';
+import { ComponentCanDeactivate } from '@global-service/pending-changes-guard/pending-changes.guard';
+
+describe('PreventNavigationBackGuard', () => {
+  let guard: PreventNavigationBackGuard;
+  let dialogSpy: jasmine.SpyObj<MatDialog>;
+  const dialogSpyObj = jasmine.createSpyObj('MatDialog', ['openDialogs', 'closeAll']);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: MatDialog, useValue: dialogSpyObj }]
+    });
+    guard = TestBed.inject(PreventNavigationBackGuard);
+    dialogSpy = TestBed.inject(MatDialog) as jasmine.SpyObj<MatDialog>;
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it('should allow navigation back when dialogs are not open', () => {
+    dialogSpyObj.openDialogs = [];
+    const spy = spyOn(history, 'pushState');
+    const result = guard.canDeactivate({} as ComponentCanDeactivate);
+    expect(result).toBeTruthy();
+    expect(dialogSpyObj.closeAll).not.toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalledWith(null, '');
+  });
+
+  it('should prevent navigation back and close dialogs when dialogs are open', () => {
+    dialogSpyObj.openDialogs = [{}];
+    const spy = spyOn(history, 'pushState');
+    const result = guard.canDeactivate({} as ComponentCanDeactivate);
+    expect(result).toBeFalsy();
+    expect(dialogSpyObj.closeAll).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(null, '');
+  });
+});

--- a/src/app/shared/guards/prevent-navigation-back.guard.ts
+++ b/src/app/shared/guards/prevent-navigation-back.guard.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { CanDeactivate } from '@angular/router';
+import { ComponentCanDeactivate } from '@global-service/pending-changes-guard/pending-changes.guard';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PreventNavigationBackGuard implements CanDeactivate<ComponentCanDeactivate> {
+  constructor(private dialog: MatDialog) {}
+
+  canDeactivate(component: ComponentCanDeactivate): boolean {
+    if (this.dialog.openDialogs.length) {
+      this.dialog.closeAll();
+      history.pushState(null, '');
+      return false;
+    } else {
+      return true;
+    }
+  }
+}

--- a/src/app/ubs/ubs/components/ubs-main-page/ubs-main-page.component.ts
+++ b/src/app/ubs/ubs/components/ubs-main-page/ubs-main-page.component.ts
@@ -251,6 +251,7 @@ export class UbsMainPageComponent implements OnInit, OnDestroy, AfterViewChecked
     const dialogRef = this.dialog.open(UbsOrderLocationPopupComponent, {
       hasBackdrop: true,
       disableClose: false,
+      closeOnNavigation: true,
       data: locationsData
     });
 

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -375,7 +375,8 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
     this.isDialogOpen = true;
     const dialogRef = this.dialog.open(UbsOrderLocationPopupComponent, {
       hasBackdrop: true,
-      disableClose: false
+      disableClose: false,
+      closeOnNavigation: false
     });
 
     dialogRef
@@ -392,6 +393,9 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
   openExtraPackages(): void {
     const dialogConfig = new MatDialogConfig();
     dialogConfig.panelClass = 'extra-packages';
+    dialogConfig.closeOnNavigation = false;
+    dialogConfig.hasBackdrop = true;
+
     this.dialog.open(ExtraPackagesPopUpComponent, dialogConfig);
   }
 

--- a/src/app/ubs/ubs/ubs-routing.module.ts
+++ b/src/app/ubs/ubs/ubs-routing.module.ts
@@ -9,6 +9,7 @@ import { UbsSubmitOrderNotificationComponent } from './components/ubs-submit-ord
 import { ConfirmRestorePasswordComponent } from '@global-auth/confirm-restore-password/confirm-restore-password.component';
 import { ConfirmRestorePasswordGuard } from '@global-service/route-guards/confirm-restore-password.guard';
 import { UBSOrderDetailsComponent } from './components/ubs-order-details/ubs-order-details.component';
+import { PreventNavigationBackGuard } from 'src/app/shared/guards/prevent-navigation-back.guard';
 
 const ubsRoutes: Routes = [
   {
@@ -16,7 +17,7 @@ const ubsRoutes: Routes = [
     component: UbsOrderComponent,
     children: [
       { path: '', component: UbsMainPageComponent },
-      { path: 'order', component: UBSOrderFormComponent, canActivate: [AuthPageGuardService] },
+      { path: 'order', component: UBSOrderFormComponent, canActivate: [AuthPageGuardService], canDeactivate: [PreventNavigationBackGuard] },
       { path: 'confirm', component: UbsConfirmPageComponent, canActivate: [AuthPageGuardService] },
       { path: `notification/confirm/:orderId`, component: UbsSubmitOrderNotificationComponent, canActivate: [AuthPageGuardService] },
       { path: 'auth/restore', component: ConfirmRestorePasswordComponent, canActivate: [ConfirmRestorePasswordGuard] },


### PR DESCRIPTION
The guard has been added to prevent users from navigating to the previous page when they click the browser's back button. Now, the dialog closes, and the user remains on the order form.