### PR TITLE
[Bugfix] #7453 Fix the pagination of the places list

### DIFF
--- a/src/app/main/component/places/places.component.html
+++ b/src/app/main/component/places/places.component.html
@@ -40,60 +40,61 @@
       <div class="place-info">
         <mat-drawer-container class="example-container sidebar-container" autosize>
           <mat-drawer #drawer class="example-sidenav sidebar-drawer" mode="side" closed>
-            <div *ngIf="!activePlaceDetails">
-              <p class="title-sidebar">{{ 'user.places-card.card-popular' | translate }}</p>
-              <div class="sidebar-content-all" *ngFor="let place of placesList">
-                <div class="head">
-                  <p class="content-title" (click)="selectPlaceFromSideBar(place)">{{ place.name }}</p>
-                  <button (click)="toggleFavoriteFromSideBar(place)" class="btn-bookmark">
-                    <span class="material-icons">{{ place.isFavorite ? 'bookmark' : 'bookmark_border' }}</span>
+            <div cdkScrollable class="mat-drawer-inner-container">
+              <div *ngIf="!activePlaceDetails">
+                <p class="title-sidebar">{{ 'user.places-card.card-popular' | translate }}</p>
+                <div class="sidebar-content-all" *ngFor="let place of placesList">
+                  <div class="head">
+                    <p class="content-title" (click)="selectPlaceFromSideBar(place)">{{ place.name }}</p>
+                    <button (click)="toggleFavoriteFromSideBar(place)" class="btn-bookmark">
+                      <span class="material-icons">{{ place.isFavorite ? 'bookmark' : 'bookmark_border' }}</span>
+                    </button>
+                  </div>
+                  <p class="content-address">{{ place.location.address }}</p>
+                </div>
+              </div>
+              <div class="sidebar-content" *ngIf="activePlaceDetails">
+                <span class="close-mark" (click)="updatePlaceList(true)"></span>
+                <div class="title-wrapper">
+                  <h6 class="content-title">{{ activePlaceDetails.name }}</h6>
+                </div>
+                <div class="sidebar-photo" *ngIf="activePlaceDetails.photos">
+                  <img [src]="activePlaceDetails.photos[0]?.getUrl({})" class="content-photo" alt="" />
+                </div>
+                <div class="sidebar-address">
+                  <span class="content-address">{{ activePlaceDetails.vicinity }}</span>
+                  <button (click)="toggleFavorite()" class="btn-bookmark">
+                    <span class="material-icons">{{ isActivePlaceFavorite ? 'bookmark' : 'bookmark_border' }}</span>
                   </button>
                 </div>
-                <p class="content-address">{{ place.location.address }}</p>
+                <div>
+                  <p class="content-description">{{ activePlaceDetails?.types.join(', ') }}</p>
+                </div>
+                <div>
+                  <a [href]="activePlaceDetails.website" target="_blank" class="content-website" *ngIf="activePlaceDetails.website">{{
+                    activePlaceDetails.website
+                  }}</a>
+                </div>
+                <ul class="content-list">
+                  <li class="content-list-event">
+                    <img class="event-icon" src="{{ notification }}" alt="event-icon" />
+                    <p class="event-description">{{ 'user.places-card.card-first-event' | translate }}</p>
+                  </li>
+                  <li class="content-list-event">
+                    <img class="event-icon" src="{{ share }}" alt="event-icon" />
+                    <p class="event-description">{{ 'user.places-card.card-second-event' | translate }}</p>
+                  </li>
+                </ul>
+                <h6 class="content-reviews-title">
+                  {{ 'user.places-card.card-rating' | translate }} &nbsp;&nbsp; <span>{{ activePlaceDetails.rating }}</span>
+                </h6>
+                <div class="stars-container">
+                  <img *ngFor="let star of getStars(activePlaceDetails.rating)" class="star" src="{{ star }}" alt="star" />
+                </div>
+                <span class="content-reviews-amount"
+                  >{{ activePlaceDetails.reviews?.length }} {{ 'user.places-card.card-reviews' | translate }}</span
+                >
               </div>
