### PR TITLE
Refactor font and color styles for edit profile and fix localization issue 

### DIFF
--- a/src/app/main/component/layout/components/footer/footer.component.scss
+++ b/src/app/main/component/layout/components/footer/footer.component.scss
@@ -6,7 +6,7 @@ footer {
 p,
 a,
 .footer_bottom-part {
-  font-family: var(--primary-font);
+  font-family: var(--tertiary-font);
   font-size: 12px;
   line-height: 16px;
 }
@@ -46,7 +46,7 @@ li {
 
 .footer_link-item {
   margin: 24px 24px 0 0;
-  color: var(--primary-dark-grey);
+  color: var(--quaternary-dark-grey);
 }
 
 .footer_social-wrp {

--- a/src/app/main/component/shared/components/input-google-autocomplete/input-google-autocomplete.component.scss
+++ b/src/app/main/component/shared/components/input-google-autocomplete/input-google-autocomplete.component.scss
@@ -2,7 +2,7 @@ input {
   border: 1px solid var(--quintynary-light-grey);
   border-radius: 4px;
   box-sizing: border-box;
-  font-family: var(--primary-font);
+  font-family: var(--tertiary-font);
   font-size: 14px;
   line-height: 20px;
   color: var(--freinacht-black);

--- a/src/app/main/component/user/components/profile/calendar/calendar-week/calendar-week.component.scss
+++ b/src/app/main/component/user/components/profile/calendar/calendar-week/calendar-week.component.scss
@@ -10,6 +10,7 @@
 
   .week {
     color: var(--quaternary-dark-grey);
+    text-transform: capitalize;
   }
 
   .arrow-next,

--- a/src/app/main/component/user/components/profile/calendar/calendar-week/calendar-week.component.ts
+++ b/src/app/main/component/user/components/profile/calendar/calendar-week/calendar-week.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CalendarBaseComponent } from '@shared/components/calendar-base/calendar-base.component';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { TranslateService } from '@ngx-translate/core';
-import { HabitAssignService } from './../../../../../../service/habit-assign/habit-assign.service';
+import { HabitAssignService } from '@global-service/habit-assign/habit-assign.service';
 import { LanguageService } from 'src/app/main/i18n/language.service';
 import { ReplaySubject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -10,6 +10,7 @@ import { CalendarWeekInterface } from '../calendar-week/calendar-week-interface'
 import { CalendarInterface } from '../calendar-interface';
 import { MatDialog } from '@angular/material/dialog';
 import { BreakpointObserver } from '@angular/cdk/layout';
+import { Locale } from 'src/app/main/i18n/Language';
 
 @Component({
   selector: 'app-calendar-week',
@@ -71,7 +72,7 @@ export class CalendarWeekComponent extends CalendarBaseComponent implements OnIn
   }
 
   private setDayName(source: Date): string {
-    return source.toLocaleDateString(this.language, { weekday: 'short' });
+    return source.toLocaleDateString(this.language === 'ua' ? Locale.UA : Locale.EN, { weekday: 'short' });
   }
 
   private getLanguage(): void {
@@ -83,10 +84,11 @@ export class CalendarWeekComponent extends CalendarBaseComponent implements OnIn
   }
 
   public buildWeekCalendarTitle(): void {
+    const language = this.language === 'ua' ? Locale.UA : Locale.EN;
     const firstDay = this.weekDates[0].date.getDate();
     const lastDay = this.weekDates[6].date.getDate();
-    const firstDayMonth = this.weekDates[0].date.toLocaleDateString(this.language, { month: 'long' });
-    const lastDayMonth = this.weekDates[6].date.toLocaleDateString(this.language, { month: 'long' });
+    const firstDayMonth = this.weekDates[0].date.toLocaleDateString(language, { month: 'long' });
+    const lastDayMonth = this.weekDates[6].date.toLocaleDateString(language, { month: 'long' });
     const firstDayYear = this.weekDates[0].date.getFullYear();
     const lastDayYear = this.weekDates[6].date.getFullYear();
     const weekBetweenTwoYears = `${firstDay} ${firstDayMonth} ${firstDayYear} - ${lastDay} ${lastDayMonth} ${lastDayYear}`;

--- a/src/app/main/component/user/components/profile/calendar/calendar.component.scss
+++ b/src/app/main/component/user/components/profile/calendar/calendar.component.scss
@@ -38,7 +38,7 @@
 
     .days {
       display: grid;
-      grid-template-columns: repeat(7, 30px);
+      grid-template-columns: repeat(7, 36px);
       justify-content: center;
       text-align: center;
       font-size: 11px;
@@ -168,6 +168,16 @@
   background-repeat: no-repeat;
   background-position: center;
   border-radius: 4px;
+}
+
+@media (min-width: 1024px) and (max-width: 1199px) {
+  .calendar {
+    .top {
+      .days {
+        grid-template-columns: repeat(7, 30px);
+      }
+    }
+  }
 }
 
 @media (max-width: 1023px) {

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.scss
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.scss
@@ -44,12 +44,14 @@ input:checked ~ .checkmark::after {
     margin-top: 40px;
 
     p {
-      font-family: var(--primary-font);
+      font-family: var(--tertiary-font);
+      color: var(--quaternary-dark-grey);
       font-style: normal;
       font-weight: 700;
       font-size: 24px;
       line-height: 32px;
       margin-bottom: 35px;
+      letter-spacing: 0.2px;
     }
 
     .input-block {
@@ -58,7 +60,7 @@ input:checked ~ .checkmark::after {
       margin-bottom: 28px;
 
       label {
-        font-family: var(--primary-font);
+        font-family: var(--tertiary-font);
         color: var(--quaternary-grey);
         font-style: normal;
         font-weight: 400;
@@ -73,7 +75,7 @@ input:checked ~ .checkmark::after {
         border: 1px solid var(--quintynary-light-grey);
         border-radius: 4px;
         box-sizing: border-box;
-        font-family: var(--primary-font);
+        font-family: var(--tertiary-font);
         font-size: 14px;
         line-height: 20px;
         color: var(--freinacht-black);
@@ -130,14 +132,15 @@ input:checked ~ .checkmark::after {
 }
 
 h2 {
-  font-family: var(--primary-font);
+  font-family: var(--tertiary-font);
   font-style: normal;
   font-weight: 700;
   height: 56px;
   font-size: 48px;
-  line-height: 48px;
+  line-height: 56px;
   margin-bottom: 40px;
   color: var(--quaternary-dark-grey);
+  letter-spacing: 0.2px;
 }
 
 .privacy-wrapper {
@@ -146,7 +149,7 @@ h2 {
   padding-bottom: 34px;
 
   .title {
-    font-family: var(--primary-font);
+    font-family: var(--tertiary-font);
     font-style: normal;
     font-weight: 700;
     font-size: 24px;
@@ -170,7 +173,7 @@ h2 {
 
       .label-wrapper {
         cursor: pointer;
-        font-family: var(--primary-font);
+        font-family: var(--tertiary-font);
         color: var(--quaternary-dark-grey);
         font-size: 14px;
         line-height: 20px;

--- a/src/app/main/component/user/components/profile/edit-profile/social-networks/social-networks.component.scss
+++ b/src/app/main/component/user/components/profile/edit-profile/social-networks/social-networks.component.scss
@@ -15,7 +15,7 @@
   align-items: center;
 
   p {
-    font-family: var(--primary-font);
+    font-family: var(--tertiary-font);
     color: var(--quaternary-dark-grey);
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -84,7 +84,7 @@
 }
 
 .add-button {
-  font-family: var(--primary-font);
+  font-family: var(--tertiary-font);
   font-style: normal;
   font-weight: 700;
   font-size: 14px;
@@ -93,6 +93,7 @@
   border: transparent;
   background-color: transparent;
   padding: 0;
+  letter-spacing: 0.02em;
 
   &:focus {
     outline: none;

--- a/src/app/main/i18n/Language.ts
+++ b/src/app/main/i18n/Language.ts
@@ -5,7 +5,7 @@ export enum Language {
   UK = 'uk'
 }
 
-export enum Locate {
+export enum Locale {
   UA = 'uk-UA',
   EN = 'en-GB'
 }

--- a/src/app/shared/header/header.component.scss
+++ b/src/app/shared/header/header.component.scss
@@ -754,9 +754,23 @@ header {
 }
 
 @media (min-width: 320px) and (max-width: 480px) {
-  .header_navigation-menu-right-list li {
-    padding: 10px 0;
-    margin-right: 5px;
+  .header_navigation-menu {
+    .header_navigation-menu-right {
+      .header_navigation-menu-right-list {
+        .lang-option {
+          padding: 10px 0;
+        }
+
+        .chat-icon,
+        .search-icon {
+          margin-right: 10px;
+        }
+      }
+    }
+  }
+
+  .header_burger-btn {
+    margin-left: 8px;
   }
 
   .header_navigation-menu-ubs .header_navigation-menu-right {

--- a/src/typography/_typography.scss
+++ b/src/typography/_typography.scss
@@ -117,13 +117,14 @@
   line-height: 28px;
   font-size: 18px;
   padding: 8px 24px;
-  font-family: var(--primary-font);
+  font-family: var(--tertiary-font);
   border-radius: 4px;
   font-style: normal;
   font-weight: 700;
   border: none;
   background: none;
   cursor: pointer;
+  letter-spacing: 0.2px;
 }
 
 .primary-global-button {


### PR DESCRIPTION
  - change font-family from `primary-font` to `tertiary-font`;
  - add color `quaternary-dark-grey`;
  - rename enum from `Locate` to `Locale` for better clarity
  - update CSS styles for header navigation menu and burger button on smaller screens
  - modify `setDayName`  to use Locale enum for language-specific formatting of date.
  - fix localization formatting issue in `buildWeekCalendarTitle` in calendar-week.