### PR TITLE
[Bugfix] #7399 Navigation Links Incorrectly Revert to Previous Order Step Instead of Redirecting to Desired Page

### DIFF
--- a/src/app/shared/guards/stepper/stepper.guard.spec.ts
+++ b/src/app/shared/guards/stepper/stepper.guard.spec.ts
@@ -1,17 +1,21 @@
-import { fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { TestBed, fakeAsync, flush } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 
-import { RouterTestingModule } from '@angular/router/testing';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
-import { isObservable, Observable } from 'rxjs';
-import { currentStepSelector } from 'src/app/store/selectors/order.selectors';
+import { Observable, isObservable } from 'rxjs';
 import { stepperGuard } from './stepper.guard';
+import { currentStepSelector } from 'src/app/store/selectors/order.selectors';
+
 import { SetCurrentStep } from 'src/app/store/actions/order.actions';
+import { PlatformLocation } from '@angular/common';
 
 describe('stepperGuard', () => {
   let store: MockStore;
   let mockCurrentStepSelector;
   let dispatchSpy;
+  let platformLocation: PlatformLocation;
+  let popStateCallback: () => void;
 
   const route: ActivatedRouteSnapshot = {} as any;
   const state: RouterStateSnapshot = {} as any;
@@ -19,13 +23,22 @@ describe('stepperGuard', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule],
-      providers: [provideMockStore()]
+      providers: [
+        provideMockStore(),
+        {
+          provide: PlatformLocation,
+          useValue: {
+            onPopState: (fn: () => void) => {
+              popStateCallback = fn;
+            }
+          }
+        }
+      ]
     });
 
     store = TestBed.inject<any>(MockStore);
-
+    platformLocation = TestBed.inject(PlatformLocation);
     mockCurrentStepSelector = store.overrideSelector(currentStepSelector, null);
-
     dispatchSpy = spyOn(store, 'dispatch').and.callThrough();
   });
 
@@ -49,9 +62,11 @@ describe('stepperGuard', () => {
     flush();
   }));
 
-  it('should not allow deactivation if current step is 1', fakeAsync(() => {
+  it('should not allow deactivation if current step is 1 and back button is pressed', fakeAsync(() => {
     mockCurrentStepSelector.setResult(1);
     const result = TestBed.runInInjectionContext(() => stepperGuard(route, state));
+
+    popStateCallback();
 
     flush();
 
@@ -69,9 +84,11 @@ describe('stepperGuard', () => {
     flush();
   }));
 
-  it('should not allow deactivation if current step is 2', fakeAsync(() => {
+  it('should not allow deactivation if current step is 2 and back button is pressed', fakeAsync(() => {
     mockCurrentStepSelector.setResult(2);
     const result = TestBed.runInInjectionContext(() => stepperGuard(route, state));
+
+    popStateCallback();
 
     flush();
 
@@ -85,6 +102,26 @@ describe('stepperGuard', () => {
     });
 
     expect(dispatchSpy).toHaveBeenCalledOnceWith(SetCurrentStep({ step: 1 }));
+
+    flush();
+  }));
+
+  it('should allow deactivation if navigation is not triggered by back button', fakeAsync(() => {
+    mockCurrentStepSelector.setResult(1);
+    const result = TestBed.runInInjectionContext(() => stepperGuard(route, state));
+
+    flush();
+
+    if (!isObservable(result)) {
+      expect(result).toBeInstanceOf(Observable);
+      return;
+    }
+
+    result.subscribe((value) => {
+      expect(value).toBeTrue();
+    });
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
 
     flush();
   }));

--- a/src/app/shared/guards/stepper/stepper.guard.ts
+++ b/src/app/shared/guards/stepper/stepper.guard.ts
@@ -1,3 +1,4 @@
+import { PlatformLocation } from '@angular/common';
 import { inject } from '@angular/core';
 import { CanActivateFn } from '@angular/router';
 import { Store } from '@ngrx/store';
@@ -7,15 +8,22 @@ import { currentStepSelector } from 'src/app/store/selectors/order.selectors';
 
 export const stepperGuard: CanActivateFn = (route, state) => {
   const store = inject(Store);
+  const platformLocation = inject(PlatformLocation);
+
+  let isBackNavigation = false;
+
+  platformLocation.onPopState(() => {
+    isBackNavigation = true;
+  });
 
   return store.select(currentStepSelector).pipe(
     take(1),
     tap((step: number) => {
-      if (step >= 1) {
+      if (isBackNavigation && step >= 1) {
         history.pushState(null, '');
         store.dispatch(SetCurrentStep({ step: step - 1 }));
       }
     }),
-    map((step) => step === 0)
+    map((step) => (isBackNavigation ? step === 0 : true))
   );
 };


### PR DESCRIPTION
Issue [#7399](https://github.com/ita-social-projects/GreenCity/issues/7399)
Related Issue [#5333](https://github.com/ita-social-projects/GreenCity/issues/5333)
Related pull-request  [#3233](https://github.com/ita-social-projects/GreenCityClient/pull/3233)

## Summary of changes
- Add PlatformLocation handling to stepperGuard for back button detection
- Update unit test to test deactivation of external redirection when back button works
