### PR TITLE
Fixed eco-events element overlapping the home page

### DIFF
--- a/src/app/main/component/home/components/eco-events/eco-events.component.scss
+++ b/src/app/main/component/home/components/eco-events/eco-events.component.scss
@@ -27,6 +27,7 @@
   margin: 0 auto;
   vertical-align: top;
   width: fit-content;
+  max-width: 100%;
 }
 
 .eco-events .eco-events-wrapper .main-event {


### PR DESCRIPTION
- Added max-width property for news components to not overlap the home page