### PR TITLE
[Bugfix] Add comments without errors

### DIFF
--- a/src/app/main/component/eco-news/models/eco-news-comments.model.ts
+++ b/src/app/main/component/eco-news/models/eco-news-comments.model.ts
@@ -23,10 +23,3 @@ export interface EcoNewsCommentsDTO {
   showRelyButton?: boolean;
   showAllRelies?: boolean;
 }
-
-export interface EcoNewsAddedCommentDTO {
-  author: EcoNewsAuthorDTO;
-  id: number;
-  modifiedDate: string;
-  text: string;
-}

--- a/src/app/main/component/eco-news/services/eco-news-comments.service.ts
+++ b/src/app/main/component/eco-news/services/eco-news-comments.service.ts
@@ -4,8 +4,8 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '@environment/environment';
 import { CommentsService } from '../../comments/services/comments.service';
-import { CommentsModel } from '../../comments/models/comments-model';
-import { EcoNewsAddedCommentDTO, EcoNewsCommentsModel } from '../models/econ-news-comments.model';
+import { AddedCommentDTO, CommentsModel } from '../../comments/models/comments-model';
+import { EcoNewsCommentsModel } from '../models/eco-news-comments.model';
 
 @Injectable({
   providedIn: 'root'
@@ -15,7 +15,7 @@ export class EcoNewsCommentsService implements CommentsService {
 
   constructor(private http: HttpClient) {}
 
-  addComment(ecoNewsId: number, text: string, id = 0): Observable<EcoNewsAddedCommentDTO> {
+  addComment(ecoNewsId: number, text: string, id = 0): Observable<AddedCommentDTO> {
     const formData = new FormData();
     const requestPayload = {
       text: text,
@@ -24,7 +24,7 @@ export class EcoNewsCommentsService implements CommentsService {
 
     formData.append('request', JSON.stringify(requestPayload));
 
-    return this.http.post<EcoNewsAddedCommentDTO>(`${this.backEnd}eco-news/${ecoNewsId}/comments`, formData);
+    return this.http.post<AddedCommentDTO>(`${this.backEnd}eco-news/${ecoNewsId}/comments`, formData);
   }
 
   getActiveCommentsByPage(ecoNewsId: number, page: number, size: number): Observable<CommentsModel> {

--- a/src/app/main/component/eco-news/services/eco-news-comments.service.ts
+++ b/src/app/main/component/eco-news/services/eco-news-comments.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '@environment/environment';
 import { CommentsService } from '../../comments/services/comments.service';
-import { AddedCommentDTO, CommentsModel } from '../../comments/models/comments-model';
+import { CommentsModel } from '../../comments/models/comments-model';
 import { EcoNewsAddedCommentDTO, EcoNewsCommentsModel } from '../models/econ-news-comments.model';
 
 @Injectable({
@@ -15,9 +15,16 @@ export class EcoNewsCommentsService implements CommentsService {
 
   constructor(private http: HttpClient) {}
 
-  addComment(ecoNewsId: number, text: string, id = 0): Observable<AddedCommentDTO> {
-    const body = { parentCommentId: id, text };
-    return this.http.post<EcoNewsAddedCommentDTO>(`${this.backEnd}eco-news/${ecoNewsId}/comments`, body);
+  addComment(ecoNewsId: number, text: string, id = 0): Observable<EcoNewsAddedCommentDTO> {
+    const formData = new FormData();
+    const requestPayload = {
+      text: text,
+      parentCommentId: id
+    };
+
+    formData.append('request', JSON.stringify(requestPayload));
+
+    return this.http.post<EcoNewsAddedCommentDTO>(`${this.backEnd}eco-news/${ecoNewsId}/comments`, formData);
   }
 
   getActiveCommentsByPage(ecoNewsId: number, page: number, size: number): Observable<CommentsModel> {


### PR DESCRIPTION
### Previous behaviour

The following response was received before:

```json
{
   "message":"Failed to parse multipart servlet request"
}
```

You couldn't leave a comment below a news article:

![image](https://github.com/user-attachments/assets/98359b1f-e72b-455e-b3e2-c256a42506be)
