### PR TITLE
[Events] The 'Сancel request' button is replaced by the 'Join event' button only after the page is refreshed

### DIFF
--- a/src/app/main/component/shared/components/events-list-item/events-list-item.component.html
+++ b/src/app/main/component/shared/components/events-list-item/events-list-item.component.html
@@ -68,6 +68,10 @@
       <button
         *ngIf="isActive || !isOwner || isAdmin"
         class="{{ btnStyle }} event-button m-btn"
+        [ngClass]="{
+          'secondary-global-button': btnName.join !== nameBtn,
+          'primary-global-button': btnName.join === nameBtn
+        }"
         (click)="buttonAction(nameBtn)"
         [disabled]="nameBtn === btnName.requestSent"
       >


### PR DESCRIPTION
[6926](https://github.com/ita-social-projects/GreenCity/issues/6926) - [Events] The 'Сancel request' button is replaced by the 'Join event' button only after the page is refreshed