### PR TITLE
[Style] Added space between login and register buttons

### DIFF
--- a/src/app/shared/header/header.component.scss
+++ b/src/app/shared/header/header.component.scss
@@ -183,6 +183,7 @@ header {
   display: flex;
   width: 145px;
   height: 36px;
+  margin: 0 10px;
   justify-content: center;
   align-items: center;
   color: var(--ubs-primary-black);


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/e5f42600-64b6-4f89-b0b2-bc37c2a3f44a)

After:

![image](https://github.com/user-attachments/assets/5edf8077-f4d3-4363-a80c-9666dd6caaef)
