### PR TITLE
[Bugfix] #6793 Hide unnecessary scrollbar from sign in/up modal

### DIFF
--- a/src/app/main/component/auth/components/auth-modal/auth-modal.component.scss
+++ b/src/app/main/component/auth/components/auth-modal/auth-modal.component.scss
@@ -38,6 +38,7 @@
     flex-direction: column;
     padding: 20px;
     box-sizing: border-box;
+    overflow: hidden;
 
     .close-modal-window {
       display: flex;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -300,8 +300,7 @@ body {
     box-shadow: none;
     border-radius: 4px;
     box-sizing: border-box;
-    overflow: auto;
-    overflow-x: hidden;
+    overflow: hidden;
     outline: 0;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
**Ticket:** [**[#6793] [Sign-in] When user moved to 'Sign-in' window, appeared scroll bar**](https://github.com/ita-social-projects/GreenCity/issues/6793)
___
Added a fix to the login and registration modal so that the scrollbar is displayed only on a small screen when necessary

### Result:
Normal size of window:
![Image](https://github.com/user-attachments/assets/157767ba-79ea-464b-a111-fdbb5c6756c0)
Small size of window:
![Image](https://github.com/user-attachments/assets/1a3404e6-acd8-426d-b06a-7820f1306ed4)