### PR TITLE
[Bugfix] #7105 Sorting Fix: Toggle Between Descending and Ascending Order on Click

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.html
@@ -238,10 +238,10 @@
               <mat-icon (click)="openColumnFilterPopup($event, column)">filter_list</mat-icon>
             </ng-container>
             <ng-container *ngIf="!nonSortableColumns.includes(column.title.key)">
-              <mat-icon *ngIf="arrowDirection !== column.title.key" (click)="getSortingData(column.title.key, 'ASC')">
+              <mat-icon *ngIf="arrowDirection === column.title.key" (click)="getSortingData(column.title.key, 'ASC')">
                 arrow_downward
               </mat-icon>
-              <mat-icon *ngIf="arrowDirection === column.title.key" (click)="getSortingData(column.title.key, 'DESC')">
+              <mat-icon *ngIf="arrowDirection !== column.title.key" (click)="getSortingData(column.title.key, 'DESC')">
                 arrow_upward
               </mat-icon>
             </ng-container>


### PR DESCRIPTION
[#7105](https://github.com/ita-social-projects/GreenCity/issues/7105)
After the first click on arrow sorting is in descending order - from high to low. After the second click on the arrow sorting is done in ascending order - from low to high

Before click:

![Знімок екрана 2024-09-05 223706](https://github.com/user-attachments/assets/ca9d011e-3ddb-422d-b9c4-56c12daa1433)

First click: 

![Знімок екрана 2024-09-05 223805](https://github.com/user-attachments/assets/f1fa9775-56f4-4104-b60d-ca40fa4e84d9)

Second click:

![Знімок екрана 2024-09-05 223909](https://github.com/user-attachments/assets/488e90eb-ee28-4a74-be27-262be826ae97)

