### PR TITLE
[Refactor] #7347 Update eco-news- comments end-points

### DIFF
--- a/src/app/main/component/eco-news/services/eco-news-comments.service.ts
+++ b/src/app/main/component/eco-news/services/eco-news-comments.service.ts
@@ -22,7 +22,7 @@ export class EcoNewsCommentsService implements CommentsService {
 
   getActiveCommentsByPage(ecoNewsId: number, page: number, size: number): Observable<CommentsModel> {
     return this.http.get<EcoNewsCommentsModel>(
-      `${this.backEnd}eco-news/${ecoNewsId}/comments?statuses=ORIGINAL,EDITED&page=${page}&size=${size}`
+      `${this.backEnd}eco-news/${ecoNewsId}/comments/active?statuses=ORIGINAL,EDITED&page=${page}&size=${size}`
     );
   }
 
@@ -32,13 +32,13 @@ export class EcoNewsCommentsService implements CommentsService {
 
   getActiveRepliesByPage(ecoNewsId: number, parentCommentId: number, page: number, size: number): Observable<CommentsModel> {
     return this.http.get<EcoNewsCommentsModel>(
-      `${this.backEnd}eco-news/${ecoNewsId}/comments/${parentCommentId}/replies?statuses=ORIGINAL,EDITED&page=${page}&size=${size}`
+      `${this.backEnd}eco-news/${ecoNewsId}/comments/${parentCommentId}/replies/active?statuses=ORIGINAL,EDITED&page=${page}&size=${size}`
     );
   }
 
   deleteComments(ecoNewsId: number, parentCommentId: number) {
     return this.http
-      .delete<object>(`${this.backEnd}eco-news/${ecoNewsId}/comments/${parentCommentId}`, { observe: 'response' })
+      .delete<object>(`${this.backEnd}eco-news/comments/${ecoNewsId}`, { observe: 'response' })
       .pipe(map((response) => response.status >= 200 && response.status < 300));
   }
 
@@ -47,14 +47,14 @@ export class EcoNewsCommentsService implements CommentsService {
   }
 
   getRepliesAmount(ecoNewsId: number, parentCommentId: number): Observable<number> {
-    return this.http.get<number>(`${this.backEnd}eco-news/${ecoNewsId}/comments/${parentCommentId}/replies/count`);
+    return this.http.get<number>(`${this.backEnd}eco-news/${ecoNewsId}/comments/${parentCommentId}/replies/active/count`);
   }
 
   postLike(ecoNewsId: number, commentId: number): Observable<void> {
-    return this.http.post<void>(`${this.backEnd}eco-news/${ecoNewsId}/comments/${commentId}/likes`, {});
+    return this.http.post<void>(`${this.backEnd}eco-news/comments/like?commentId=${commentId}`, {});
   }
 
   editComment(ecoNewsId: number, commentId: number, text: string): Observable<void> {
-    return this.http.put<void>(`${this.backEnd}eco-news/${ecoNewsId}/comments/${commentId}`, text);
+    return this.http.patch<void>(`${this.backEnd}eco-news/comments?commentId=${commentId}`, text);
   }
 }


### PR DESCRIPTION
[7347](https://github.com/ita-social-projects/GreenCity/issues/7437)

GET: getAllActiveReplies(): 
 “/eco-news/{ecoNewsId}/comments/{parentCommentId}/replies” → “/eco-news/comments/{parentCommentId}/replies/active”
 
GET: getCountOfActiveReplies(): “/eco-news/{ecoNewsId}/comments/{parentCommentId}/replies/count” → 
“/eco-news/comments/{parentCommentId}/replies/active/count”

DELETE: delete():  “/eco-news/{ecoNewsId}/comments/{commentId}” → “/eco-news/comments/{id}”

PUT: update(): ”/eco-news/{ecoNewsId}/comments/{commentId}” → 
PATCH: “/eco-news/comments” and comment id now as RequestParameter not as PathVariable

 POST: like():“eco-news/{ecoNewsId}/comments/{commentId}/likes” → 
 “eco-news/comments/like” and + RequestParam of commentId 

GET: countLikes(): MessageMapping: “eco-news/{ecoNewsId}/comments/likeAndCount” →  “eco-news/comments/active” 
GET: getAllActiveComments():  “eco-news/{ecoNewsId}/comments” → “eco-news/comments/active”