### PR TITLE
[Bugfix] #5333 add stepper guard to prevent navigation back

### DIFF
--- a/src/app/shared/guards/stepper/stepper.guard.spec.ts
+++ b/src/app/shared/guards/stepper/stepper.guard.spec.ts
@@ -1,0 +1,91 @@
+import { fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+
+import { RouterTestingModule } from '@angular/router/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { isObservable, Observable } from 'rxjs';
+import { currentStepSelector } from 'src/app/store/selectors/order.selectors';
+import { stepperGuard } from './stepper.guard';
+import { SetCurrentStep } from 'src/app/store/actions/order.actions';
+
+describe('stepperGuard', () => {
+  let store: MockStore;
+  let mockCurrentStepSelector;
+  let dispatchSpy;
+
+  const route: ActivatedRouteSnapshot = {} as any;
+  const state: RouterStateSnapshot = {} as any;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [provideMockStore()]
+    });
+
+    store = TestBed.inject<any>(MockStore);
+
+    mockCurrentStepSelector = store.overrideSelector(currentStepSelector, null);
+
+    dispatchSpy = spyOn(store, 'dispatch').and.callThrough();
+  });
+
+  it('should allow deactivation if current step is 0', fakeAsync(() => {
+    mockCurrentStepSelector.setResult(0);
+    const result = TestBed.runInInjectionContext(() => stepperGuard(route, state));
+
+    flush();
+
+    if (!isObservable(result)) {
+      expect(result).toBeInstanceOf(Observable);
+      return;
+    }
+
+    result.subscribe((value) => {
+      expect(value).toBeTrue();
+    });
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+
+    flush();
+  }));
+
+  it('should not allow deactivation if current step is 1', fakeAsync(() => {
+    mockCurrentStepSelector.setResult(1);
+    const result = TestBed.runInInjectionContext(() => stepperGuard(route, state));
+
+    flush();
+
+    if (!isObservable(result)) {
+      expect(result).toBeInstanceOf(Observable);
+      return;
+    }
+
+    result.subscribe((value) => {
+      expect(value).toBeFalse();
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledOnceWith(SetCurrentStep({ step: 0 }));
+
+    flush();
+  }));
+
+  it('should not allow deactivation if current step is 2', fakeAsync(() => {
+    mockCurrentStepSelector.setResult(2);
+    const result = TestBed.runInInjectionContext(() => stepperGuard(route, state));
+
+    flush();
+
+    if (!isObservable(result)) {
+      expect(result).toBeInstanceOf(Observable);
+      return;
+    }
+
+    result.subscribe((value) => {
+      expect(value).toBeFalse();
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledOnceWith(SetCurrentStep({ step: 1 }));
+
+    flush();
+  }));
+});

--- a/src/app/shared/guards/stepper/stepper.guard.ts
+++ b/src/app/shared/guards/stepper/stepper.guard.ts
@@ -1,0 +1,21 @@
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { map, take, tap } from 'rxjs';
+import { SetCurrentStep } from 'src/app/store/actions/order.actions';
+import { currentStepSelector } from 'src/app/store/selectors/order.selectors';
+
+export const stepperGuard: CanActivateFn = (route, state) => {
+  const store = inject(Store);
+
+  return store.select(currentStepSelector).pipe(
+    take(1),
+    tap((step: number) => {
+      if (step >= 1) {
+        history.pushState(null, '');
+        store.dispatch(SetCurrentStep({ step: step - 1 }));
+      }
+    }),
+    map((step) => step === 0)
+  );
+};

--- a/src/app/store/actions/order.actions.ts
+++ b/src/app/store/actions/order.actions.ts
@@ -4,6 +4,7 @@ import { Address, AddressData, CourierLocations, OrderDetails, PersonalData } fr
 import { CCertificate } from 'src/app/ubs/ubs/models/ubs.model';
 
 export enum OrderActions {
+  SetCurrentStep = '[Order] Set Current Step',
   SetBags = '[Order] Set Bags',
   SetOrderSum = '[Order] Set Order Sum',
   SetPointsUsed = '[Order] Set Points Used',
@@ -63,6 +64,7 @@ export enum OrderActions {
   ClearOrderData = '[Order] Clear Order Data'
 }
 
+export const SetCurrentStep = createAction(OrderActions.SetCurrentStep, props<{ step: number }>());
 export const SetBags = createAction(OrderActions.SetBags, props<{ bagId: number; bagValue: number }>());
 export const SetOrderSum = createAction(OrderActions.SetOrderSum, props<{ orderSum: number }>());
 export const SetPointsUsed = createAction(OrderActions.SetPointsUsed, props<{ pointsUsed: number }>());

--- a/src/app/store/reducers/order.reducer.ts
+++ b/src/app/store/reducers/order.reducer.ts
@@ -34,12 +34,17 @@ import {
   UpdateAddress,
   DeleteAddress,
   CreateAddress,
-  SetSecondFormStatus
+  SetSecondFormStatus,
+  SetCurrentStep
 } from '../actions/order.actions';
 import { createReducer, on } from '@ngrx/store';
 
 export const orderReducer = createReducer(
   initialOrderState,
+  on(SetCurrentStep, (state, action) => ({
+    ...state,
+    currentStep: action.step
+  })),
   on(SetBags, (state, action) => {
     const newBagVal = state.orderDetails.bags.map((item) => ({
       ...item,

--- a/src/app/store/selectors/order.selectors.ts
+++ b/src/app/store/selectors/order.selectors.ts
@@ -3,6 +3,8 @@ import { IAppState } from 'src/app/store/state/app.state';
 
 export const orderSelectors = (store: IAppState) => store.order;
 
+export const currentStepSelector = createSelector(orderSelectors, (order) => order.currentStep);
+
 export const orderDetailsSelector = createSelector(orderSelectors, (order) => order.orderDetails);
 
 export const personalDataSelector = createSelector(orderSelectors, (order) => order.personalData);

--- a/src/app/store/state/order.state.ts
+++ b/src/app/store/state/order.state.ts
@@ -3,6 +3,7 @@ import { PersonalData, OrderDetails, CourierLocations, Address } from 'src/app/u
 import { CCertificate } from 'src/app/ubs/ubs/models/ubs.model';
 
 export interface IOrderState {
+  currentStep: number;
   orderDetails: OrderDetails | null;
   courierLocations: CourierLocations | null;
   UBSCourierId: number | null;
@@ -24,6 +25,7 @@ export interface IOrderState {
 }
 
 export const initialOrderState: IOrderState = {
+  currentStep: 0,
   orderDetails: null,
   courierLocations: null,
   UBSCourierId: null,

--- a/src/app/ubs/ubs/components/ubs-order-form/ubs-order-form.component.html
+++ b/src/app/ubs/ubs/components/ubs-order-form/ubs-order-form.component.html
@@ -1,6 +1,6 @@
 <div class="container ubs-container">
   <h1 class="h1 text-center form-title">{{ 'order-form.ubs-courier' | translate }}</h1>
-  <mat-horizontal-stepper linear>
+  <mat-horizontal-stepper linear (selectionChange)="onSelectionChange($event)" [(selectedIndex)]="currentStep">
     <ng-template matStepperIcon="edit">
       <mat-icon class="text-light">check</mat-icon>
     </ng-template>

--- a/src/app/ubs/ubs/components/ubs-order-form/ubs-order-form.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-form/ubs-order-form.component.ts
@@ -49,7 +49,7 @@ export class UBSOrderFormComponent implements OnInit, AfterViewInit, DoCheck, On
     return true;
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.shareFormService.locationId = this.localStorageService.getLocationId();
     this.shareFormService.locations = this.localStorageService.getLocations();
     this.store.dispatch(SetCurrentStep({ step: 0 }));
@@ -63,11 +63,11 @@ export class UBSOrderFormComponent implements OnInit, AfterViewInit, DoCheck, On
     }, 0);
   }
 
-  onSelectionChange($event: StepperSelectionEvent) {
+  onSelectionChange($event: StepperSelectionEvent): void {
     this.store.dispatch(SetCurrentStep({ step: $event.selectedIndex }));
   }
 
-  private getOrderDetailsFromState() {
+  private getOrderDetailsFromState(): void {
     this.store.pipe(select((state: IAppState): OrderDetails => state.order.orderDetails)).subscribe((stateOrderDetails: OrderDetails) => {
       this.stateOrderDetails = stateOrderDetails;
       if (this.stateOrderDetails) {
@@ -104,7 +104,7 @@ export class UBSOrderFormComponent implements OnInit, AfterViewInit, DoCheck, On
     this.shareFormService.isDataSaved = false;
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
     this.store.dispatch(ClearOrderData());

--- a/src/app/ubs/ubs/components/ubs-order-form/ubs-order-form.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-form/ubs-order-form.component.ts
@@ -9,8 +9,10 @@ import { UBSOrderFormService } from '../../services/ubs-order-form.service';
 import { Store, select } from '@ngrx/store';
 import { IAppState } from 'src/app/store/state/app.state';
 import { OrderDetails, PersonalData } from '../../models/ubs.interface';
-import { ClearOrderData } from 'src/app/store/actions/order.actions';
-import { isSecondFormValidSelector } from 'src/app/store/selectors/order.selectors';
+import { ClearOrderData, SetCurrentStep } from 'src/app/store/actions/order.actions';
+import { currentStepSelector, isSecondFormValidSelector } from 'src/app/store/selectors/order.selectors';
+import { StepperSelectionEvent } from '@angular/cdk/stepper';
+import { Subject, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-ubs-order-form',
@@ -24,8 +26,11 @@ export class UBSOrderFormComponent implements OnInit, AfterViewInit, DoCheck, On
   completed = false;
   isSecondStepDisabled = true;
   isSecondFormValid$ = this.store.pipe(select(isSecondFormValidSelector));
+  currentStep = 0;
+
   private statePersonalData: PersonalData;
   private stateOrderDetails: OrderDetails;
+  private destroy$ = new Subject<void>();
 
   @ViewChild('firstStep') stepOneComponent: UBSOrderDetailsComponent;
   @ViewChild('secondStep') stepTwoComponent: UBSPersonalInformationComponent;
@@ -47,9 +52,19 @@ export class UBSOrderFormComponent implements OnInit, AfterViewInit, DoCheck, On
   ngOnInit() {
     this.shareFormService.locationId = this.localStorageService.getLocationId();
     this.shareFormService.locations = this.localStorageService.getLocations();
+    this.store.dispatch(SetCurrentStep({ step: 0 }));
+
+    this.store.pipe(select(currentStepSelector), takeUntil(this.destroy$)).subscribe((step: number) => {
+      this.currentStep = step;
+    });
+
     setTimeout(() => {
       this.getOrderDetailsFromState();
     }, 0);
+  }
+
+  onSelectionChange($event: StepperSelectionEvent) {
+    this.store.dispatch(SetCurrentStep({ step: $event.selectedIndex }));
   }
 
   private getOrderDetailsFromState() {
@@ -90,6 +105,8 @@ export class UBSOrderFormComponent implements OnInit, AfterViewInit, DoCheck, On
   }
 
   ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
     this.store.dispatch(ClearOrderData());
     this.saveDataOnLocalStorage();
   }

--- a/src/app/ubs/ubs/ubs-routing.module.ts
+++ b/src/app/ubs/ubs/ubs-routing.module.ts
@@ -10,6 +10,7 @@ import { ConfirmRestorePasswordComponent } from '@global-auth/confirm-restore-pa
 import { ConfirmRestorePasswordGuard } from '@global-service/route-guards/confirm-restore-password.guard';
 import { UBSOrderDetailsComponent } from './components/ubs-order-details/ubs-order-details.component';
 import { PreventNavigationBackGuard } from 'src/app/shared/guards/prevent-navigation-back.guard';
+import { stepperGuard } from 'src/app/shared/guards/stepper/stepper.guard';
 
 const ubsRoutes: Routes = [
   {
@@ -17,7 +18,12 @@ const ubsRoutes: Routes = [
     component: UbsOrderComponent,
     children: [
       { path: '', component: UbsMainPageComponent },
-      { path: 'order', component: UBSOrderFormComponent, canActivate: [AuthPageGuardService], canDeactivate: [PreventNavigationBackGuard] },
+      {
+        path: 'order',
+        component: UBSOrderFormComponent,
+        canActivate: [AuthPageGuardService],
+        canDeactivate: [PreventNavigationBackGuard, stepperGuard]
+      },
       { path: 'confirm', component: UbsConfirmPageComponent, canActivate: [AuthPageGuardService] },
       { path: `notification/confirm/:orderId`, component: UbsSubmitOrderNotificationComponent, canActivate: [AuthPageGuardService] },
       { path: 'auth/restore', component: ConfirmRestorePasswordComponent, canActivate: [ConfirmRestorePasswordGuard] },


### PR DESCRIPTION
[#5333](https://github.com/ita-social-projects/GreenCity/issues/5333)

Add stepper guard to prevent user from being redirected to main page instead of switching step of stepper to previous. 
- If user is on first step redirect back. 
- If user on second step switch current step to first
- If user on third step switch current step to second