### PR TITLE
[Bugfix] #6573 Hide filters buttons when no selected filters on admin orders page

### DIFF
--- a/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.html
@@ -1,5 +1,5 @@
 <ng-container class="dropdown-menu">
-  <div class="btn-group">
+  <div class="btn-group" *ngIf="selectedFiltersCount">
     <button type="button" class="btn filter-btn" [mat-dialog-close]="['clear', data.columnName]">
       {{ 'ubs-tables.clear-filters' | translate }}
     </button>

--- a/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.ts
@@ -30,6 +30,8 @@ export class ColumnFiltersPopUpComponent implements OnInit, OnDestroy {
 
   isPopupOpened = false;
 
+  selectedFiltersCount = 0;
+
   private allFilters: IFilters;
   private destroy$: Subject<void> = new Subject<void>();
 
@@ -90,9 +92,12 @@ export class ColumnFiltersPopUpComponent implements OnInit, OnDestroy {
 
   changeColumnFilters(checked: boolean, currentColumn: string, option: IFilteredColumnValue): void {
     const value = columnsToFilterByName.includes(currentColumn) ? option.en : option.key;
+
     checked
       ? this.store.dispatch(AddFilterMultiAction({ filter: { column: currentColumn, value }, fetchTable: true }))
       : this.store.dispatch(RemoveFilter({ filter: { column: currentColumn, value }, fetchTable: true }));
+
+    this.selectedFiltersCount = (this.allFilters?.[this.data.columnName] as string[]).length;
   }
 
   onDateChecked(e: MatCheckboxChange, checked: boolean): void {


### PR DESCRIPTION
**Ticket:** [**[#6573] [Admin cabinet. Orders] Buttons 'Застосувати' and 'Скасувати' are displayed when no filter items selected**](https://github.com/ita-social-projects/GreenCity/issues/7115)
___
Added a fix for displaying the "Apply" and "Cancel" buttons when selecting filters on the orders page of the admin panel.

### Result:
No selected case:
![Image](https://github.com/user-attachments/assets/de2f9e84-9e89-4a06-bef7-581df1bd07b5)
Selected case:
![Image](https://github.com/user-attachments/assets/a65bbf3d-97cc-4bcb-9918-8cfb44bd98e7)