-              <div infiniteScroll [infiniteScrollThrottle]="500" (scrolled)="updatePlaceList(false)"></div>
-            </div>
-            <div class="sidebar-content" *ngIf="activePlaceDetails">
-              <span class="close-mark" (click)="updatePlaceList(true)"></span>
-              <div class="title-wrapper">
-                <h6 class="content-title">{{ activePlaceDetails.name }}</h6>
-              </div>
-              <div class="sidebar-photo" *ngIf="activePlaceDetails.photos">
-                <img [src]="activePlaceDetails.photos[0]?.getUrl({})" class="content-photo" alt="" />
-              </div>
-              <div class="sidebar-address">
-                <span class="content-address">{{ activePlaceDetails.vicinity }}</span>
-                <button (click)="toggleFavorite()" class="btn-bookmark">
-                  <span class="material-icons">{{ isActivePlaceFavorite ? 'bookmark' : 'bookmark_border' }}</span>
-                </button>
-              </div>
-              <div>
-                <p class="content-description">{{ activePlaceDetails?.types.join(', ') }}</p>
-              </div>
-              <div>
-                <a [href]="activePlaceDetails.website" target="_blank" class="content-website" *ngIf="activePlaceDetails.website">{{
-                  activePlaceDetails.website
-                }}</a>
-              </div>
-              <ul class="content-list">
-                <li class="content-list-event">
-                  <img class="event-icon" src="{{ notification }}" alt="event-icon" />
-                  <p class="event-description">{{ 'user.places-card.card-first-event' | translate }}</p>
-                </li>
-                <li class="content-list-event">
-                  <img class="event-icon" src="{{ share }}" alt="event-icon" />
-                  <p class="event-description">{{ 'user.places-card.card-second-event' | translate }}</p>
-                </li>
-              </ul>
-              <h6 class="content-reviews-title">
-                {{ 'user.places-card.card-rating' | translate }} &nbsp;&nbsp; <span>{{ activePlaceDetails.rating }}</span>
-              </h6>
-              <div class="stars-container">
-                <img *ngFor="let star of getStars(activePlaceDetails.rating)" class="star" src="{{ star }}" alt="star" />
-              </div>
-              <span class="content-reviews-amount"
-                >{{ activePlaceDetails.reviews?.length }} {{ 'user.places-card.card-reviews' | translate }}</span
-              >
             </div>
           </mat-drawer>
         </mat-drawer-container>

--- a/src/app/main/component/places/places.component.html
+++ b/src/app/main/component/places/places.component.html
@@ -40,12 +40,18 @@
       <div class="place-info">
         <mat-drawer-container class="example-container sidebar-container" autosize>
           <mat-drawer #drawer class="example-sidenav sidebar-drawer" mode="side" closed>
-            <div cdkScrollable class="mat-drawer-inner-container">
+            <div
+              class="sidebar-content-all"
+              infiniteScroll
+              [infiniteScrollThrottle]="500"
+              [scrollWindow]="false"
+              (scrolled)="updatePlaceList(false)"
+            >
               <div *ngIf="!activePlaceDetails">
                 <div class="title-container">
                   <p class="title-sidebar">{{ 'user.places-card.card-popular' | translate }}</p>
                 </div>
-                <div class="sidebar-content-all" *ngFor="let place of placesList">
+                <div class="sidebar-item-content" *ngFor="let place of placesList">
                   <div class="head">
                     <p class="content-title" (click)="selectPlaceFromSideBar(place)">{{ place.name }}</p>
                     <button (click)="toggleFavoriteFromSideBar(place)" class="btn-bookmark">

--- a/src/app/main/component/places/places.component.html
+++ b/src/app/main/component/places/places.component.html
@@ -42,7 +42,9 @@
           <mat-drawer #drawer class="example-sidenav sidebar-drawer" mode="side" closed>
             <div cdkScrollable class="mat-drawer-inner-container">
               <div *ngIf="!activePlaceDetails">
