### PR TITLE
[Facts of the day] #7384 Add additional display of fact of the day by habit tag acquired by the user 

### DIFF
--- a/src/app/main/component/user/components/profile/profile-cards/profile-cards.component.html
+++ b/src/app/main/component/user/components/profile/profile-cards/profile-cards.component.html
@@ -6,4 +6,12 @@
       <img src="assets/img/wave_shape.png" alt="wave-background" />
     </div>
   </div>
+
+  <div class="card habit-card" *ngIf="habitFactOfTheDay">
+    <p class="cart-title">{{ 'profile.fact-of-the-day' | translate }}</p>
+    <p class="card-description">{{ habitFactOfTheDay?.content }}</p>
+    <div class="shape-img">
+      <img src="assets/img/wave_shape.png" alt="wave-background" />
+    </div>
+  </div>
 </div>

--- a/src/app/main/component/user/components/profile/profile-cards/profile-cards.component.scss
+++ b/src/app/main/component/user/components/profile/profile-cards/profile-cards.component.scss
@@ -38,6 +38,7 @@
       }
     }
   }
+
   .habit-card {
     background: #ccb7fa;
   }

--- a/src/app/main/component/user/components/profile/profile-cards/profile-cards.component.scss
+++ b/src/app/main/component/user/components/profile/profile-cards/profile-cards.component.scss
@@ -38,4 +38,7 @@
       }
     }
   }
+  .habit-card {
+    background: #ccb7fa;
+  }
 }

--- a/src/app/main/component/user/components/profile/profile-cards/profile-cards.component.spec.ts
+++ b/src/app/main/component/user/components/profile/profile-cards/profile-cards.component.spec.ts
@@ -1,45 +1,63 @@
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
-import { BehaviorSubject, of, Subscription, throwError } from 'rxjs';
+import { BehaviorSubject, of, throwError } from 'rxjs';
 import { ProfileService } from '@global-user/components/profile/profile-service/profile.service';
 import { HttpClientModule } from '@angular/common/http';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ProfileCardsComponent } from '@global-user/components';
 import { FactOfTheDay } from '@global-user/models/factOfTheDay';
