### PR TITLE
bugfix/#7290 Confirmation tab of order does not load is sender is another person

### DIFF
--- a/src/app/store/actions/order.actions.ts
+++ b/src/app/store/actions/order.actions.ts
@@ -10,6 +10,7 @@ export enum OrderActions {
   SetCertificates = '[Order] Set Certificates',
   SetCertificateUsed = '[Order] Set Certificate Used',
   SetFirstFormStatus = '[Order] Set First Form Status',
+  SetSecondFormStatus = '[Order] Set Second Form Status',
   SetPersonalData = '[Order] Set Personal Data',
   SetAddress = '[Order] Set Address',
   SetAdditionalOrders = '[Order] Set Additional Orders',
@@ -68,6 +69,7 @@ export const SetPointsUsed = createAction(OrderActions.SetPointsUsed, props<{ po
 export const SetCertificates = createAction(OrderActions.SetCertificates, props<{ certificates: string[] }>());
 export const SetCertificateUsed = createAction(OrderActions.SetCertificateUsed, props<{ certificateUsed: number }>());
 export const SetFirstFormStatus = createAction(OrderActions.SetFirstFormStatus, props<{ isValid: boolean }>());
+export const SetSecondFormStatus = createAction(OrderActions.SetSecondFormStatus, props<{ isValid: boolean }>());
 export const SetPersonalData = createAction(OrderActions.SetPersonalData, props<{ personalData: PersonalData }>());
 export const SetAdditionalOrders = createAction(OrderActions.SetAdditionalOrders, props<{ orders: string[] }>());
 export const SetOrderComment = createAction(OrderActions.SetOrderComment, props<{ comment: string }>());

--- a/src/app/store/reducers/order.reducer.ts
+++ b/src/app/store/reducers/order.reducer.ts
@@ -33,7 +33,8 @@ import {
   SetAddress,
   UpdateAddress,
   DeleteAddress,
-  CreateAddress
+  CreateAddress,
+  SetSecondFormStatus
 } from '../actions/order.actions';
 import { createReducer, on } from '@ngrx/store';
 
@@ -222,16 +223,22 @@ export const orderReducer = createReducer(
       orderDetails: { ...state.orderDetails, certificates: action.certificates }
     };
   }),
-  on(SetFirstFormStatus, (state, action) => {
-    return {
-      ...state,
-      firstFormValid: action.isValid
-    };
-  }),
+  on(SetFirstFormStatus, (state, action) => ({
+    ...state,
+    firstFormValid: action.isValid
+  })),
+  on(SetSecondFormStatus, (state, action) => ({
+    ...state,
+    secondFormValid: action.isValid
+  })),
   on(SetPersonalData, (state, action) => {
+    console.warn('SetPersonalData', action.personalData);
     return {
       ...state,
-      personalData: action.personalData
+      personalData: {
+        ...state.personalData,
+        ...action.personalData
+      }
     };
   }),
   on(SetAdditionalOrders, (state, action) => {

--- a/src/app/store/reducers/order.reducer.ts
+++ b/src/app/store/reducers/order.reducer.ts
@@ -232,7 +232,6 @@ export const orderReducer = createReducer(
     secondFormValid: action.isValid
   })),
   on(SetPersonalData, (state, action) => {
-    console.warn('SetPersonalData', action.personalData);
     return {
       ...state,
       personalData: {

--- a/src/app/store/selectors/order.selectors.ts
+++ b/src/app/store/selectors/order.selectors.ts
@@ -31,6 +31,8 @@ export const pointsUsedSelector = createSelector(orderSelectors, (order) => orde
 
 export const isFirstFormValidSelector = createSelector(orderSelectors, (order) => order.firstFormValid);
 
+export const isSecondFormValidSelector = createSelector(orderSelectors, (order) => order.secondFormValid);
+
 export const isAddressLoadingSelector = createSelector(orderSelectors, (order) => order.isAddressLoading);
 
 export const isOrderDetailsLoadingSelector = createSelector(orderSelectors, (order) => order.isOrderDetailsLoading);

--- a/src/app/store/state/order.state.ts
+++ b/src/app/store/state/order.state.ts
@@ -14,6 +14,7 @@ export interface IOrderState {
   pointsUsed: number;
   isOrderDetailsLoading: boolean;
   firstFormValid: boolean;
+  secondFormValid: boolean;
   existingOrderInfo: IUserOrderInfo | null;
   personalData: PersonalData | null;
   isAddressLoading: boolean;
@@ -35,6 +36,7 @@ export const initialOrderState: IOrderState = {
   isOrderDetailsLoading: false,
   existingOrderInfo: null,
   firstFormValid: false,
+  secondFormValid: false,
   personalData: null,
   isAddressLoading: false,
   addresses: [],

--- a/src/app/ubs/ubs/components/ubs-order-form/ubs-order-form.component.html
+++ b/src/app/ubs/ubs/components/ubs-order-form/ubs-order-form.component.html
@@ -8,7 +8,7 @@
       <ng-template matStepLabel>{{ 'order-form.order-details' | translate }}</ng-template>
       <app-ubs-order-details #firstStep (secondStepDisabledChange)="isSecondStepDisabled = $event"></app-ubs-order-details>
     </mat-step>
-    <mat-step [stepControl]="secondStepForm">
+    <mat-step [stepControl]="secondStepForm" [completed]="isSecondFormValid$ | async">
       <ng-template matStepLabel>{{ 'order-form.personal-data' | translate }}</ng-template>
       <app-ubs-personal-information #secondStep></app-ubs-personal-information>
     </mat-step>

--- a/src/app/ubs/ubs/components/ubs-order-form/ubs-order-form.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-order-form/ubs-order-form.component.spec.ts
@@ -13,8 +13,9 @@ describe('UBSOrderFormComponent ', () => {
   let component: UBSOrderFormComponent;
   let fixture: ComponentFixture<UBSOrderFormComponent>;
 
-  const storeMock = jasmine.createSpyObj('Store', ['select', 'dispatch']);
+  const storeMock = jasmine.createSpyObj('Store', ['select', 'dispatch', 'pipe']);
   storeMock.select.and.returnValue(of({ order: ubsOrderServiseMock }));
+  storeMock.pipe.and.returnValue(of());
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({

--- a/src/app/ubs/ubs/components/ubs-order-form/ubs-order-form.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-form/ubs-order-form.component.ts
@@ -10,6 +10,7 @@ import { Store, select } from '@ngrx/store';
 import { IAppState } from 'src/app/store/state/app.state';
 import { OrderDetails, PersonalData } from '../../models/ubs.interface';
 import { ClearOrderData } from 'src/app/store/actions/order.actions';
+import { isSecondFormValidSelector } from 'src/app/store/selectors/order.selectors';
 
 @Component({
   selector: 'app-ubs-order-form',
@@ -22,6 +23,7 @@ export class UBSOrderFormComponent implements OnInit, AfterViewInit, DoCheck, On
   thirdStepForm: FormGroup;
   completed = false;
   isSecondStepDisabled = true;
+  isSecondFormValid$ = this.store.pipe(select(isSecondFormValidSelector));
   private statePersonalData: PersonalData;
   private stateOrderDetails: OrderDetails;
 

--- a/src/app/ubs/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
+++ b/src/app/ubs/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
@@ -11,7 +11,7 @@ import { PhoneNumberValidator } from 'src/app/shared/phone-validator/phone.valid
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { Masks, Patterns } from 'src/assets/patterns/patterns';
 import { Store, select } from '@ngrx/store';
-import { GetPersonalData, SetPersonalData, GetExistingOrderInfo } from 'src/app/store/actions/order.actions';
+import { GetPersonalData, SetPersonalData, GetExistingOrderInfo, SetSecondFormStatus } from 'src/app/store/actions/order.actions';
 import { addressIdSelector, existingOrderInfoSelector, personalDataSelector } from 'src/app/store/selectors/order.selectors';
 import { IUserOrderInfo } from 'src/app/ubs/ubs-user/ubs-user-orders-list/models/UserOrder.interface';
 import { WarningPopUpComponent } from '@shared/components';
@@ -173,6 +173,10 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
         this.senderEmail.setValue(this.email.value, { emitEvent: false });
       }
       this.dispatchPersonalData();
+    });
+
+    this.personalDataForm.statusChanges.pipe(takeUntil(this.$destroy)).subscribe(() => {
+      this.store.dispatch(SetSecondFormStatus({ isValid: this.personalDataForm.valid }));
     });
   }
 


### PR DESCRIPTION
[#7290](https://github.com/ita-social-projects/GreenCity/issues/7290)

- Fix issue with rewriting address in personal data if  checkbox'sender is another person' selected
- Disable confirmation step if personal data form is invalid