### PR TITLE
[Edit habit. Invite friends] #7459 Implement habit friends invite functionality

### DIFF
--- a/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.html
+++ b/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.html
@@ -64,7 +64,7 @@
           </div>
         </div>
         <div class="invite-friends">
-          <app-habit-invite-friends class="invite-friends-container"></app-habit-invite-friends>
+          <app-habit-invite-friends class="invite-friends-container" [habitId]="getHabitId()"></app-habit-invite-friends>
         </div>
       </div>
     </div>

--- a/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.ts
@@ -79,11 +79,15 @@ export class AddNewHabitComponent implements OnInit {
     public userFriendsService: UserFriendsService
   ) {}
 
+  getHabitId(): number {
+    return this.habitId;
+  }
+
   ngOnInit() {
     this.getUserId();
     this.subscribeToLangChange();
     this.bindLang(this.localStorageService.getCurrentLanguage());
-    this.route.params.subscribe((params) => {
+    this.route.params.pipe(takeUntil(this.destroyed$)).subscribe((params) => {
       if (this.router.url.includes('add')) {
         this.habitId = Number(params.habitId);
       } else {
@@ -94,6 +98,11 @@ export class AddNewHabitComponent implements OnInit {
     this.checkIfAssigned();
     this.getRecommendedNews(this.page, this.size);
     this.userFriendsService.addedFriends.length = 0;
+  }
+
+  ngOnDestroy() {
+    this.destroyed$.next(true);
+    this.destroyed$.complete();
   }
 
   private bindLang(lang: string): void {

--- a/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/add-new-habit.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
 import { HabitAssignService } from '@global-service/habit-assign/habit-assign.service';
@@ -32,7 +32,7 @@ import { HabitPageable } from '@global-user/components/habit/models/interfaces/c
   templateUrl: './add-new-habit.component.html',
   styleUrls: ['./add-new-habit.component.scss']
 })
-export class AddNewHabitComponent implements OnInit {
+export class AddNewHabitComponent implements OnInit, OnDestroy {
   assignedHabit: HabitAssignInterface;
   habitResponse: HabitInterface;
   recommendedHabits: HabitInterface[];

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.html
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.html
@@ -22,8 +22,8 @@
         {{ 'user.habit.invite.all' | translate }}
       </mat-checkbox>
       <ul>
-        <li *ngFor="let friend of friends" [class.disabled]="setFriendDisable(friend.id)">
-          <mat-checkbox [(ngModel)]="friend.added" (ngModelChange)="updateAllAdd()">
+        <li *ngFor="let friend of inputFriends" [class.disabled]="setFriendDisable(friend.id)">
+          <mat-checkbox [checked]="selectedFriends.includes(friend.id)" (change)="onFriendCheckboxChange(friend.id, $event.checked)">
             <div class="friend">
               <app-user-profile-image
                 [imgPath]="friend.profilePicturePath"
@@ -44,7 +44,7 @@
     <div *ngIf="inputValue">
       <ul>
         <li *ngFor="let friend of inputFriends" [class.disabled]="setFriendDisable(friend.id)">
-          <mat-checkbox [(ngModel)]="friend.added" (ngModelChange)="updateAllAdd()">
+          <mat-checkbox [checked]="selectedFriends.includes(friend.id)" (change)="onFriendCheckboxChange(friend.id, $event.checked)">
             <div class="friend">
               <app-user-profile-image
                 [imgPath]="friend.profilePicturePath"
@@ -67,7 +67,7 @@
     <button class="btn btn-outline-success" mat-dialog-close>
       {{ 'user.habit.invite.btn.cancel' | translate }}
     </button>
-    <button class="btn btn-success" [mat-dialog-close]="true" cdkFocusInitial (click)="setAddedFriends()">
+    <button class="btn btn-success" [mat-dialog-close]="true" cdkFocusInitial (click)="inviteFriends($event)">
       {{ 'user.habit.invite.btn.invite' | translate }}
     </button>
   </mat-dialog-actions>

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.html
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.html
@@ -11,57 +11,36 @@
     />
   </form>
   <section class="popup-section">
-    <div *ngIf="!inputValue">
-      <mat-checkbox
-        class="all-friends"
-        [checked]="allAdd"
-        [indeterminate]="someAdd()"
-        (change)="setAll($event.checked)"
-        [class.disabled]="setAllFriendsDisable()"
-      >
-        {{ 'user.habit.invite.all' | translate }}
-      </mat-checkbox>
-      <ul>
-        <li *ngFor="let friend of inputFriends" [class.disabled]="setFriendDisable(friend.id)">
-          <mat-checkbox [checked]="selectedFriends.includes(friend.id)" (change)="onFriendCheckboxChange(friend.id, $event.checked)">
-            <div class="friend">
-              <app-user-profile-image
-                [imgPath]="friend.profilePicturePath"
-                [firstName]="friend.name"
-                class="friend-img"
-                [additionalImgClass]="'friend-user-profile'"
-              >
-              </app-user-profile-image>
-              <div class="friend-details">
-                <p class="friend-name">{{ friend.name }}</p>
-                <p class="friend-email">{{ friend.email }}</p>
-              </div>
+    <mat-checkbox
+      *ngIf="!inputValue"
+      class="all-friends"
+      [checked]="allAdd"
+      [indeterminate]="someAdd()"
+      (change)="setAll($event.checked)"
+      [class.disabled]="setAllFriendsDisable()"
+    >
+      {{ 'user.habit.invite.all' | translate }}
+    </mat-checkbox>
+
+    <ul>
+      <li *ngFor="let friend of inputFriends" [class.disabled]="setFriendDisable(friend.id)">
+        <mat-checkbox [checked]="selectedFriends.includes(friend.id)" (change)="onFriendCheckboxChange(friend.id, $event.checked)">
+          <div class="friend">
+            <app-user-profile-image
+              [imgPath]="friend.profilePicturePath"
+              [firstName]="friend.name"
+              class="friend-img"
+              [additionalImgClass]="'friend-user-profile'"
+            >
+            </app-user-profile-image>
+            <div class="friend-details">
+              <p class="friend-name">{{ friend.name }}</p>
+              <p class="friend-email">{{ friend.email }}</p>
             </div>
-          </mat-checkbox>
-        </li>
-      </ul>
-    </div>
-    <div *ngIf="inputValue">
-      <ul>
-        <li *ngFor="let friend of inputFriends" [class.disabled]="setFriendDisable(friend.id)">
-          <mat-checkbox [checked]="selectedFriends.includes(friend.id)" (change)="onFriendCheckboxChange(friend.id, $event.checked)">
-            <div class="friend">
-              <app-user-profile-image
-                [imgPath]="friend.profilePicturePath"
-                [firstName]="friend.name"
-                class="friend-img"
-                [additionalImgClass]="'friend-user-profile'"
-              >
-              </app-user-profile-image>
-              <div class="friend-details">
-                <p class="friend-name">{{ friend.name }}</p>
-                <p class="friend-email">{{ friend.email }}</p>
-              </div>
-            </div>
-          </mat-checkbox>
-        </li>
-      </ul>
-    </div>
+          </div>
+        </mat-checkbox>
+      </li>
+    </ul>
   </section>
   <mat-dialog-actions class="invite-popup-footer">
     <button class="btn btn-outline-success" mat-dialog-close>

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.spec.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.spec.ts
@@ -9,6 +9,7 @@ import { Router } from '@angular/router';
 import { FRIENDS, FIRSTFRIEND, SECONDFRIEND } from '@global-user/mocks/friends-mock';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 describe('HabitInviteFriendsPopUpComponent', () => {
   let component: HabitInviteFriendsPopUpComponent;
@@ -29,9 +30,9 @@ describe('HabitInviteFriendsPopUpComponent', () => {
       imports: [HttpClientTestingModule, TranslateModule.forRoot(), MatDialogModule, MatCheckboxModule],
       providers: [
         { provide: LocalStorageService, useValue: localStorageServiceMock },
-        { provide: LocalStorageService, useValue: localStorageServiceMock },
         { provide: Router, useValue: routerSpy },
-        { provide: MatSnackBarComponent, useValue: MatSnackBarMock }
+        { provide: MatSnackBarComponent, useValue: MatSnackBarMock },
+        { provide: MAT_DIALOG_DATA, useValue: { habitId: 1 } }
       ]
     }).compileComponents();
 

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.ts
@@ -1,10 +1,12 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { FriendArrayModel, FriendModel } from '@global-user/models/friend.model';
 import { UserFriendsService } from '@global-user/services/user-friends.service';
 import { Subject } from 'rxjs';
 import { searchIcon } from 'src/app/main/image-pathes/places-icons';
 import { takeUntil } from 'rxjs/operators';
+import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
 
 @Component({
   selector: 'app-habit-invite-friends-pop-up',
@@ -14,19 +16,24 @@ import { takeUntil } from 'rxjs/operators';
 export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
   private destroyed$: Subject<boolean> = new Subject<boolean>();
   userId: number;
-  friends: FriendModel[];
-  inputFriends: FriendModel[];
-  inputValue: string;
+  friends: FriendModel[] = [];
+  selectedFriends: number[] = [];
+  inputFriends: FriendModel[] = [];
+  inputValue = '';
   allAdd = false;
-  addedFriends: FriendModel[] = [];
   searchIcon = searchIcon;
+  habitId: number;
+  invitationSent = false;
 
   constructor(
     private userFriendsService: UserFriendsService,
-    private localStorageService: LocalStorageService
+    private localStorageService: LocalStorageService,
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    private snackBar: MatSnackBarComponent
   ) {}
 
   ngOnInit() {
+    this.habitId = this.data.habitId;
     this.getUserId();
     this.getFriends();
   }
@@ -41,48 +48,89 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroyed$))
       .subscribe((data: FriendArrayModel) => {
         this.friends = data.page;
+        this.inputFriends = [...this.friends];
       });
   }
 
+  onFriendCheckboxChange(friendId: number, isChecked: boolean) {
+    const friend = this.friends.find((f) => f.id === friendId);
+    if (friend) {
+      friend.added = isChecked;
+      this.toggleFriendSelection(friendId, isChecked);
+      this.updateAllAdd();
+    }
+  }
+
+  toggleFriendSelection(friendId: number, isChecked: boolean) {
+    if (isChecked) {
+      if (!this.selectedFriends.includes(friendId)) {
+        this.selectedFriends.push(friendId);
+      }
+    } else {
+      this.selectedFriends = this.selectedFriends.filter((id) => id !== friendId);
+    }
+  }
+
+  inviteFriends(event: Event) {
+    event.preventDefault();
+    if (this.habitId && this.selectedFriends.length) {
+      this.userFriendsService.inviteFriendsToHabit(this.habitId, this.selectedFriends).subscribe(
+        () => {
+          this.invitationSent = true;
+          this.setAddedFriends();
+        },
+        (error) => {
+          this.snackBar.openSnackBar('snack-bar.error.default');
+        }
+      );
+    }
+  }
+
   setFriendDisable(friendId: number): boolean {
-    return this.userFriendsService.addedFriends?.some((addedFriend) => addedFriend.id === friendId);
+    return this.userFriendsService.addedFriends?.some((addedFriend) => addedFriend.id === friendId) || this.invitationSent;
   }
 
   setAllFriendsDisable(): boolean {
-    return this.userFriendsService.addedFriends?.length === this.friends?.length;
+    return this.invitationSent || this.userFriendsService.addedFriends?.length === this.friends?.length;
   }
 
   updateAllAdd() {
-    this.allAdd = this.friends !== null && this.friends.every((friend) => friend.added);
+    this.allAdd = this.friends.length > 0 && this.friends.every((friend) => friend.added);
   }
 
   someAdd(): boolean {
-    if (this.friends) {
-      return this.friends.filter((friend) => friend.added).length > 0 && !this.allAdd;
-    }
+    return this.friends.some((friend) => friend.added) && !this.allAdd;
   }
 
   setAll(added: boolean) {
     this.allAdd = added;
-    if (this.friends) {
-      return this.friends?.map((friend) => {
-        const isAlreadyAdded = this.userFriendsService.addedFriends?.some((addedFriend) => addedFriend.id === friend.id);
-        if (!isAlreadyAdded) {
-          friend.added = added;
-        }
-      });
-    }
+    this.friends.forEach((friend) => {
+      if (!this.isFriendAddedAlready(friend.id)) {
+        this.toggleFriendSelection(friend.id, added);
+      }
+    });
   }
 
-  onInput(input): void {
-    this.inputValue = input.target.value;
-    this.inputFriends = this.friends.filter((friend) => friend.name.includes(this.inputValue) || friend.email.includes(this.inputValue));
+  isFriendAddedAlready(friendId: number): boolean {
+    return this.userFriendsService.addedFriends?.some((addedFriend) => addedFriend.id === friendId);
+  }
+
+  filterFriendsByInput(input: string): FriendModel[] {
+    return this.friends.filter((friend) => friend.name.toLowerCase().includes(input) || friend.email.toLowerCase().includes(input));
+  }
+
+  onInput(event: Event): void {
+    const input = (event.target as HTMLInputElement).value.toLowerCase();
+    this.inputValue = input;
+    this.allAdd = false;
+    this.inputFriends = input ? this.filterFriendsByInput(input) : [...this.friends];
   }
 
   setAddedFriends() {
-    return this.friends.map((friend) => {
-      if (friend.added) {
-        this.userFriendsService.addedFriendsToHabit(friend);
+    this.selectedFriends.forEach((friendId) => {
+      const friend = this.friends.find((f) => f.id === friendId);
+      if (friend) {
+        this.userFriendsService.addedFriends.push(friend);
       }
     });
   }

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy } from '@angular/core';
+import { Component, Input, OnDestroy } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { FriendModel } from '@global-user/models/friend.model';
 import { UserFriendsService } from '@global-user/services/user-friends.service';
@@ -13,6 +13,7 @@ import { HabitInviteFriendsPopUpComponent } from './habit-invite-friends-pop-up/
 })
 export class HabitInviteFriendsComponent implements OnDestroy {
   private destroyed$: Subject<boolean> = new Subject<boolean>();
+  @Input() habitId: number;
   userId: number;
   addedFriends: FriendModel[] = [];
 
@@ -23,7 +24,10 @@ export class HabitInviteFriendsComponent implements OnDestroy {
 
   openInviteFriendsDialog() {
     this.dialog.open(HabitInviteFriendsPopUpComponent, {
-      hasBackdrop: true
+      hasBackdrop: true,
+      data: {
+        habitId: this.habitId
+      }
     });
     this.dialog.afterAllClosed.pipe(takeUntil(this.destroyed$)).subscribe(() => this.getAddedFriends());
   }

--- a/src/app/main/component/user/services/user-friends.service.ts
+++ b/src/app/main/component/user/services/user-friends.service.ts
@@ -89,4 +89,9 @@ export class UserFriendsService {
   addedFriendsToHabit(friend) {
     this.addedFriends.push(friend);
   }
+
+  inviteFriendsToHabit(habitId: number, friendsIds: number[]): Observable<any> {
+    const queryParams = friendsIds.map((id) => `friendsIds=${id}`).join('&');
+    return this.http.post(`${this.urlFriend}habit/assign/${habitId}/invite?${queryParams}`, {}, this.httpOptions);
+  }
 }


### PR DESCRIPTION
## **Summary of work 🔥**
### **Summary of Key Functional Updates**

- _Fixed: Incorrect pop-up message when trying to add a seventh habit_ (#7416)
- _Fixed: When we tag a user in the comments, the dropdown list with users appears, and typing becomes disabled_ (#7401)
- _Fixed: Everytime while tagging someone in the comments, with every new letter the dropdown opened and close, causing flickering effect_ (#7417)
- _Fixed: Trigger the endpoint when the @ or # symbol is entered while tagging user, rather than on the first letter_ (#7407)

##

###  **Developed the UI mechanism for displaying the additional "Fact of the Day" on the "My Account" page, ensuring that it updates daily.**  (#7384)

- [x] Added a **new card** to display the habitFactOfTheDay content in the UI when available.
- [x]  Introduced **habitFactOfTheDay** for managing habit-related facts.
- [x]  **ProfileService**: Added getFactsOfTheDayByTags() to fetch habit facts.
- [x]  **LocalStorageService**: Added methods to save, retrieve, and clear habit facts with a 24-hour validity check.
- [x]  Logic to verify if **more than 24 hours have passed** since the last fetch and to update the habit facts accordingly.
- [x]  Replaced individual subscriptions with a Subject<void> for **cleaner subscription** handling.

<img width="301" alt="Знімок екрана 2024-10-01 о 13 57 46" src="https://github.com/user-attachments/assets/d0e2689c-6fd6-4805-8703-aff65bb5c7f9">


###  **Implemented habit friends invite functionality** (#7459)

- [x] Added an API call inviteFriendsToHabit in inviteFriends() for sending invitations
- [x] HabitId passed into the pop-up component via MAT_DIALOG_DATA to facilitate inviting friends to a specific habit.
- [x]  Added setFriendDisable and setAllFriendsDisable methods to determine if individual or all friends should be disabled after an invite.
- [x] The two-way binding has been replaced with explicit function calls (onFriendCheckboxChange) that manage the state more clearly by updating selectedFriends and the checkbox state.
- [x]  Unified the display logic under *ngIf="!inputValue" to manage showing either all friends or a filtered list of friends based on the search input. The inputFriends list is dynamically updated as the search input changes, replacing the need for separate blocks for displaying all friends vs. filtered friends.
- [x] This fixes a bug "Friends don`t receive an invitation letter to track habit together after sending them a request" (#7423)

<img width="716" alt="Знімок екрана 2024-10-03 о 13 04 25" src="https://github.com/user-attachments/assets/56446547-e09f-49ff-ae62-39d05bcebc6e">

###  **Added comments to the Habit**   (#7484)

- [x] Implemented comments section on the habit page.
- [x] Created a service for handling habit comments. 
- [x] Сreated new interfaces (HabitCommentsModel, HabitAuthorDTO, HabitCommentsDTO, HabitAddedCommentDTO) to handle habit-specific comments
- [x] Integrated the comments container component (<app-comments-container>) into the habit details page, passing the habitId dynamically.
- [x] Updated the checkSocketMessageToSubscribe method to handle real-time comment updates (likes and counts) for habits
<img width="1333" alt="Знімок екрана 2024-10-01 о 14 03 22" src="https://github.com/user-attachments/assets/fb793d3d-7faa-4f80-af71-e7631089644c">

###  **Implemented Settings for managing which emails notification user wants to get**  (#7467)

- [x] Extended the form with email preferences, added checkboxes, updated the form submission logic so the user can choose which types of notification he/she wants to receive by email, specifically there are types like: System(by default are on), Comments, Invites, Likes
<img width="1089" alt="Знімок екрана 2024-10-03 о 08 46 31" src="https://github.com/user-attachments/assets/ce8c00cf-5e92-4de2-b50e-da1acaf6c8f2">

_Right now I am working on implementing the periodicity of receiving these notifications_ (#7544)

##
### **Summary of changes connected to styles**

- _Position of "more options" button_  (#7388)

#### Before
![5373141767223893663](https://github.com/user-attachments/assets/946c6187-a946-465e-91de-e5abf8005a24)
### After
<img width="1194" alt="Знімок екрана 2024-08-30 о 16 57 11" src="https://github.com/user-attachments/assets/3f50a0a6-6e30-4c13-a30d-c761fd514dcf">

##
- _Title description_ (#7398)

#### Before
![5373141767223894015](https://github.com/user-attachments/assets/fad39e4f-d5be-4bc1-a1e2-16d2a81ac520)

### After
![5373141767223894000](https://github.com/user-attachments/assets/ae601042-365b-452a-9817-9efb25c1e3f5)
##
- _Slider for distance_ (#7396)

#### Before
<img width="260" alt="Знімок екрана 2024-09-03 о 11 15 15" src="https://github.com/user-attachments/assets/c7f78e32-071d-49fd-afdd-1501d7d01101">

### After
<img width="278" alt="Знімок екрана 2024-09-03 о 11 16 21" src="https://github.com/user-attachments/assets/94f1e4fc-3efe-40b0-9464-bdf1af64ee30">

##
- _Pop-up notifications_ (#7435)

#### Before
<img src="https://github.com/user-attachments/assets/4dcb90d2-ae10-48fe-a891-b0445245aed9" width="384">

### After
<img width="384" alt="Знімок екрана 2024-09-10 о 16 52 16" src="https://github.com/user-attachments/assets/b1f7d9ff-a514-4f95-b289-a00cdc888c50">

##

### **Thank you for your attention.**