+import { ProfileStatistics } from '@global-user/models/profile-statistiscs';
+import { TranslateModule } from '@ngx-translate/core';
 
 describe('ProfileCardsComponent', () => {
   let component: ProfileCardsComponent;
   let fixture: ComponentFixture<ProfileCardsComponent>;
   let profileServiceMock: jasmine.SpyObj<ProfileService>;
-  let localStorageService: LocalStorageService;
+  let localStorageServiceMock: jasmine.SpyObj<LocalStorageService>;
+  let languageSubject: BehaviorSubject<string>;
 
   const factOfTheDayMock: FactOfTheDay = { id: 1, content: 'Hello' };
+  const profileStatisticsMock: ProfileStatistics = {
+    amountHabitsInProgress: 1,
+    amountHabitsAcquired: 0,
+    amountPublishedNews: 0,
+    amountOrganizedAndAttendedEvents: 0
+  };
 
   beforeEach(waitForAsync(() => {
-    profileServiceMock = jasmine.createSpyObj<ProfileService>('ProfileService', ['getRandomFactOfTheDay']);
+    profileServiceMock = jasmine.createSpyObj('ProfileService', [
+      'getRandomFactOfTheDay',
+      'getUserProfileStatistics',
+      'getFactsOfTheDayByTags'
+    ]);
+
+    profileServiceMock.getRandomFactOfTheDay.and.returnValue(of(factOfTheDayMock));
+    profileServiceMock.getUserProfileStatistics.and.returnValue(of(profileStatisticsMock));
+    profileServiceMock.getFactsOfTheDayByTags.and.returnValue(of(factOfTheDayMock));
+
+    localStorageServiceMock = jasmine.createSpyObj('LocalStorageService', [
+      'getHabitFactFromLocalStorage',
+      'clearHabitFactFromLocalStorage',
+      'saveHabitFactToLocalStorage'
+    ]);
+
+    languageSubject = new BehaviorSubject<string>('ua');
+    localStorageServiceMock.languageBehaviourSubject = languageSubject;
 
     TestBed.configureTestingModule({
       declarations: [ProfileCardsComponent],
-      imports: [HttpClientModule],
+      imports: [HttpClientModule, TranslateModule.forRoot()],
       providers: [
         { provide: ProfileService, useValue: profileServiceMock },
-        { provide: LocalStorageService, useValue: { languageBehaviourSubject: new BehaviorSubject('ua') } }
+        { provide: LocalStorageService, useValue: localStorageServiceMock }
       ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ProfileCardsComponent);
     component = fixture.componentInstance;
-    localStorageService = TestBed.inject(LocalStorageService);
-    component.profileSubscription = new Subscription();
-    component.languageSubscription = new Subscription();
   }));
 
   afterEach(() => {
-    fixture = null;
-  });
-
-  afterAll(() => {
-    TestBed.resetTestingModule();
-    fixture?.destroy();
+    fixture.destroy();
   });
 
   it('should create the component', () => {
@@ -47,22 +65,18 @@ describe('ProfileCardsComponent', () => {
   });
 
   it('should get fact of the day on language change', () => {
-    const languageSubject = new BehaviorSubject<string>('ua');
-    spyOn(localStorageService.languageBehaviourSubject, 'subscribe').and.callThrough();
     spyOn(component, 'getFactOfTheDay').and.callThrough();
     fixture.detectChanges();
 
-    expect(localStorageService.languageBehaviourSubject.subscribe).toHaveBeenCalled();
     expect(component.getFactOfTheDay).toHaveBeenCalled();
 
     languageSubject.next('en');
     fixture.detectChanges();
 
-    expect(localStorageService.languageBehaviourSubject.subscribe).toHaveBeenCalledTimes(1);
-    expect(component.getFactOfTheDay).toHaveBeenCalledTimes(1);
+    expect(component.getFactOfTheDay).toHaveBeenCalledTimes(2);
   });
 
-  it('should set factOfTheDay on successful', () => {
+  it('should set factOfTheDay on successful response', () => {
     profileServiceMock.getRandomFactOfTheDay.and.returnValue(of(factOfTheDayMock));
     component.ngOnInit();
 
@@ -70,35 +84,48 @@ describe('ProfileCardsComponent', () => {
     expect(component.error).toBeUndefined();
   });
 
-  it('should handle success in getFactOfTheDay', () => {
-    profileServiceMock.getRandomFactOfTheDay.and.returnValue(of(factOfTheDayMock));
+  it('should handle error in getFactOfTheDay', () => {
+    const errorMessage = 'Error occurred';
+    profileServiceMock.getRandomFactOfTheDay.and.returnValue(throwError(() => new Error(errorMessage)));
+
     component.getFactOfTheDay();
 
-    expect(component.factOfTheDay).toEqual(factOfTheDayMock);
-    expect(component.error).toBeUndefined();
+    expect(component.error).toBe(errorMessage);
+    expect(component.factOfTheDay).toBeUndefined();
   });
 
-  it('should handle error', () => {
-    const errorMessage = 'Error message';
-    const errorResponse = new Error(errorMessage);
-    profileServiceMock.getRandomFactOfTheDay.and.returnValue(throwError(() => errorResponse.message));
-    component.ngOnInit();
+  it('should load habit fact from local storage', () => {
+    localStorageServiceMock.getHabitFactFromLocalStorage.and.returnValue(factOfTheDayMock);
 
-    expect(component.error).toEqual(errorMessage);
+    component.loadHabitFactFromLocalStorage();
+
+    expect(component.habitFactOfTheDay).toEqual(factOfTheDayMock);
   });
 
-  it('should unsubscribe from subscriptions on component destroy', () => {
-    component.profileSubscription = new Subscription();
-    component.languageSubscription = new Subscription();
-    spyOn(component.profileSubscription, 'unsubscribe');
-    spyOn(component.languageSubscription, 'unsubscribe');
+  it('should update habit fact if more than one day has passed', () => {
+    const profileStatisticsMock: ProfileStatistics = {
+      amountHabitsInProgress: 1,
+      amountHabitsAcquired: 0,
+      amountPublishedNews: 0,
+      amountOrganizedAndAttendedEvents: 0
+    };
+
+    profileServiceMock.getUserProfileStatistics.and.returnValue(of(profileStatisticsMock));
+
+    spyOn(component, 'updateHabitFactIfNeeded').and.callThrough();
+
+    component.checkAndUpdateHabitFact();
+
+    expect(component.updateHabitFactIfNeeded).toHaveBeenCalled();
+  });
+
+  it('should unsubscribe from observables on destroy', () => {
+    spyOn(component['destroy$'], 'next').and.callThrough();
+    spyOn(component['destroy$'], 'complete').and.callThrough();
+
     component.ngOnDestroy();
 
-    if (component.profileSubscription) {
-      expect(component.profileSubscription.unsubscribe).toHaveBeenCalled();
-    }
-    if (component.languageSubscription) {
-      expect(component.languageSubscription.unsubscribe).toHaveBeenCalled();
-    }
+    expect(component['destroy$'].next).toHaveBeenCalled();
+    expect(component['destroy$'].complete).toHaveBeenCalled();
   });
 });

--- a/src/app/main/component/user/components/profile/profile-cards/profile-cards.component.ts
+++ b/src/app/main/component/user/components/profile/profile-cards/profile-cards.component.ts
@@ -1,9 +1,10 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { catchError } from 'rxjs/operators';
-import { Subscription } from 'rxjs';
+import { catchError, take } from 'rxjs/operators';
+import { Subscription, of, timer } from 'rxjs';
 import { FactOfTheDay } from '@global-user/models/factOfTheDay';
 import { ProfileService } from '../profile-service/profile.service';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
+import { ProfileStatistics } from '@global-user/models/profile-statistiscs';
 
 @Component({
   selector: 'app-profile-cards',
@@ -13,7 +14,9 @@ import { LocalStorageService } from '@global-service/localstorage/local-storage.
 export class ProfileCardsComponent implements OnInit, OnDestroy {
   profileSubscription: Subscription;
   languageSubscription: Subscription;
+  dailyUpdateSubscription: Subscription;
   factOfTheDay: FactOfTheDay;
+  habitFactOfTheDay: FactOfTheDay;
   error: string;
 
   constructor(
@@ -23,8 +26,27 @@ export class ProfileCardsComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.languageSubscription = this.localStorageService.languageBehaviourSubject.subscribe(() => {
+      this.loadFactsFromLocalStorage();
       this.getFactOfTheDay();
+      this.checkAndUpdateHabitFact();
     });
+
+    this.dailyUpdateSubscription = timer(0, 24 * 60 * 60 * 1000).subscribe(() => {
+      this.checkAndUpdateHabitFact();
+    });
+  }
+
+  loadFactsFromLocalStorage() {
+    const savedHabitFact = localStorage.getItem('habitFactOfTheDay');
+    const lastHabitFetchTime = localStorage.getItem('lastHabitFactFetchTime');
+    const currentTime = Date.now();
+    const oneDay = 24 * 60 * 60 * 1000;
+
+    if (savedHabitFact && lastHabitFetchTime && currentTime - Number(lastHabitFetchTime) < oneDay) {
+      this.habitFactOfTheDay = JSON.parse(savedHabitFact);
+    } else {
+      this.habitFactOfTheDay = null;
+    }
   }
 
   getFactOfTheDay(): void {
@@ -41,8 +63,52 @@ export class ProfileCardsComponent implements OnInit, OnDestroy {
       });
   }
 
+  checkAndUpdateHabitFact(): void {
+    this.profileService
+      .getUserProfileStatistics()
+      .pipe(
+        take(1),
+        catchError(() => of(null))
+      )
+      .subscribe((profileStats: ProfileStatistics) => {
+        if (profileStats?.amountHabitsInProgress > 0) {
+          this.updateHabitFactIfNeeded();
+        } else {
+          this.clearHabitFact();
+        }
+      });
+  }
+
+  updateHabitFactIfNeeded(): void {
+    const lastHabitFetchTime = localStorage.getItem('lastHabitFactFetchTime');
+    const currentTime = Date.now();
+    const oneDay = 60 * 1000;
+
+    if (!lastHabitFetchTime || currentTime - Number(lastHabitFetchTime) > oneDay) {
+      this.clearHabitFact();
+
+      this.profileService
+        .getFactsOfTheDayByTags()
+        .pipe(catchError(() => of(null)))
+        .subscribe((fact: FactOfTheDay | null) => {
+          if (fact) {
+            this.habitFactOfTheDay = fact;
+            localStorage.setItem('habitFactOfTheDay', JSON.stringify(fact));
+            localStorage.setItem('lastHabitFactFetchTime', currentTime.toString());
+          }
+        });
+    }
+  }
+
+  clearHabitFact(): void {
+    this.habitFactOfTheDay = null;
+    localStorage.removeItem('habitFactOfTheDay');
+    localStorage.removeItem('lastHabitFactFetchTime');
+  }
+
   ngOnDestroy(): void {
     this.profileSubscription.unsubscribe();
     this.languageSubscription.unsubscribe();
+    this.dailyUpdateSubscription.unsubscribe();
   }
 }

--- a/src/app/main/component/user/components/profile/profile-cards/profile-cards.component.ts
+++ b/src/app/main/component/user/components/profile/profile-cards/profile-cards.component.ts
@@ -16,7 +16,6 @@ export class ProfileCardsComponent implements OnInit, OnDestroy {
   factOfTheDay: FactOfTheDay;
   habitFactOfTheDay: FactOfTheDay;
   error: string;
-  oneDayInMillis = 24 * 60 * 60 * 1000;
 
   constructor(
     private profileService: ProfileService,
@@ -30,7 +29,7 @@ export class ProfileCardsComponent implements OnInit, OnDestroy {
       this.checkAndUpdateHabitFact();
     });
 
-    timer(0, this.oneDayInMillis)
+    timer(0, this.localStorageService.ONE_DAY_IN_MILLIS)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.checkAndUpdateHabitFact());
   }
@@ -73,9 +72,9 @@ export class ProfileCardsComponent implements OnInit, OnDestroy {
   }
 
   updateHabitFactIfNeeded(): void {
-    const lastHabitFetchTime = localStorage.getItem('lastHabitFactFetchTime');
+    const lastHabitFetchTime = localStorage.getItem('lastHabitFetchTime');
     const currentTime = Date.now();
-    const oneDay = this.oneDayInMillis;
+    const oneDay = this.localStorageService.ONE_DAY_IN_MILLIS;
 
     if (this.isMoreThanOneDayPassed(lastHabitFetchTime, currentTime, oneDay)) {
       this.clearHabitFact();

--- a/src/app/main/component/user/components/profile/profile-service/profile.service.ts
+++ b/src/app/main/component/user/components/profile/profile-service/profile.service.ts
@@ -14,6 +14,7 @@ import { Patterns } from 'src/assets/patterns/patterns';
   providedIn: 'root'
 })
 export class ProfileService {
+  readonly oneDayInMillis: number = 24 * 60 * 60 * 1000;
   userId: number;
   icons = {
     edit: './assets/img/profile/icons/edit.svg',
@@ -44,6 +45,27 @@ export class ProfileService {
   getRandomFactOfTheDay(): Observable<FactOfTheDay> {
     const currentLang = this.languageService.getCurrentLanguage();
     return this.http.get<FactOfTheDay>(`${mainLink}fact-of-the-day/random?lang=${currentLang}`);
+  }
+
+  getHabitFactFromLocalStorage(): FactOfTheDay | null {
+    const savedHabitFact = localStorage.getItem('habitFactOfTheDay');
+    const lastHabitFetchTime = localStorage.getItem('lastHabitFactFetchTime');
+    const currentTime = Date.now();
+
+    if (savedHabitFact && lastHabitFetchTime && currentTime - Number(lastHabitFetchTime) < this.oneDayInMillis) {
+      return JSON.parse(savedHabitFact);
+    }
+    return null;
+  }
+
+  saveHabitFactToLocalStorage(fact: FactOfTheDay, currentTime: number): void {
+    localStorage.setItem('habitFactOfTheDay', JSON.stringify(fact));
+    localStorage.setItem('lastHabitFetchTime', currentTime.toString());
+  }
+
+  clearHabitFactFromLocalStorage(): void {
+    localStorage.removeItem('habitFactOfTheDay');
+    localStorage.removeItem('lastHabitFetchTime');
   }
 
   getFactsOfTheDayByTags(): Observable<FactOfTheDay> {

--- a/src/app/main/component/user/components/profile/profile-service/profile.service.ts
+++ b/src/app/main/component/user/components/profile/profile-service/profile.service.ts
@@ -48,7 +48,7 @@ export class ProfileService {
 
   getFactsOfTheDayByTags(): Observable<FactOfTheDay> {
     const currentLang = this.languageService.getCurrentLanguage();
-    return this.http.get<FactOfTheDay>(`${mainLink}factoftheday/random/by-tags?lang=${currentLang}`);
+    return this.http.get<FactOfTheDay>(`${mainLink}fact-of-the-day/random/by-tags?lang=${currentLang}`);
   }
 
   getUserInfo(): Observable<EditProfileModel> {

--- a/src/app/main/component/user/components/profile/profile-service/profile.service.ts
+++ b/src/app/main/component/user/components/profile/profile-service/profile.service.ts
@@ -46,6 +46,11 @@ export class ProfileService {
     return this.http.get<FactOfTheDay>(`${mainLink}fact-of-the-day/random?lang=${currentLang}`);
   }
 
+  getFactsOfTheDayByTags(): Observable<FactOfTheDay> {
+    const currentLang = this.languageService.getCurrentLanguage();
+    return this.http.get<FactOfTheDay>(`${mainLink}factoftheday/random/by-tags?lang=${currentLang}`);
+  }
+
   getUserInfo(): Observable<EditProfileModel> {
     this.setUserId();
     return this.http.get<EditProfileModel>(`${mainUserLink}user/${this.userId}/profile/`);

--- a/src/app/main/component/user/components/profile/profile-service/profile.service.ts
+++ b/src/app/main/component/user/components/profile/profile-service/profile.service.ts
@@ -1,7 +1,7 @@
 import { EcoPlaces } from '@user-models/ecoPlaces.model';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { FactOfTheDay as FactOfTheDay } from '@global-user/models/factOfTheDay';
+import { FactOfTheDay } from '@global-user/models/factOfTheDay';
 import { HttpClient } from '@angular/common/http';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { ProfileStatistics } from '@user-models/profile-statistiscs';
@@ -14,7 +14,6 @@ import { Patterns } from 'src/assets/patterns/patterns';
   providedIn: 'root'
 })
 export class ProfileService {
-  readonly oneDayInMillis: number = 24 * 60 * 60 * 1000;
   userId: number;
   icons = {
     edit: './assets/img/profile/icons/edit.svg',
@@ -45,27 +44,6 @@ export class ProfileService {
   getRandomFactOfTheDay(): Observable<FactOfTheDay> {
     const currentLang = this.languageService.getCurrentLanguage();
     return this.http.get<FactOfTheDay>(`${mainLink}fact-of-the-day/random?lang=${currentLang}`);
-  }
-
-  getHabitFactFromLocalStorage(): FactOfTheDay | null {
-    const savedHabitFact = localStorage.getItem('habitFactOfTheDay');
-    const lastHabitFetchTime = localStorage.getItem('lastHabitFactFetchTime');
-    const currentTime = Date.now();
-
-    if (savedHabitFact && lastHabitFetchTime && currentTime - Number(lastHabitFetchTime) < this.oneDayInMillis) {
-      return JSON.parse(savedHabitFact);
-    }
-    return null;
-  }
-
-  saveHabitFactToLocalStorage(fact: FactOfTheDay, currentTime: number): void {
-    localStorage.setItem('habitFactOfTheDay', JSON.stringify(fact));
-    localStorage.setItem('lastHabitFetchTime', currentTime.toString());
-  }
-
-  clearHabitFactFromLocalStorage(): void {
-    localStorage.removeItem('habitFactOfTheDay');
-    localStorage.removeItem('lastHabitFetchTime');
   }
 
   getFactsOfTheDayByTags(): Observable<FactOfTheDay> {

--- a/src/app/main/component/user/components/profile/profile.component.scss
+++ b/src/app/main/component/user/components/profile/profile.component.scss
@@ -131,7 +131,6 @@
 
       .app-profile-cards {
         display: block;
-        box-shadow: 1px 4px 8px var(--quintynary-dark-grey);
       }
     }
   }

--- a/src/app/main/service/localstorage/local-storage.service.ts
+++ b/src/app/main/service/localstorage/local-storage.service.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, Subject } from 'rxjs';
 import { EventResponse, PagePreviewDTO } from '../../component/events/models/events.interface';
 import { Address, CourierLocations, OrderDetails } from 'src/app/ubs/ubs/models/ubs.interface';
 import { IFilters } from 'src/app/ubs/ubs-admin/models/ubs-admin.interface';
+import { FactOfTheDay } from '@global-user/models/factOfTheDay';
 
 @Injectable({
   providedIn: 'root'
@@ -384,5 +385,32 @@ export class LocalStorageService {
 
   private getName(): string {
     return localStorage.getItem(this.NAME);
+  }
+
+  saveHabitFactToLocalStorage(fact: FactOfTheDay, currentTime: number): void {
+    localStorage.setItem('habitFactOfTheDay', JSON.stringify(fact));
+    localStorage.setItem('lastHabitFetchTime', currentTime.toString());
+  }
+
+  getHabitFactFromLocalStorage(): FactOfTheDay | null {
+    const savedHabitFact = localStorage.getItem('habitFactOfTheDay');
+    const lastHabitFetchTime = localStorage.getItem('lastHabitFetchTime');
+    const currentTime = Date.now();
+    const oneDayInMillis = 24 * 60 * 60 * 1000;
+
+    const isHabitFactPresent = !!savedHabitFact;
+    const isLastFetchTimePresent = !!lastHabitFetchTime;
+    const isWithinOneDay = currentTime - Number(lastHabitFetchTime) < oneDayInMillis;
+
+    if (isHabitFactPresent && isLastFetchTimePresent && isWithinOneDay) {
+      return JSON.parse(savedHabitFact);
+    }
+
+    return null;
+  }
+
+  clearHabitFactFromLocalStorage(): void {
+    localStorage.removeItem('habitFactOfTheDay');
+    localStorage.removeItem('lastHabitFetchTime');
   }
 }

--- a/src/app/main/service/localstorage/local-storage.service.ts
+++ b/src/app/main/service/localstorage/local-storage.service.ts
@@ -26,6 +26,7 @@ export class LocalStorageService {
   private readonly EDIT_EVENT = 'editEvent';
   private readonly ORDER_TO_REDIRECT = 'orderIdToRedirect';
   private readonly HABITS_GALLERY_VIEW = 'habitsGalleryView';
+  readonly ONE_DAY_IN_MILLIS = 24 * 60 * 60 * 1000;
 
   constructor() {
     this.firstNameBehaviourSubject = new BehaviorSubject<string>(this.getName());
@@ -396,11 +397,10 @@ export class LocalStorageService {
     const savedHabitFact = localStorage.getItem('habitFactOfTheDay');
     const lastHabitFetchTime = localStorage.getItem('lastHabitFetchTime');
     const currentTime = Date.now();
-    const oneDayInMillis = 24 * 60 * 60 * 1000;
 
     const isHabitFactPresent = !!savedHabitFact;
     const isLastFetchTimePresent = !!lastHabitFetchTime;
-    const isWithinOneDay = currentTime - Number(lastHabitFetchTime) < oneDayInMillis;
+    const isWithinOneDay = currentTime - Number(lastHabitFetchTime) < this.ONE_DAY_IN_MILLIS;
 
     if (isHabitFactPresent && isLastFetchTimePresent && isWithinOneDay) {
       return JSON.parse(savedHabitFact);


### PR DESCRIPTION
## Issue Link 📋
[#7384](https://github.com/ita-social-projects/GreenCity/issues/7384)

#### As a registered user, I want to see an additional "Fact of the Day" on the "My Account" page based on the tag of the habits I acquire, so I can view it.
##
**Summary Of Changes 🔥**

**_Developed the UI mechanism for displaying the additional "Fact of the Day" on the "My Account" page, ensuring that it updates daily._** 

-  Added a new card to display the habitFactOfTheDay content in the UI when available.

- Introduced habitFactOfTheDay for managing habit-related facts.

- **ProfileService**: Added getFactsOfTheDayByTags() to fetch habit facts.

- **LocalStorageService**: Added methods to save, retrieve, and clear habit facts with a 24-hour validity check.

- Logic to verify if more than 24 hours have passed since the last fetch and to update the habit facts accordingly.

- Replaced individual subscriptions with a Subject<void> for cleaner subscription handling.

<img width="316" alt="Знімок екрана 2024-09-15 о 11 45 51" src="https://github.com/user-attachments/assets/3e34489a-a1f3-4ee6-81e9-01afdf610108">