-                <p class="title-sidebar">{{ 'user.places-card.card-popular' | translate }}</p>
+                <div class="title-container">
+                  <p class="title-sidebar">{{ 'user.places-card.card-popular' | translate }}</p>
+                </div>
                 <div class="sidebar-content-all" *ngFor="let place of placesList">
                   <div class="head">
                     <p class="content-title" (click)="selectPlaceFromSideBar(place)">{{ place.name }}</p>

--- a/src/app/main/component/places/places.component.scss
+++ b/src/app/main/component/places/places.component.scss
@@ -263,15 +263,19 @@ $cardTextColor: #1d2830;
   }
 }
 
-.title-sidebar {
-  color: #313131;
-  font-family: var(--primary-font), sans-serif;
-  font-size: 20px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 28px;
-  letter-spacing: 0.04px;
-  margin: 18px 73px;
+.title-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 16px 24px;
+
+  .title-sidebar {
+    color: #313131;
+    font-family: var(--primary-font), sans-serif;
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 28px;
+  }
 }
 
 .sidebar-content-all {

--- a/src/app/main/component/places/places.component.scss
+++ b/src/app/main/component/places/places.component.scss
@@ -279,6 +279,11 @@ $cardTextColor: #1d2830;
 }
 
 .sidebar-content-all {
+  height: 540px;
+  overflow-y: auto;
+}
+
+.sidebar-item-content {
   display: flex;
   flex-direction: column;
   width: 264px;
@@ -334,6 +339,10 @@ $cardTextColor: #1d2830;
     font-weight: 400;
     line-height: 12px;
   }
