### PR TITLE
Fix message loading by page

### DIFF
--- a/src/app/chat/model/Message.model.ts
+++ b/src/app/chat/model/Message.model.ts
@@ -12,3 +12,7 @@ export interface Messages {
   totalElements: number;
   totalPages: number;
 }
+
+export interface MessagesToSave extends Messages {
+  newMessagesAmount?: number;
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-edit-form/ubs-admin-employee-edit-form.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-edit-form/ubs-admin-employee-edit-form.component.html
@@ -100,7 +100,7 @@
                     <th class="col-city">{{ 'ubs-employee.tariffs-columns.city' | translate }}</th>
                     <th class="col-courier">{{ 'ubs-employee.tariffs-columns.courier' | translate }}</th>
                     <th class="col-actions">{{ 'ubs-employee.tariffs-columns.chat' | translate }}</th>
-                    <th class="col-actions"></th>
+                    <th class="col-actions">{{ 'ubs-employee.tariffs-columns.tariff' | translate }}</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -637,7 +637,8 @@
       "city": "City",
       "station": "Station",
       "courier": "Courier",
-      "chat": "Chat"
+      "chat": "Chat",
+      "tariff": "Tariff"
     },
     "tariffs-selector": {
       "title": "Add tariffs",

--- a/src/assets/i18n/ubs-admin/ua.json
+++ b/src/assets/i18n/ubs-admin/ua.json
@@ -634,7 +634,8 @@
       "city": "Місто",
       "station": "Станція",
       "courier": "Кур'єр",
-      "chat": "Чат"
+      "chat": "Чат",
+      "tariff": "Тариф"
     },
     "tariffs-selector": {
       "title": "Додати тарифи",


### PR DESCRIPTION
The list of chat messages contains messages received from HTTP requests and from socket messages. When the user scrolls to load more messages, the next page is loaded, but the messages are duplicated because the total amount of messages changes.