### PR TITLE
Filtering predictions response to remove duplicates in "street" word

### DIFF
--- a/src/app/main/component/shared/components/input-google-autocomplete/input-google-autocomplete.component.ts
+++ b/src/app/main/component/shared/components/input-google-autocomplete/input-google-autocomplete.component.ts
@@ -110,8 +110,11 @@ export class InputGoogleAutocompleteComponent implements OnInit, OnDestroy, Cont
           ...this.autoCompRequest
         };
 
-        this.autocompleteService.getPlacePredictions(request, (cityPredictionList) => {
-          this.predictionList = cityPredictionList?.filter((city) => !regex.test(city.description)) ?? [];
+        this.autocompleteService.getPlacePredictions(request, (predictions: google.maps.places.AutocompletePrediction[]) => {
+          predictions =
+            predictions?.filter((prediction) => !regex.test(prediction.description) && !prediction.terms[0].value.includes('вул.')) ?? [];
+
+          this.predictionList = predictions;
         });
       } else {
         this.predictionList = [];


### PR DESCRIPTION
- Added filtering for `predictions` array we're getting from google places api to filter all streets with abbreviation "вул."
- Changes removes all duplicates with abbreviations and leaves only one variant of the street name