+}
+
+:host ::ng-deep .mat-drawer-inner-container {
+  overflow: hidden;
 }
 
 @media screen and (max-width: 767px) {

--- a/src/app/main/component/places/places.component.spec.ts
+++ b/src/app/main/component/places/places.component.spec.ts
@@ -198,7 +198,7 @@ describe('PlacesComponent', () => {
     expect(component.scrollable).toBeDefined();
   });
 
-  it('should call checkIfScrolledToBottom when scrollable is defined and scrolled', () => {
+  it('should subscribe to elementScrolled when scrollable is defined and call checkIfScrolledToBottom', () => {
     const spy = spyOn(component, 'checkIfScrolledToBottom');
 
     scrollSubject = new Subject<Event>();
@@ -208,7 +208,11 @@ describe('PlacesComponent', () => {
 
     component.scrollable = mockScrollable;
 
+    const subscribeSpy = spyOn(scrollSubject, 'subscribe').and.callThrough();
+
     component.ngAfterViewInit();
+
+    expect(subscribeSpy).toHaveBeenCalled();
 
     scrollSubject.next(new Event('scroll'));
 

--- a/src/app/main/component/places/places.component.spec.ts
+++ b/src/app/main/component/places/places.component.spec.ts
@@ -198,6 +198,14 @@ describe('PlacesComponent', () => {
     expect(component.scrollable).toBeDefined();
   });
 
+  it('should checkIfScrolledToBottom method be called when scrolling', () => {
+    const spy = spyOn(component, 'checkIfScrolledToBottom');
+    component.ngAfterViewInit();
+    component.scrollable.elementScrolled();
+    component.checkIfScrolledToBottom();
+    expect(spy).toHaveBeenCalled();
+  });
+
   afterEach(() => {
     spyOn(component, 'ngOnDestroy').and.callFake(() => {});
     fixture.destroy();

--- a/src/app/main/component/places/places.component.spec.ts
+++ b/src/app/main/component/places/places.component.spec.ts
@@ -198,11 +198,17 @@ describe('PlacesComponent', () => {
     expect(component.scrollable).toBeDefined();
   });
 
-  it('should checkIfScrolledToBottom method be called when scrolling', () => {
+  it('should call checkIfScrolledToBottom when elementScrolled is triggered', () => {
     const spy = spyOn(component, 'checkIfScrolledToBottom');
+
+    const scrollSubject = new Subject<Event>();
+
+    spyOn(component.scrollable, 'elementScrolled').and.returnValue(scrollSubject.asObservable());
+
     component.ngAfterViewInit();
-    component.scrollable.elementScrolled();
-    component.checkIfScrolledToBottom();
+
+    scrollSubject.next(new Event('scroll'));
+
     expect(spy).toHaveBeenCalled();
   });
 

--- a/src/app/main/component/places/places.component.spec.ts
+++ b/src/app/main/component/places/places.component.spec.ts
@@ -1,9 +1,9 @@
-import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { PlacesComponent } from './places.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { PlaceService } from '@global-service/place/place.service';
-import { BehaviorSubject, Subject, lastValueFrom, of } from 'rxjs';
+import { BehaviorSubject, Subject, of } from 'rxjs';
 import { AllAboutPlace, Place } from './models/place';
 import { FilterPlaceService } from '@global-service/filtering/filter-place.service';
 import { PlaceStatus } from '@global-models/placeStatus.model';
@@ -14,12 +14,10 @@ import { CreatePlaceModel, OpeningHoursDto } from './models/create-place.model';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { tagsListPlacesData } from './models/places-consts';
 import { FilterModel } from '@shared/components/tag-filter/tag-filter.model';
-import { CdkScrollable } from '@angular/cdk/scrolling';
 
 describe('PlacesComponent', () => {
   let component: PlacesComponent;
   let fixture: ComponentFixture<PlacesComponent>;
-  let scrollSubject: Subject<Event>;
   let tagsArray: Array<FilterModel> = tagsListPlacesData;
 
   const localStorageServiceMock: LocalStorageService = jasmine.createSpyObj('LocalStorageService', [
@@ -191,40 +189,6 @@ describe('PlacesComponent', () => {
     const spy = spyOn(component, 'selectPlace');
     component.selectPlaceFromSideBar(placeMock);
     expect(spy).toHaveBeenCalled();
-  });
-
-  it('should have scrollable defined after view init', () => {
-    fixture.detectChanges();
-    expect(component.scrollable).toBeDefined();
-  });
-
-  it('should subscribe to elementScrolled and call checkIfScrolledToBottom', async () => {
-    const spy = spyOn(component, 'checkIfScrolledToBottom');
-
-    scrollSubject = new Subject<Event>();
-
-    const mockScrollable = jasmine.createSpyObj('CdkScrollable', ['elementScrolled']);
-    mockScrollable.elementScrolled.and.returnValue(scrollSubject.asObservable());
-
-    component.scrollable = mockScrollable;
-
-    component.ngAfterViewInit();
-
-    await fakeAsync(() => {
-      scrollSubject.next(new Event('scroll'));
-      tick();
-    })();
-    expect(spy).toHaveBeenCalled();
-  });
-
-  it('should not subscribe or call checkIfScrolledToBottom when scrollable is undefined', () => {
-    component.scrollable = undefined;
-
-    const spy = spyOn(component, 'checkIfScrolledToBottom');
-
-    component.ngAfterViewInit();
-
-    expect(spy).not.toHaveBeenCalled();
   });
 
   afterEach(() => {

--- a/src/app/main/component/places/places.component.spec.ts
+++ b/src/app/main/component/places/places.component.spec.ts
@@ -19,7 +19,7 @@ import { CdkScrollable } from '@angular/cdk/scrolling';
 describe('PlacesComponent', () => {
   let component: PlacesComponent;
   let fixture: ComponentFixture<PlacesComponent>;
-
+  let scrollSubject: Subject<Event>;
   let tagsArray: Array<FilterModel> = tagsListPlacesData;
 
   const localStorageServiceMock: LocalStorageService = jasmine.createSpyObj('LocalStorageService', [
@@ -154,6 +154,15 @@ describe('PlacesComponent', () => {
     fixture = TestBed.createComponent(PlacesComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+
+    scrollSubject = new Subject<Event>();
+    const mockScrollable = jasmine.createSpyObj('CdkScrollable', ['elementScrolled']);
+
+    // Mock the `elementScrolled()` method to return the `scrollSubject`
+    mockScrollable.elementScrolled.and.returnValue(scrollSubject.asObservable());
+
+    // Assign the mocked CdkScrollable to the component's `scrollable` property
+    component.scrollable = mockScrollable;
   });
 
   it('should create', () => {
@@ -198,12 +207,8 @@ describe('PlacesComponent', () => {
     expect(component.scrollable).toBeDefined();
   });
 
-  it('should call checkIfScrolledToBottom when elementScrolled is triggered', () => {
+  it('should call checkIfScrolledToBottom when scrollable is scrolled', () => {
     const spy = spyOn(component, 'checkIfScrolledToBottom');
-
-    const scrollSubject = new Subject<Event>();
-
-    spyOn(component.scrollable, 'elementScrolled').and.returnValue(scrollSubject.asObservable());
 
     component.ngAfterViewInit();
 

--- a/src/app/main/component/places/places.component.spec.ts
+++ b/src/app/main/component/places/places.component.spec.ts
@@ -14,6 +14,7 @@ import { CreatePlaceModel, OpeningHoursDto } from './models/create-place.model';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { tagsListPlacesData } from './models/places-consts';
 import { FilterModel } from '@shared/components/tag-filter/tag-filter.model';
+import { CdkScrollable } from '@angular/cdk/scrolling';
 
 describe('PlacesComponent', () => {
   let component: PlacesComponent;
@@ -122,7 +123,7 @@ describe('PlacesComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [PlacesComponent],
-      imports: [TranslateModule.forRoot(), MatDialogModule, InfiniteScrollModule],
+      imports: [TranslateModule.forRoot(), MatDialogModule, InfiniteScrollModule, CdkScrollable],
       providers: [
         {
           provide: LocalStorageService,
@@ -190,6 +191,11 @@ describe('PlacesComponent', () => {
     const spy = spyOn(component, 'selectPlace');
     component.selectPlaceFromSideBar(placeMock);
     expect(spy).toHaveBeenCalled();
+  });
+
+  it('should have scrollable defined after view init', () => {
+    fixture.detectChanges();
+    expect(component.scrollable).toBeDefined();
   });
 
   afterEach(() => {

--- a/src/app/main/component/places/places.component.spec.ts
+++ b/src/app/main/component/places/places.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { PlacesComponent } from './places.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
@@ -198,7 +198,7 @@ describe('PlacesComponent', () => {
     expect(component.scrollable).toBeDefined();
   });
 
-  it('should subscribe to elementScrolled when scrollable is defined and call checkIfScrolledToBottom', () => {
+  it('should subscribe to elementScrolled and call checkIfScrolledToBottom', fakeAsync(() => {
     const spy = spyOn(component, 'checkIfScrolledToBottom');
 
     scrollSubject = new Subject<Event>();
@@ -208,18 +208,16 @@ describe('PlacesComponent', () => {
 
     component.scrollable = mockScrollable;
 
-    const subscribeSpy = spyOn(scrollSubject, 'subscribe').and.callThrough();
-
     component.ngAfterViewInit();
-
-    expect(subscribeSpy).toHaveBeenCalled();
 
     scrollSubject.next(new Event('scroll'));
 
-    expect(spy).toHaveBeenCalled();
-  });
+    tick();
 
-  it('should not subscribe to elementScrolled or call checkIfScrolledToBottom when scrollable is undefined', () => {
+    expect(spy).toHaveBeenCalled();
+  }));
+
+  it('should not subscribe or call checkIfScrolledToBottom when scrollable is undefined', () => {
     component.scrollable = undefined;
 
     const spy = spyOn(component, 'checkIfScrolledToBottom');

--- a/src/app/main/component/places/places.component.spec.ts
+++ b/src/app/main/component/places/places.component.spec.ts
@@ -121,7 +121,7 @@ describe('PlacesComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [PlacesComponent],
-      imports: [TranslateModule.forRoot(), MatDialogModule, InfiniteScrollModule, CdkScrollable],
+      imports: [TranslateModule.forRoot(), MatDialogModule, InfiniteScrollModule],
       providers: [
         {
           provide: LocalStorageService,

--- a/src/app/main/component/places/places.component.spec.ts
+++ b/src/app/main/component/places/places.component.spec.ts
@@ -154,15 +154,6 @@ describe('PlacesComponent', () => {
     fixture = TestBed.createComponent(PlacesComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-
-    scrollSubject = new Subject<Event>();
-    const mockScrollable = jasmine.createSpyObj('CdkScrollable', ['elementScrolled']);
-
-    // Mock the `elementScrolled()` method to return the `scrollSubject`
-    mockScrollable.elementScrolled.and.returnValue(scrollSubject.asObservable());
-
-    // Assign the mocked CdkScrollable to the component's `scrollable` property
-    component.scrollable = mockScrollable;
   });
 
   it('should create', () => {
@@ -207,14 +198,31 @@ describe('PlacesComponent', () => {
     expect(component.scrollable).toBeDefined();
   });
 
-  it('should call checkIfScrolledToBottom when scrollable is scrolled', () => {
+  it('should call checkIfScrolledToBottom when scrollable is defined and scrolled', () => {
     const spy = spyOn(component, 'checkIfScrolledToBottom');
+
+    scrollSubject = new Subject<Event>();
+
+    const mockScrollable = jasmine.createSpyObj('CdkScrollable', ['elementScrolled']);
+    mockScrollable.elementScrolled.and.returnValue(scrollSubject.asObservable());
+
+    component.scrollable = mockScrollable;
 
     component.ngAfterViewInit();
 
     scrollSubject.next(new Event('scroll'));
 
     expect(spy).toHaveBeenCalled();
+  });
+
+  it('should not subscribe to elementScrolled or call checkIfScrolledToBottom when scrollable is undefined', () => {
+    component.scrollable = undefined;
+
+    const spy = spyOn(component, 'checkIfScrolledToBottom');
+
+    component.ngAfterViewInit();
+
+    expect(spy).not.toHaveBeenCalled();
   });
 
   afterEach(() => {

--- a/src/app/main/component/places/places.component.spec.ts
+++ b/src/app/main/component/places/places.component.spec.ts
@@ -3,7 +3,7 @@ import { PlacesComponent } from './places.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { PlaceService } from '@global-service/place/place.service';
-import { BehaviorSubject, Subject, of } from 'rxjs';
+import { BehaviorSubject, Subject, lastValueFrom, of } from 'rxjs';
 import { AllAboutPlace, Place } from './models/place';
 import { FilterPlaceService } from '@global-service/filtering/filter-place.service';
 import { PlaceStatus } from '@global-models/placeStatus.model';
@@ -198,7 +198,7 @@ describe('PlacesComponent', () => {
     expect(component.scrollable).toBeDefined();
   });
 
-  it('should subscribe to elementScrolled and call checkIfScrolledToBottom', fakeAsync(() => {
+  it('should subscribe to elementScrolled and call checkIfScrolledToBottom', async () => {
     const spy = spyOn(component, 'checkIfScrolledToBottom');
 
     scrollSubject = new Subject<Event>();
@@ -210,12 +210,12 @@ describe('PlacesComponent', () => {
 
     component.ngAfterViewInit();
 
-    scrollSubject.next(new Event('scroll'));
-
-    tick();
-
+    await fakeAsync(() => {
+      scrollSubject.next(new Event('scroll'));
+      tick();
+    })();
     expect(spy).toHaveBeenCalled();
-  }));
+  });
 
   it('should not subscribe or call checkIfScrolledToBottom when scrollable is undefined', () => {
     component.scrollable = undefined;

--- a/src/app/main/component/places/places.component.ts
+++ b/src/app/main/component/places/places.component.ts
@@ -75,9 +75,11 @@ export class PlacesComponent implements OnInit, OnDestroy, AfterViewInit {
   ) {}
 
   ngAfterViewInit(): void {
-    this.scrollable.elementScrolled().subscribe(() => {
-      this.checkIfScrolledToBottom();
-    });
+    if (this.scrollable) {
+      this.scrollable.elementScrolled().subscribe(() => {
+        this.checkIfScrolledToBottom();
+      });
+    }
   }
 
   ngOnInit() {

--- a/src/app/main/component/places/places.component.ts
+++ b/src/app/main/component/places/places.component.ts
@@ -355,7 +355,7 @@ export class PlacesComponent implements OnInit, OnDestroy, AfterViewInit {
       });
   }
 
-  private checkIfScrolledToBottom() {
+  checkIfScrolledToBottom() {
     const element = this.scrollable.getElementRef().nativeElement;
     const atBottom = element.scrollHeight - element.scrollTop === element.clientHeight;
 

--- a/src/app/main/component/places/places.component.ts
+++ b/src/app/main/component/places/places.component.ts
@@ -1,5 +1,5 @@
 import { TranslateService } from '@ngx-translate/core';
-import { Component, OnInit, OnDestroy, ViewChild, ChangeDetectorRef, AfterViewInit } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild, ChangeDetectorRef } from '@angular/core';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { MatDrawer } from '@angular/material/sidenav';
 import { PlaceService } from '@global-service/place/place.service';
@@ -19,14 +19,13 @@ import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component
 import { FilterModel } from '@shared/components/tag-filter/tag-filter.model';
 import { tagsListPlacesData } from './models/places-consts';
 import { GoogleScript } from '@assets/google-script/google-script';
-import { CdkScrollable } from '@angular/cdk/scrolling';
 
 @Component({
   selector: 'app-places',
   templateUrl: './places.component.html',
   styleUrls: ['./places.component.scss']
 })
-export class PlacesComponent implements OnInit, OnDestroy, AfterViewInit {
+export class PlacesComponent implements OnInit, OnDestroy {
   position: any = {};
   zoom = 13;
   tagList: FilterModel[] = tagsListPlacesData;
@@ -51,7 +50,6 @@ export class PlacesComponent implements OnInit, OnDestroy, AfterViewInit {
   placesList: AllAboutPlace[] = [];
 
   @ViewChild('drawer') drawer: MatDrawer;
-  @ViewChild(CdkScrollable) scrollable: CdkScrollable;
 
   private map: any;
   private googlePlacesService: google.maps.places.PlacesService;
@@ -73,14 +71,6 @@ export class PlacesComponent implements OnInit, OnDestroy, AfterViewInit {
     private googleScript: GoogleScript,
     private cdr: ChangeDetectorRef
   ) {}
-
-  ngAfterViewInit(): void {
-    if (this.scrollable) {
-      this.scrollable.elementScrolled().subscribe(() => {
-        this.checkIfScrolledToBottom();
-      });
-    }
-  }
 
   ngOnInit() {
     this.checkUserSingIn();
@@ -355,13 +345,8 @@ export class PlacesComponent implements OnInit, OnDestroy, AfterViewInit {
       });
   }
 
-  checkIfScrolledToBottom() {
-    const element = this.scrollable.getElementRef().nativeElement;
-    const atBottom = element.scrollHeight - element.scrollTop === element.clientHeight;
-
-    if (atBottom) {
-      this.updatePlaceList(false);
-    }
+  onScroll() {
+    alert('scroll');
   }
 
   ngOnDestroy(): void {

--- a/src/app/main/component/places/places.component.ts
+++ b/src/app/main/component/places/places.component.ts
@@ -1,5 +1,5 @@
 import { TranslateService } from '@ngx-translate/core';
-import { Component, OnInit, OnDestroy, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { MatDrawer } from '@angular/material/sidenav';
 import { PlaceService } from '@global-service/place/place.service';
@@ -66,10 +66,9 @@ export class PlacesComponent implements OnInit, OnDestroy {
     private placeService: PlaceService,
     private filterPlaceService: FilterPlaceService,
     private favoritePlaceService: FavoritePlaceService,
-    private dialog: MatDialog,
-    private userOwnAuthService: UserOwnAuthService,
     private googleScript: GoogleScript,
-    private cdr: ChangeDetectorRef
+    private dialog: MatDialog,
+    private userOwnAuthService: UserOwnAuthService
   ) {}
 
   ngOnInit() {
@@ -227,7 +226,6 @@ export class PlacesComponent implements OnInit, OnDestroy {
     }
     this.totalPages = item.totalPages;
     this.page += 1;
-    this.cdr.detectChanges();
   }
 
   toggleFavorite(): void {

--- a/src/app/main/component/places/places.component.ts
+++ b/src/app/main/component/places/places.component.ts
@@ -214,17 +214,20 @@ export class PlacesComponent implements OnInit, OnDestroy {
 
   private getPlaceList(): void {
     this.placeService.getAllPlaces(this.page, this.size).subscribe((item: any) => {
-      if (item.page) {
-        this.placesList = [...this.placesList, ...item.page];
-        this.drawer.toggle(true);
-      } else {
-        this.drawer.toggle(false);
-      }
-      this.totalPages = item.totalPages;
-      this.page += 1;
-
-      this.cdr.detectChanges();
+      this.handlePlaceListResponse(item);
     });
+  }
+
+  private handlePlaceListResponse(item: any): void {
+    if (item.page) {
+      this.placesList = [...this.placesList, ...item.page];
+      this.drawer.toggle(true);
+    } else {
+      this.drawer.toggle(false);
+    }
+    this.totalPages = item.totalPages;
+    this.page += 1;
+    this.cdr.detectChanges();
   }
 
   toggleFavorite(): void {

--- a/src/app/main/component/places/places.component.ts
+++ b/src/app/main/component/places/places.component.ts
@@ -70,7 +70,8 @@ export class PlacesComponent implements OnInit, OnDestroy, AfterViewInit {
     private favoritePlaceService: FavoritePlaceService,
     private dialog: MatDialog,
     private userOwnAuthService: UserOwnAuthService,
-    private googleScript: GoogleScript
+    private googleScript: GoogleScript,
+    private cdr: ChangeDetectorRef
   ) {}
 
   ngAfterViewInit(): void {
@@ -229,6 +230,8 @@ export class PlacesComponent implements OnInit, OnDestroy, AfterViewInit {
       }
       this.totalPages = item.totalPages;
       this.page += 1;
+
+      this.cdr.detectChanges();
     });
   }
 

--- a/src/app/main/component/places/places.component.ts
+++ b/src/app/main/component/places/places.component.ts
@@ -345,10 +345,6 @@ export class PlacesComponent implements OnInit, OnDestroy {
       });
   }
 
-  onScroll() {
-    alert('scroll');
-  }
-
   ngOnDestroy(): void {
     this.langChangeSub.unsubscribe();
     this.$destroy.next(true);


### PR DESCRIPTION
Issue: [link](https://github.com/ita-social-projects/GreenCity/issues/7453)

## Summary Of Changes 
1. The problem of the previous code was that the pagination was triggered by the parent page scrollbar, because the infinite scroll doesn't work on the mat-drawer, because it have embedded scrollable elements and api to monitor it
2. So, I subscribe to the scrollable container changes and check whether its in the bottom, if it is, I add the new page content to the previous one
3. Have the problem with very slow displaying of the new places, so I didn't find the better solution, unless to trigger the change detection manually.
4. Update the position of the title of the places
