### PR TITLE
[Bugfix] #7344 Add functionality of uploading photos to comments

### DIFF
--- a/src/app/main/component/comments/components/add-comment/add-comment.component.html
+++ b/src/app/main/component/comments/components/add-comment/add-comment.component.html
@@ -11,8 +11,9 @@
     <app-comment-textarea
       class="comment-width"
       placeholder="homepage.eco-news.comment.placeholder.add-a-comment"
-      (commentText)="setContent($event)"
+      (comment)="setContent($event)"
       [commentHtml]="commentHtml"
+      (imageUploaderStatus)="isImageUploaderOpen = $event"
     ></app-comment-textarea>
     <button class="primary-global-button" [disabled]="!addCommentForm.valid">
       {{ 'homepage.eco-news.comment.comment' | translate }}
@@ -24,8 +25,9 @@
         <app-comment-textarea
           class="reply-width"
           placeholder="homepage.eco-news.comment.placeholder.add-a-reply"
-          (commentText)="setContent($event)"
+          (comment)="setContent($event)"
           [commentHtml]="commentHtml"
+          (imageUploaderStatus)="isImageUploaderOpen = $event"
         ></app-comment-textarea>
       </div>
 

--- a/src/app/main/component/comments/components/add-comment/add-comment.component.spec.ts
+++ b/src/app/main/component/comments/components/add-comment/add-comment.component.spec.ts
@@ -14,6 +14,7 @@ import { PlaceholderForDivDirective } from '../../directives/placeholder-for-div
 import { SocketService } from '@global-service/socket/socket.service';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
+import { CommentFormData } from '../../models/comments-model';
 
 const COMMENT_MOCK = {
   author: {
@@ -112,10 +113,18 @@ describe('AddCommentComponent', () => {
       innerHTML: 'test html',
       imageFiles: []
     });
+
+    const commentData: CommentFormData = {
+      entityId: component.entityId,
+      text: 'test html',
+      imageFiles: [],
+      parentCommentId: component.commentId
+    };
+
     component.onSubmit();
 
     flush();
-    expect(commentsServiceMock.addComment).toHaveBeenCalledWith(component.entityId, 'test html', [], component.commentId);
+    expect(commentsServiceMock.addComment).toHaveBeenCalledWith(commentData);
     expect(updateListSpy).toHaveBeenCalledWith(COMMENT_MOCK);
     expect(component.addCommentForm.value.content).toBe('');
   }));

--- a/src/app/main/component/comments/components/add-comment/add-comment.component.spec.ts
+++ b/src/app/main/component/comments/components/add-comment/add-comment.component.spec.ts
@@ -13,6 +13,7 @@ import { CommentTextareaComponent } from '../comment-textarea/comment-textarea.c
 import { PlaceholderForDivDirective } from '../../directives/placeholder-for-div.directive';
 import { SocketService } from '@global-service/socket/socket.service';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatIconModule } from '@angular/material/icon';
 
 const COMMENT_MOCK = {
   author: {
@@ -65,7 +66,7 @@ describe('AddCommentComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [AddCommentComponent, UserProfileImageComponent, CommentTextareaComponent, PlaceholderForDivDirective],
-      imports: [FormsModule, ReactiveFormsModule, TranslateModule.forRoot(), HttpClientTestingModule, MatMenuModule],
+      imports: [FormsModule, ReactiveFormsModule, TranslateModule.forRoot(), HttpClientTestingModule, MatMenuModule, MatIconModule],
       providers: [
         { provide: ProfileService, useValue: profileServiceMock },
         { provide: CommentsService, useValue: commentsServiceMock },
@@ -108,13 +109,24 @@ describe('AddCommentComponent', () => {
     const updateListSpy = spyOn(component.updateList, 'emit');
     component.setContent({
       text: 'test text',
-      innerHTML: 'test html'
+      innerHTML: 'test html',
+      imageFiles: []
     });
     component.onSubmit();
 
     flush();
-    expect(commentsServiceMock.addComment).toHaveBeenCalledWith(component.entityId, 'test html', component.commentId);
+    expect(commentsServiceMock.addComment).toHaveBeenCalledWith(component.entityId, 'test html', [], component.commentId);
     expect(updateListSpy).toHaveBeenCalledWith(COMMENT_MOCK);
     expect(component.addCommentForm.value.content).toBe('');
   }));
+
+  it('should update content and uploaded image in setContent', () => {
+    const mockData = { text: 'Test Comment', innerHTML: '<p>Test Comment</p>', imageFiles: [new File([], 'test.jpg')] };
+    component.setContent(mockData);
+
+    expect(component.addCommentForm.controls.content.value).toBe('Test Comment');
+    expect(component.commentHtml).toBe('<p>Test Comment</p>');
+    expect(component.uploadedImage).toEqual(mockData.imageFiles[0]);
+    expect(component.showImageControls).toBeTrue();
+  });
 });

--- a/src/app/main/component/comments/components/add-comment/add-comment.component.ts
+++ b/src/app/main/component/comments/components/add-comment/add-comment.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angu
 import { FormBuilder, FormControl, FormGroup, Validators, ValidationErrors } from '@angular/forms';
 import { CommentsService } from '../../services/comments.service';
 import { ProfileService } from '@global-user/components/profile/profile-service/profile.service';
-import { AddedCommentDTO } from 'src/app/main/component/comments/models/comments-model';
+import { AddedCommentDTO, CommentFormData } from 'src/app/main/component/comments/models/comments-model';
 import { CommentTextareaComponent } from '../comment-textarea/comment-textarea.component';
 
 @Component({
@@ -67,9 +67,14 @@ export class AddCommentComponent implements OnInit {
   }
 
   onSubmit(): void {
-    const imageFiles = this.commentTextareaComponent.uploadedImage.map((image) => image.file);
+    const commentData: CommentFormData = {
+      entityId: this.entityId,
+      text: this.commentHtml,
+      imageFiles: this.commentTextareaComponent.uploadedImage.map((image) => image.file),
+      parentCommentId: this.commentId
+    };
 
-    this.commentsService.addComment(this.entityId, this.commentHtml, imageFiles, this.commentId).subscribe((comment: AddedCommentDTO) => {
+    this.commentsService.addComment(commentData).subscribe((comment: AddedCommentDTO) => {
       this.updateList.emit(comment);
       this.resetForm();
     });

--- a/src/app/main/component/comments/components/add-comment/add-comment.component.ts
+++ b/src/app/main/component/comments/components/add-comment/add-comment.component.ts
@@ -60,7 +60,7 @@ export class AddCommentComponent implements OnInit {
   setContent(data: { text: string; innerHTML: string; imageFiles?: File[] }) {
     this.addCommentForm.controls.content.setValue(data.text);
     this.commentHtml = data.innerHTML;
-    if (data.imageFiles && data.imageFiles.length) {
+    if (data?.imageFiles?.length) {
       this.uploadedImage = data.imageFiles[0];
       this.showImageControls = true;
     }

--- a/src/app/main/component/comments/components/add-comment/add-comment.component.ts
+++ b/src/app/main/component/comments/components/add-comment/add-comment.component.ts
@@ -11,7 +11,7 @@ import { CommentTextareaComponent } from '../comment-textarea/comment-textarea.c
   styleUrls: ['./add-comment.component.scss']
 })
 export class AddCommentComponent implements OnInit {
-  @Input() public isImageUploaderOpen: boolean = false;
+  @Input() public isImageUploaderOpen = false;
   @Input() public entityId: number;
   @Input() public commentId: number;
   @Output() public imageUploaderStatus = new EventEmitter<boolean>();

--- a/src/app/main/component/comments/components/add-comment/add-comment.component.ts
+++ b/src/app/main/component/comments/components/add-comment/add-comment.component.ts
@@ -1,9 +1,9 @@
-import { take } from 'rxjs/operators';
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators, ValidationErrors } from '@angular/forms';
 import { CommentsService } from '../../services/comments.service';
 import { ProfileService } from '@global-user/components/profile/profile-service/profile.service';
 import { AddedCommentDTO } from 'src/app/main/component/comments/models/comments-model';
+import { CommentTextareaComponent } from '../comment-textarea/comment-textarea.component';
 
 @Component({
   selector: 'app-add-comment',
@@ -11,11 +11,17 @@ import { AddedCommentDTO } from 'src/app/main/component/comments/models/comments
   styleUrls: ['./add-comment.component.scss']
 })
 export class AddCommentComponent implements OnInit {
+  @Input() public isImageUploaderOpen: boolean = false;
   @Input() public entityId: number;
   @Input() public commentId: number;
+  @Output() public imageUploaderStatus = new EventEmitter<boolean>();
   @Output() public updateList = new EventEmitter<AddedCommentDTO>();
+  @ViewChild(CommentTextareaComponent) commentTextareaComponent: CommentTextareaComponent;
+
   avatarImage: string;
   firstName: string;
+  uploadedImage: File | null = null;
+  showImageControls = true;
   addCommentForm: FormGroup = this.fb.group({
     content: ['', [Validators.required, Validators.maxLength(8000), this.noSpaceValidator]]
   });
@@ -42,20 +48,30 @@ export class AddCommentComponent implements OnInit {
     });
   }
 
-  setContent(data: { text: string; innerHTML: string }) {
+  resetForm(): void {
+    this.addCommentForm.reset();
+    this.addCommentForm.controls.content.setValue('');
+    this.commentHtml = '';
+    this.uploadedImage = null;
+    this.imageUploaderStatus.emit(false);
+    this.commentTextareaComponent.onCancelImage();
+  }
+
+  setContent(data: { text: string; innerHTML: string; imageFiles?: File[] }) {
     this.addCommentForm.controls.content.setValue(data.text);
     this.commentHtml = data.innerHTML;
+    if (data.imageFiles && data.imageFiles.length) {
+      this.uploadedImage = data.imageFiles[0];
+      this.showImageControls = true;
+    }
   }
 
   onSubmit(): void {
-    this.commentsService
-      .addComment(this.entityId, this.commentHtml, this.commentId)
-      .pipe(take(1))
-      .subscribe((comment: AddedCommentDTO) => {
-        this.updateList.emit(comment);
-        this.addCommentForm.reset();
-        this.addCommentForm.controls.content.setValue('');
-        this.commentHtml = '';
-      });
+    const imageFiles = this.commentTextareaComponent.uploadedImage.map((image) => image.file);
+
+    this.commentsService.addComment(this.entityId, this.commentHtml, imageFiles, this.commentId).subscribe((comment: AddedCommentDTO) => {
+      this.updateList.emit(comment);
+      this.resetForm();
+    });
   }
 }

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.html
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.html
@@ -42,12 +42,12 @@
 
 <div class="comment-textarea-uploader" *ngIf="isImageUploaderOpen">
   <app-drag-and-drop [aspectRatio]="aspectRatio || 1" (newFile)="onImageSelected($event)"> </app-drag-and-drop>
-  <mat-icon class="cancel-btn" type="button" (click)="toggleImageUploader()">close</mat-icon>
+  <mat-icon class="cancel-btn" type="button" (click)="toggleImageUploader()" (keydown)="onCommentKeyDown($event)">close</mat-icon>
 </div>
 
 <div class="image-wrapper" *ngIf="showImageControls">
   <div class="image-preview-wrapper" *ngFor="let image of uploadedImage; let i = index">
-    <mat-icon class="cancel-btn" type="button" (click)="removeImage(i)">close</mat-icon>
+    <mat-icon class="cancel-btn" type="button" (click)="removeImage(i)" (keydown)="onCommentKeyDown($event)">close</mat-icon>
     <img [src]="image.url" alt="Uploaded {{ i + 1 }}" class="image-preview" />
   </div>
 

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.html
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.html
@@ -48,7 +48,7 @@
 <div class="image-wrapper" *ngIf="showImageControls">
   <div class="image-preview-wrapper" *ngFor="let image of uploadedImage; let i = index">
     <mat-icon class="cancel-btn" type="button" (click)="removeImage(i)">close</mat-icon>
-    <img [src]="image.url" alt="Uploaded Image {{ i + 1 }}" class="image-preview" />
+    <img [src]="image.url" alt="Uploaded {{ i + 1 }}" class="image-preview" />
   </div>
 
   <button

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.html
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.html
@@ -15,6 +15,9 @@
   <p *ngIf="content.errors?.maxlength" class="error-message">
     {{ 'homepage.eco-news.comment.reply-error-message' | translate }}
   </p>
+  <button mat-icon-button type="button" (click)="toggleImageUploader()" class="image-upload-btn">
+    <mat-icon>image</mat-icon>
+  </button>
   <button
     mat-icon-button
     #menuTrigger="matMenuTrigger"
@@ -35,4 +38,23 @@
       <div class="user-name">{{ user.userName }}</div>
     </button>
   </mat-menu>
+</div>
+
+<div class="comment-textarea-uploader" *ngIf="isImageUploaderOpen">
+  <app-drag-and-drop [aspectRatio]="aspectRatio || 1" (newFile)="onImageSelected($event)"> </app-drag-and-drop>
+  <mat-icon class="cancel-btn" type="button" (click)="toggleImageUploader()">close</mat-icon>
+</div>
+
+<div class="image-wrapper" *ngIf="showImageControls">
+  <div class="image-preview-wrapper" *ngFor="let image of uploadedImage; let i = index">
+    <mat-icon class="cancel-btn" type="button" (click)="removeImage(i)">close</mat-icon>
+    <img [src]="image.url" alt="Uploaded Image {{ i + 1 }}" class="image-preview" />
+  </div>
+
+  <button
+    *ngIf="uploadedImage.length > 0 && uploadedImage.length < 5"
+    class="add-more-images"
+    type="button"
+    (click)="toggleImageUploader()"
+  ></button>
 </div>

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.scss
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.scss
@@ -3,6 +3,64 @@
   width: 100%;
 }
 
+::ng-deep .comment-textarea-uploader {
+  .cropper-block,
+  .cropper-buttons {
+    display: none !important;
+  }
+}
+
+.comment-textarea-uploader {
+  position: relative;
+  width: 100%;
+
+  .cancel-btn {
+    font-size: 18px;
+    position: absolute;
+    top: 0;
+    right: -15px;
+    cursor: pointer;
+    color: var(--tertiary-dark-grey);
+  }
+}
+
+.image-preview-wrapper {
+  padding-left: 9px;
+  max-width: calc(33.33% - 16px);
+  width: 100%;
+
+  img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 5px;
+  }
+
+  .cancel-btn {
+    font-size: 18px;
+    position: absolute;
+    width: 19px;
+    height: 19px;
+    cursor: pointer;
+    color: var(--tertiary-dark-grey);
+    background-color: var(--shadow-dark-grey);
+  }
+}
+
+.image-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.add-more-images {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 0;
+  margin-left: 8px;
+  background: url('/assets/icons/habits/plus-circle-green.svg') no-repeat center;
+}
+
 .comment-textarea-wrapper {
   width: 100%;
 

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.spec.ts
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.spec.ts
@@ -10,6 +10,7 @@ import { PlaceholderForDivDirective } from 'src/app/main/component/comments/dire
 import { MatSelectModule } from '@angular/material/select';
 import { UserProfileImageComponent } from '@global-user/components/shared/components/user-profile-image/user-profile-image.component';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatIconModule } from '@angular/material/icon';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('CommentTextareaComponent', () => {
@@ -51,7 +52,7 @@ describe('CommentTextareaComponent', () => {
         { provide: SocketService, useValue: socketServiceMock },
         { provide: LocalStorageService, useValue: localStorageServiceMock }
       ],
-      imports: [MatSelectModule, TranslateModule.forRoot(), BrowserAnimationsModule, MatMenuModule]
+      imports: [MatSelectModule, TranslateModule.forRoot(), BrowserAnimationsModule, MatMenuModule, MatIconModule]
     }).compileComponents();
   }));
 
@@ -168,5 +169,24 @@ describe('CommentTextareaComponent', () => {
     component.ngOnDestroy();
     expect(nextSpy).toHaveBeenCalled();
     expect(completeSpy).toHaveBeenCalled();
+  });
+
+  it('should toggle image uploader visibility', () => {
+    component.isImageUploaderOpen = false;
+
+    component.toggleImageUploader();
+    expect(component.isImageUploaderOpen).toBeTrue();
+
+    component.toggleImageUploader();
+    expect(component.isImageUploaderOpen).toBeFalse();
+  });
+
+  it('should remove an uploaded image', () => {
+    const mockFile = new File(['image content'], 'test.png', { type: 'image/png' });
+    component.uploadedImage = [{ url: 'mockUrl', file: mockFile }];
+
+    component.removeImage(0);
+
+    expect(component.uploadedImage.length).toBe(0);
   });
 });

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.spec.ts
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.spec.ts
@@ -171,22 +171,86 @@ describe('CommentTextareaComponent', () => {
     expect(completeSpy).toHaveBeenCalled();
   });
 
-  it('should toggle image uploader visibility', () => {
-    component.isImageUploaderOpen = false;
+  it('should correctly toggle image uploader visibility', () => {
+    spyOn(component.imageUploaderStatus, 'emit');
+
+    component.toggleImageUploaderVisibility(true);
+    expect(component.isImageUploaderOpen).toBeTrue();
+    expect(component.showImageControls).toBeFalse();
+    expect(component.imageUploaderStatus.emit).toHaveBeenCalledWith(true);
+
+    component.toggleImageUploaderVisibility(false);
+    expect(component.isImageUploaderOpen).toBeFalse();
+    expect(component.showImageControls).toBeTrue();
+    expect(component.imageUploaderStatus.emit).toHaveBeenCalledWith(false);
+  });
+
+  it('should toggle image uploader when there are less than 5 uploaded images', () => {
+    spyOn(component.imageUploaderStatus, 'emit');
+    component.uploadedImage = [{ url: '', file: new File([], 'file1') }];
 
     component.toggleImageUploader();
     expect(component.isImageUploaderOpen).toBeTrue();
+    expect(component.imageUploaderStatus.emit).toHaveBeenCalledWith(true);
 
     component.toggleImageUploader();
     expect(component.isImageUploaderOpen).toBeFalse();
+    expect(component.imageUploaderStatus.emit).toHaveBeenCalledWith(false);
   });
 
-  it('should remove an uploaded image', () => {
-    const mockFile = new File(['image content'], 'test.png', { type: 'image/png' });
-    component.uploadedImage = [{ url: 'mockUrl', file: mockFile }];
+  it('should not toggle image uploader when there are 5 or more uploaded images', () => {
+    component.uploadedImage = new Array(5).fill({ url: '', file: new File([], 'file') });
+
+    component.isImageUploaderOpen = false;
+    component.toggleImageUploader();
+
+    expect(component.isImageUploaderOpen).toBeFalse();
+  });
+
+  it('should not add image when there are already 5 images', () => {
+    component.uploadedImage = new Array(5).fill({ url: '', file: new File([], 'file') });
+
+    const fileHandle = { url: 'unsafeUrl', file: new File([], 'image.png') };
+    component.onImageSelected(fileHandle);
+
+    expect(component.uploadedImage.length).toBe(5);
+  });
+
+  it('should remove the image at the specified index', () => {
+    component.uploadedImage = [
+      { url: 'image1', file: new File([], 'file1') },
+      { url: 'image2', file: new File([], 'file2') }
+    ];
 
     component.removeImage(0);
 
+    expect(component.uploadedImage.length).toBe(1);
+    expect(component.uploadedImage[0].url).toBe('image2');
+  });
+
+  it('should not remove anything if index is out of bounds', () => {
+    component.uploadedImage = [{ url: 'image1', file: new File([], 'file1') }];
+
+    component.removeImage(5);
+
+    expect(component.uploadedImage.length).toBe(1);
+  });
+
+  it('should clear uploaded images, hide controls and emit comment with null image files', () => {
+    spyOn(component.comment, 'emit');
+    component.uploadedImage = [{ url: 'image1', file: new File([], 'file1') }];
+    component.showImageControls = true;
+    component.isImageUploaderOpen = true;
+
+    component.onCancelImage();
+
     expect(component.uploadedImage.length).toBe(0);
+    expect(component.showImageControls).toBeFalse();
+    expect(component.isImageUploaderOpen).toBeFalse();
+    expect(component.comment.emit).toHaveBeenCalledWith({
+      text: component.content.value,
+      innerHTML: '',
+      imageFiles: null
+    });
   });
 });

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
@@ -213,12 +213,6 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
     });
   }
 
-  onImageLoad(): void {
-    if (this.uploadedImage.length > 0) {
-      this.isFirstImageLoaded = true;
-    }
-  }
-
   private insertTextAtCursor(text: string): void {
     const selection = window.getSelection();
     const range = selection.getRangeAt(0);

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
@@ -4,22 +4,22 @@ import {
   OnInit,
   ElementRef,
   ViewChild,
-  ViewChildren,
-  QueryList,
   Output,
   Input,
   EventEmitter,
   AfterViewInit,
   OnChanges,
   SimpleChanges,
-  OnDestroy
+  OnDestroy,
+  SecurityContext
 } from '@angular/core';
 import { TaggedUser } from '../../models/comments-model';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
-import { MatOption } from '@angular/material/core';
 import { FormControl, Validators } from '@angular/forms';
 import { Subject, fromEvent } from 'rxjs';
 import { debounceTime, filter, takeUntil, tap } from 'rxjs/operators';
+import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
+import { CHAT_ICONS } from 'src/app/chat/chat-icons';
 
 @Component({
   selector: 'app-comment-textarea',
@@ -27,11 +27,17 @@ import { debounceTime, filter, takeUntil, tap } from 'rxjs/operators';
   styleUrls: ['./comment-textarea.component.scss']
 })
 export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChanges, OnDestroy {
+  chatIcons = CHAT_ICONS;
   private userId: number;
   private searchQuery = '';
   private lastTagCharIndex: number;
   private charToTagUsers = ['@', '#'];
   private range: Range;
+  aspectRatio: number;
+  isImageUploaderOpen = false;
+  showImageControls = false;
+  isFirstImageLoaded = false;
+  uploadedImage: { url: string; file: File }[] = [];
 
   content: FormControl = new FormControl('', [Validators.required, this.innerHtmlMaxLengthValidator(8000)]);
   suggestedUsers: TaggedUser[] = [];
@@ -45,7 +51,8 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
   @ViewChild('dropdown') dropdown;
   @ViewChild('menuTrigger') menuTrigger;
 
-  @Output() commentText = new EventEmitter<{ text: string; innerHTML: string }>();
+  @Output() comment = new EventEmitter<{ text: string; innerHTML: string; imageFiles?: File[] }>();
+  @Output() imageUploaderStatus = new EventEmitter<boolean>();
   @Input() commentTextToEdit: string;
   @Input() commentHtml: string;
   @Input() placeholder: string;
@@ -53,7 +60,8 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
   constructor(
     public socketService: SocketService,
     private localStorageService: LocalStorageService,
-    public elementRef: ElementRef
+    public elementRef: ElementRef,
+    private sanitizer: DomSanitizer
   ) {
     this.socketService.initiateConnection(this.socketService.connection.greenCity);
   }
@@ -85,7 +93,7 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
         debounceTime(300),
         tap(() => {
           this.content.setValue(this.commentTextarea.nativeElement.textContent);
-          this.emitCommentText();
+          this.emitComment();
           const textContent = this.commentTextarea.nativeElement.textContent;
           const hasTagCharacter = this.charToTagUsers.some((char) => textContent.includes(char));
           if (!hasTagCharacter) {
@@ -120,6 +128,9 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.commentHtml?.currentValue === '') {
       this.commentTextarea.nativeElement.innerHTML = '';
+    }
+    if (changes.isImageUploaderOpen) {
+      this.toggleImageUploaderVisibility(changes.isImageUploaderOpen.currentValue);
     }
   }
 
@@ -158,7 +169,53 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
     const text = event.clipboardData?.getData('text/plain');
     this.insertTextAtCursor(text);
     this.content.setValue(this.commentTextarea.nativeElement.textContent);
-    this.emitCommentText();
+    this.emitComment();
+  }
+
+  toggleImageUploaderVisibility(isOpen: boolean): void {
+    this.isImageUploaderOpen = isOpen;
+    this.showImageControls = !isOpen;
+    this.imageUploaderStatus.emit(isOpen);
+  }
+
+  toggleImageUploader(): void {
+    if (this.uploadedImage.length < 5) {
+      this.isImageUploaderOpen = !this.isImageUploaderOpen;
+      this.imageUploaderStatus.emit(this.isImageUploaderOpen);
+    }
+  }
+
+  onImageSelected(fileHandle: { url: SafeUrl; file: File }): void {
+    if (this.uploadedImage.length < 5) {
+      this.uploadedImage.push({
+        url: this.sanitizer.sanitize(SecurityContext.URL, fileHandle.url) || '',
+        file: fileHandle.file
+      });
+    }
+    this.isImageUploaderOpen = false;
+    this.showImageControls = true;
+    this.emitComment();
+  }
+
+  removeImage(index: number): void {
+    this.uploadedImage.splice(index, 1);
+  }
+
+  onCancelImage(): void {
+    this.uploadedImage = [];
+    this.showImageControls = false;
+    this.isImageUploaderOpen = false;
+    this.comment.emit({
+      text: this.content.value,
+      innerHTML: (this.commentTextarea.nativeElement.innerHTML = ''),
+      imageFiles: null
+    });
+  }
+
+  onImageLoad(): void {
+    if (this.uploadedImage.length > 0) {
+      this.isFirstImageLoaded = true;
+    }
   }
 
   private insertTextAtCursor(text: string): void {
@@ -233,14 +290,15 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
     this.insertNodeAtCursor(user, tagChar);
     this.setFocusCommentTextarea();
     this.content.setValue(this.commentTextarea.nativeElement.textContent);
-    this.emitCommentText();
+    this.emitComment();
     this.refocusTextarea();
   }
 
-  private emitCommentText(): void {
-    this.commentText.emit({
+  emitComment(): void {
+    this.comment.emit({
       text: this.commentTextarea.nativeElement.textContent,
-      innerHTML: this.commentTextarea.nativeElement.innerHTML.replace('&nbsp;', ' ')
+      innerHTML: this.commentTextarea.nativeElement.innerHTML,
+      imageFiles: this.uploadedImage.map((image) => image.file)
     });
   }
 

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
@@ -61,7 +61,7 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
     public socketService: SocketService,
     private localStorageService: LocalStorageService,
     public elementRef: ElementRef,
-    private sanitizer: DomSanitizer
+    private readonly sanitizer: DomSanitizer
   ) {
     this.socketService.initiateConnection(this.socketService.connection.greenCity);
   }
@@ -205,9 +205,10 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
     this.uploadedImage = [];
     this.showImageControls = false;
     this.isImageUploaderOpen = false;
+    this.commentTextarea.nativeElement.innerHTML = '';
     this.comment.emit({
       text: this.content.value,
-      innerHTML: (this.commentTextarea.nativeElement.innerHTML = ''),
+      innerHTML: this.commentTextarea.nativeElement.innerHTML,
       imageFiles: null
     });
   }
@@ -294,7 +295,7 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
     this.refocusTextarea();
   }
 
-  emitComment(): void {
+  private emitComment(): void {
     this.comment.emit({
       text: this.commentTextarea.nativeElement.textContent,
       innerHTML: this.commentTextarea.nativeElement.innerHTML,

--- a/src/app/main/component/comments/components/comments-list/comments-list.component.html
+++ b/src/app/main/component/comments/components/comments-list/comments-list.component.html
@@ -33,7 +33,7 @@
     <div class="comment-text" [ngClass]="{ hide: comment.isEdit }" [appLinkify]="comment.text" (click)="onCommentClick($event)"></div>
     <div class="comment-images">
       <div *ngIf="comment.additionalImages && comment.additionalImages.length">
-        <img *ngFor="let image of comment.additionalImages" [src]="image" alt="comment image" class="comment-image" />
+        <img *ngFor="let image of comment.additionalImages" [src]="image" alt="comment" class="comment-image" />
       </div>
     </div>
     <div class="comment-edit-text" *ngIf="comment.isEdit">

--- a/src/app/main/component/comments/components/comments-list/comments-list.component.html
+++ b/src/app/main/component/comments/components/comments-list/comments-list.component.html
@@ -31,10 +31,15 @@
   </div>
   <div class="comment-main-text">
     <div class="comment-text" [ngClass]="{ hide: comment.isEdit }" [appLinkify]="comment.text" (click)="onCommentClick($event)"></div>
+    <div class="comment-images">
+      <div *ngIf="comment.additionalImages && comment.additionalImages.length">
+        <img *ngFor="let image of comment.additionalImages" [src]="image" alt="comment image" class="comment-image" />
+      </div>
+    </div>
     <div class="comment-edit-text" *ngIf="comment.isEdit">
       <app-comment-textarea
         [commentTextToEdit]="comment.text"
-        (commentText)="setCommentText($event)"
+        (comment)="setCommentText($event)"
         [placeholder]="'homepage.eco-news.comment.placeholder.new-comment'"
         class="edit-text-input"
       >

--- a/src/app/main/component/comments/components/comments-list/comments-list.component.scss
+++ b/src/app/main/component/comments/components/comments-list/comments-list.component.scss
@@ -84,6 +84,11 @@
   }
 }
 
+.comment-image {
+  margin: 0 10px 10px 0;
+  border-radius: 4px;
+}
+
 .comments-elements {
   display: flex;
   padding-left: 73px;

--- a/src/app/main/component/comments/models/comments-model.ts
+++ b/src/app/main/component/comments/models/comments-model.ts
@@ -33,6 +33,13 @@ export interface AddedCommentDTO {
   text: string;
 }
 
+export interface CommentFormData {
+  entityId: number;
+  text: string;
+  imageFiles: File[];
+  parentCommentId?: number;
+}
+
 export interface SocketAmountLikes {
   id: number;
   amountLikes: number;

--- a/src/app/main/component/comments/models/comments-model.ts
+++ b/src/app/main/component/comments/models/comments-model.ts
@@ -23,6 +23,7 @@ export interface CommentsDTO {
   showRelyButton?: boolean;
   showAllRelies?: boolean;
   numberOfLikes?: number;
+  additionalImages?: string[];
 }
 
 export interface AddedCommentDTO {

--- a/src/app/main/component/comments/services/comments.service.ts
+++ b/src/app/main/component/comments/services/comments.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { AddedCommentDTO, CommentsModel } from '../models/comments-model';
+import { AddedCommentDTO, CommentFormData, CommentsModel } from '../models/comments-model';
 
 @Injectable({
   providedIn: 'root'
 })
 export abstract class CommentsService {
-  abstract addComment(entityId: number, text: string, imageFiles: File[], parentCommentId: number): Observable<AddedCommentDTO>;
+  abstract addComment(formData: CommentFormData): Observable<AddedCommentDTO>;
 
   abstract getActiveCommentsByPage(entityId: number, page: number, size: number): Observable<CommentsModel>;
 

--- a/src/app/main/component/comments/services/comments.service.ts
+++ b/src/app/main/component/comments/services/comments.service.ts
@@ -6,7 +6,7 @@ import { AddedCommentDTO, CommentsModel } from '../models/comments-model';
   providedIn: 'root'
 })
 export abstract class CommentsService {
-  abstract addComment(entityId: number, text: string, parentCommentId: number): Observable<AddedCommentDTO>;
+  abstract addComment(entityId: number, text: string, imageFiles: File[], parentCommentId: number): Observable<AddedCommentDTO>;
 
   abstract getActiveCommentsByPage(entityId: number, page: number, size: number): Observable<CommentsModel>;
 

--- a/src/app/main/component/eco-news/services/eco-news-comments.service.spec.ts
+++ b/src/app/main/component/eco-news/services/eco-news-comments.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { environment } from '@environment/environment';
 import { EcoNewsCommentsService } from './eco-news-comments.service';
+import { CommentFormData } from '../../comments/models/comments-model';
 
 xdescribe('EcoNewsCommentsService', () => {
   let service: EcoNewsCommentsService;
@@ -42,9 +43,13 @@ xdescribe('EcoNewsCommentsService', () => {
       modifiedDate: new Date('2021-05-27T15:37:15.661Z'),
       text: 'some cool content!'
     };
-    const imageFiles: File[] = [];
+    const commentData: CommentFormData = {
+      entityId: 1,
+      text: commentText,
+      imageFiles: []
+    };
 
-    service.addComment(1, commentText, imageFiles).subscribe((commentData: any) => {
+    service.addComment(commentData).subscribe((commentData: any) => {
       expect(commentData).toEqual(commentBody);
     });
 
@@ -64,8 +69,12 @@ xdescribe('EcoNewsCommentsService', () => {
       modifiedDate: new Date('2021-05-27T15:37:15.661Z'),
       text: 'some cool content!'
     };
-    const imageFiles: File[] = [];
-    service.addComment(1, commentText, imageFiles).subscribe((commentData: any) => {
+    const commentData: CommentFormData = {
+      entityId: 1,
+      text: commentText,
+      imageFiles: []
+    };
+    service.addComment(commentData).subscribe((commentData: any) => {
       expect(commentData).toEqual(commentBody);
     });
 

--- a/src/app/main/component/eco-news/services/eco-news-comments.service.spec.ts
+++ b/src/app/main/component/eco-news/services/eco-news-comments.service.spec.ts
@@ -42,7 +42,9 @@ xdescribe('EcoNewsCommentsService', () => {
       modifiedDate: new Date('2021-05-27T15:37:15.661Z'),
       text: 'some cool content!'
     };
-    service.addComment(1, commentText, 1).subscribe((commentData: any) => {
+    const imageFiles: File[] = [];
+
+    service.addComment(1, commentText, imageFiles).subscribe((commentData: any) => {
       expect(commentData).toEqual(commentBody);
     });
 
@@ -62,8 +64,8 @@ xdescribe('EcoNewsCommentsService', () => {
       modifiedDate: new Date('2021-05-27T15:37:15.661Z'),
       text: 'some cool content!'
     };
-
-    service.addComment(1, commentText).subscribe((commentData: any) => {
+    const imageFiles: File[] = [];
+    service.addComment(1, commentText, imageFiles).subscribe((commentData: any) => {
       expect(commentData).toEqual(commentBody);
     });
 
@@ -127,7 +129,7 @@ xdescribe('EcoNewsCommentsService', () => {
       totalPages: 0
     };
 
-    service.getActiveRepliesByPage( 2, 3, 4).subscribe((commentData: any) => {
+    service.getActiveRepliesByPage(2, 3, 4).subscribe((commentData: any) => {
       expect(commentData).toEqual(commentBody);
     });
 
@@ -137,7 +139,7 @@ xdescribe('EcoNewsCommentsService', () => {
   });
 
   it('should make DELETE request to deleteComments', () => {
-    service.deleteComments( 2).subscribe((deleted) => {
+    service.deleteComments(2).subscribe((deleted) => {
       expect(deleted).toBe(true);
     });
 
@@ -148,7 +150,7 @@ xdescribe('EcoNewsCommentsService', () => {
 
   it('should make GET request to get comment likes', () => {
     const commentLikes = 5;
-    service.getCommentLikes( 1).subscribe((commentData: number) => {
+    service.getCommentLikes(1).subscribe((commentData: number) => {
       expect(commentData).toEqual(commentLikes);
     });
 
@@ -159,7 +161,7 @@ xdescribe('EcoNewsCommentsService', () => {
 
   it('should make GET request to get replies amount', () => {
     const commentReplies = 5;
-    service.getRepliesAmount( 2).subscribe((commentData: number) => {
+    service.getRepliesAmount(2).subscribe((commentData: number) => {
       expect(commentData).toEqual(commentReplies);
     });
 

--- a/src/app/main/component/eco-news/services/eco-news-comments.service.ts
+++ b/src/app/main/component/eco-news/services/eco-news-comments.service.ts
@@ -5,6 +5,7 @@ import { map } from 'rxjs/operators';
 import { environment } from '@environment/environment';
 import { CommentsService } from '../../comments/services/comments.service';
 import { AddedCommentDTO, CommentFormData, CommentsModel } from '../../comments/models/comments-model';
+import { CommentService } from '@global-service/comment/comment.service';
 
 @Injectable({
   providedIn: 'root'
@@ -12,23 +13,14 @@ import { AddedCommentDTO, CommentFormData, CommentsModel } from '../../comments/
 export class EcoNewsCommentsService implements CommentsService {
   private backEnd = environment.backendLink;
 
-  constructor(private http: HttpClient) {}
+  constructor(
+    private http: HttpClient,
+    private commentService: CommentService
+  ) {}
 
   addComment(formData: CommentFormData): Observable<AddedCommentDTO> {
-    const { entityId, text, imageFiles, parentCommentId = 0 } = formData;
-    const formPayload = new FormData();
-
-    const requestPayload = JSON.stringify({
-      text: text,
-      parentCommentId: parentCommentId
-    });
-    formPayload.append('request', requestPayload);
-
-    imageFiles.forEach((file) => {
-      formPayload.append('images', file, file.name);
-    });
-
-    return this.http.post<AddedCommentDTO>(`${this.backEnd}eco-news/${entityId}/comments`, formPayload);
+    const entityUrl = `${this.backEnd}eco-news/${formData.entityId}/comments`;
+    return this.commentService.addCommentByEntityId(entityUrl, formData);
   }
 
   getActiveCommentsByPage(ecoNewsId: number, page: number, size: number): Observable<CommentsModel> {

--- a/src/app/main/component/eco-news/services/eco-news-comments.service.ts
+++ b/src/app/main/component/eco-news/services/eco-news-comments.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '@environment/environment';
 import { CommentsService } from '../../comments/services/comments.service';
-import { AddedCommentDTO, CommentsModel } from '../../comments/models/comments-model';
+import { AddedCommentDTO, CommentFormData, CommentsModel } from '../../comments/models/comments-model';
 
 @Injectable({
   providedIn: 'root'
@@ -14,20 +14,21 @@ export class EcoNewsCommentsService implements CommentsService {
 
   constructor(private http: HttpClient) {}
 
-  addComment(ecoNewsId: number, text: string, imageFiles: File[], parentCommentId = 0): Observable<AddedCommentDTO> {
-    const formData = new FormData();
+  addComment(formData: CommentFormData): Observable<AddedCommentDTO> {
+    const { entityId, text, imageFiles, parentCommentId = 0 } = formData;
+    const formPayload = new FormData();
 
     const requestPayload = JSON.stringify({
       text: text,
       parentCommentId: parentCommentId
     });
-    formData.append('request', requestPayload);
+    formPayload.append('request', requestPayload);
 
-    imageFiles.forEach((imageFile, index) => {
-      formData.append(`images`, imageFile, imageFile.name);
+    imageFiles.forEach((file) => {
+      formPayload.append('images', file, file.name);
     });
 
-    return this.http.post<AddedCommentDTO>(`${this.backEnd}eco-news/${ecoNewsId}/comments`, formData);
+    return this.http.post<AddedCommentDTO>(`${this.backEnd}eco-news/${entityId}/comments`, formPayload);
   }
 
   getActiveCommentsByPage(ecoNewsId: number, page: number, size: number): Observable<CommentsModel> {

--- a/src/app/main/component/eco-news/services/eco-news-comments.service.ts
+++ b/src/app/main/component/eco-news/services/eco-news-comments.service.ts
@@ -14,8 +14,8 @@ export class EcoNewsCommentsService implements CommentsService {
   private backEnd = environment.backendLink;
 
   constructor(
-    private http: HttpClient,
-    private commentService: CommentService
+    private readonly http: HttpClient,
+    private readonly commentService: CommentService
   ) {}
 
   addComment(formData: CommentFormData): Observable<AddedCommentDTO> {

--- a/src/app/main/component/eco-news/services/eco-news-comments.service.ts
+++ b/src/app/main/component/eco-news/services/eco-news-comments.service.ts
@@ -14,14 +14,19 @@ export class EcoNewsCommentsService implements CommentsService {
 
   constructor(private http: HttpClient) {}
 
-  addComment(ecoNewsId: number, text: string, id = 0): Observable<AddedCommentDTO> {
+  addComment(ecoNewsId: number, text: string, imageFiles: File[], parentCommentId = 0): Observable<AddedCommentDTO> {
     const formData = new FormData();
-    const requestPayload = {
-      text: text,
-      parentCommentId: id
-    };
 
-    formData.append('request', JSON.stringify(requestPayload));
+    const requestPayload = JSON.stringify({
+      text: text,
+      parentCommentId: parentCommentId
+    });
+    formData.append('request', requestPayload);
+
+    imageFiles.forEach((imageFile, index) => {
+      formData.append(`images`, imageFile, imageFile.name);
+    });
+
     return this.http.post<AddedCommentDTO>(`${this.backEnd}eco-news/${ecoNewsId}/comments`, formData);
   }
 

--- a/src/app/main/component/events/services/events-comments.service.spec.ts
+++ b/src/app/main/component/events/services/events-comments.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { environment } from '@environment/environment';
 import { EventsCommentsService } from './events-comments.service';
+import { CommentFormData } from '../../comments/models/comments-model';
 
 describe('EventsCommentsService', () => {
   let service: EventsCommentsService;
@@ -42,9 +43,13 @@ describe('EventsCommentsService', () => {
       modifiedDate: new Date('2021-05-27T15:37:15.661Z'),
       text: 'some cool content!'
     };
-    const imageFiles: File[] = [];
+    const commentData: CommentFormData = {
+      entityId: 1,
+      text: commentText,
+      imageFiles: []
+    };
 
-    service.addComment(1, commentText, imageFiles).subscribe((commentData: any) => {
+    service.addComment(commentData).subscribe((commentData: any) => {
       expect(commentData).toEqual(commentBody);
     });
 
@@ -65,9 +70,13 @@ describe('EventsCommentsService', () => {
       text: 'some cool content!'
     };
 
-    const imageFiles: File[] = [];
+    const commentData: CommentFormData = {
+      entityId: 1,
+      text: commentText,
+      imageFiles: []
+    };
 
-    service.addComment(1, commentText, imageFiles).subscribe((commentData: any) => {
+    service.addComment(commentData).subscribe((commentData: any) => {
       expect(commentData).toEqual(commentBody);
     });
 

--- a/src/app/main/component/events/services/events-comments.service.spec.ts
+++ b/src/app/main/component/events/services/events-comments.service.spec.ts
@@ -42,7 +42,9 @@ describe('EventsCommentsService', () => {
       modifiedDate: new Date('2021-05-27T15:37:15.661Z'),
       text: 'some cool content!'
     };
-    service.addComment(1, commentText, 1).subscribe((commentData: any) => {
+    const imageFiles: File[] = [];
+
+    service.addComment(1, commentText, imageFiles).subscribe((commentData: any) => {
       expect(commentData).toEqual(commentBody);
     });
 
@@ -63,7 +65,9 @@ describe('EventsCommentsService', () => {
       text: 'some cool content!'
     };
 
-    service.addComment(1, commentText).subscribe((commentData: any) => {
+    const imageFiles: File[] = [];
+
+    service.addComment(1, commentText, imageFiles).subscribe((commentData: any) => {
       expect(commentData).toEqual(commentBody);
     });
 
@@ -170,7 +174,7 @@ describe('EventsCommentsService', () => {
   });
 
   it('should make POST request to post Like', () => {
-    service.postLike( 1).subscribe((commentData: any) => {
+    service.postLike(1).subscribe((commentData: any) => {
       expect(commentData).toEqual({});
     });
 
@@ -180,7 +184,7 @@ describe('EventsCommentsService', () => {
   });
 
   it('should make PUT request to edit comment', () => {
-    service.editComment( 1, commentText).subscribe((commentData: any) => {
+    service.editComment(1, commentText).subscribe((commentData: any) => {
       expect(commentData).toEqual({});
     });
 

--- a/src/app/main/component/events/services/events-comments.service.ts
+++ b/src/app/main/component/events/services/events-comments.service.ts
@@ -5,6 +5,7 @@ import { map } from 'rxjs/operators';
 import { environment } from '@environment/environment';
 import { CommentsService } from '../../comments/services/comments.service';
 import { AddedCommentDTO, CommentFormData, CommentsModel } from '../../comments/models/comments-model';
+import { CommentService } from '@global-service/comment/comment.service';
 
 @Injectable({
   providedIn: 'root'
@@ -12,23 +13,14 @@ import { AddedCommentDTO, CommentFormData, CommentsModel } from '../../comments/
 export class EventsCommentsService implements CommentsService {
   private backEnd = environment.backendLink;
 
-  constructor(private http: HttpClient) {}
+  constructor(
+    private http: HttpClient,
+    private commentService: CommentService
+  ) {}
 
   addComment(formData: CommentFormData): Observable<AddedCommentDTO> {
-    const { entityId, text, imageFiles, parentCommentId = 0 } = formData;
-    const formPayload = new FormData();
-
-    const requestPayload = JSON.stringify({
-      text: text,
-      parentCommentId: parentCommentId
-    });
-    formPayload.append('request', requestPayload);
-
-    imageFiles.forEach((file) => {
-      formPayload.append('images', file, file.name);
-    });
-
-    return this.http.post<AddedCommentDTO>(`${this.backEnd}events/${entityId}/comments`, formPayload);
+    const entityUrl = `${this.backEnd}events/${formData.entityId}/comments`;
+    return this.commentService.addCommentByEntityId(entityUrl, formData);
   }
 
   getActiveCommentsByPage(eventId: number, page: number, size: number): Observable<CommentsModel> {

--- a/src/app/main/component/events/services/events-comments.service.ts
+++ b/src/app/main/component/events/services/events-comments.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '@environment/environment';
 import { CommentsService } from '../../comments/services/comments.service';
-import { AddedCommentDTO, CommentsModel } from '../../comments/models/comments-model';
+import { AddedCommentDTO, CommentFormData, CommentsModel } from '../../comments/models/comments-model';
 
 @Injectable({
   providedIn: 'root'
@@ -14,19 +14,21 @@ export class EventsCommentsService implements CommentsService {
 
   constructor(private http: HttpClient) {}
 
-  addComment(eventId: number, text: string, imageFiles: File[], parentCommentId = 0): Observable<AddedCommentDTO> {
-    const formData = new FormData();
+  addComment(formData: CommentFormData): Observable<AddedCommentDTO> {
+    const { entityId, text, imageFiles, parentCommentId = 0 } = formData;
+    const formPayload = new FormData();
 
     const requestPayload = JSON.stringify({
       text: text,
       parentCommentId: parentCommentId
     });
-    formData.append('request', requestPayload);
+    formPayload.append('request', requestPayload);
 
-    imageFiles.forEach((imageFile, index) => {
-      formData.append(`images`, imageFile, imageFile.name);
+    imageFiles.forEach((file) => {
+      formPayload.append('images', file, file.name);
     });
-    return this.http.post<AddedCommentDTO>(`${this.backEnd}events/${eventId}/comments`, formData);
+
+    return this.http.post<AddedCommentDTO>(`${this.backEnd}events/${entityId}/comments`, formPayload);
   }
 
   getActiveCommentsByPage(eventId: number, page: number, size: number): Observable<CommentsModel> {

--- a/src/app/main/component/events/services/events-comments.service.ts
+++ b/src/app/main/component/events/services/events-comments.service.ts
@@ -14,8 +14,8 @@ export class EventsCommentsService implements CommentsService {
   private backEnd = environment.backendLink;
 
   constructor(
-    private http: HttpClient,
-    private commentService: CommentService
+    private readonly http: HttpClient,
+    private readonly commentService: CommentService
   ) {}
 
   addComment(formData: CommentFormData): Observable<AddedCommentDTO> {

--- a/src/app/main/component/events/services/events-comments.service.ts
+++ b/src/app/main/component/events/services/events-comments.service.ts
@@ -14,15 +14,23 @@ export class EventsCommentsService implements CommentsService {
 
   constructor(private http: HttpClient) {}
 
-  addComment(eventId: number, text: string, id = 0): Observable<AddedCommentDTO> {
+  addComment(eventId: number, text: string, imageFiles: File[], parentCommentId = 0): Observable<AddedCommentDTO> {
     const formData = new FormData();
-    formData.append('request', JSON.stringify({ text: text, parentCommentId: id }));
+
+    const requestPayload = JSON.stringify({
+      text: text,
+      parentCommentId: parentCommentId
+    });
+    formData.append('request', requestPayload);
+
+    imageFiles.forEach((imageFile, index) => {
+      formData.append(`images`, imageFile, imageFile.name);
+    });
     return this.http.post<AddedCommentDTO>(`${this.backEnd}events/${eventId}/comments`, formData);
   }
 
   getActiveCommentsByPage(eventId: number, page: number, size: number): Observable<CommentsModel> {
-    return this.http.get<CommentsModel>(
-      `${this.backEnd}events/${eventId}/comments?statuses=ORIGINAL,EDITED&page=${page}&size=${size}`);
+    return this.http.get<CommentsModel>(`${this.backEnd}events/${eventId}/comments?statuses=ORIGINAL,EDITED&page=${page}&size=${size}`);
   }
 
   getCommentsCount(eventId: number): Observable<number> {

--- a/src/app/main/service/comment/comment.service.ts
+++ b/src/app/main/service/comment/comment.service.ts
@@ -2,12 +2,26 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { placeLink } from '../../links';
 import { Comment } from '../../model/comment/comment';
+import { AddedCommentDTO, CommentFormData } from '../../component/comments/models/comments-model';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class CommentService {
   constructor(private http: HttpClient) {}
+
+  addCommentByEntityId(entityUrl: string, formData: CommentFormData): Observable<AddedCommentDTO> {
+    const { text, imageFiles, parentCommentId = 0 } = formData;
+    const formPayload = new FormData();
+    const requestPayload = JSON.stringify({
+      text,
+      parentCommentId
+    });
+    formPayload.append('request', requestPayload);
+    imageFiles.forEach((file) => formPayload.append('images', file, file.name));
+    return this.http.post<AddedCommentDTO>(entityUrl, formPayload);
+  }
 
   saveCommentByPlaceId(id: number, comment: Comment) {
     this.http.post(`${placeLink}${id}/comments`, comment);

--- a/src/app/main/service/habit-comments/habit-comments.service.spec.ts
+++ b/src/app/main/service/habit-comments/habit-comments.service.spec.ts
@@ -3,11 +3,14 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { HabitCommentsService } from './habit-comments.service';
 import { environment } from '@environment/environment';
 import { MOCK_HABIT_ADDED_COMMENT, MOCK_HABIT_COMMENTS_MODEL } from 'src/app/main/component/user/components/habit/mocks/habit-mock';
+import { CommentFormData } from '../../component/comments/models/comments-model';
 
 describe('HabitCommentsService', () => {
   let service: HabitCommentsService;
   let httpTestingController: HttpTestingController;
   const url = environment.backendLink;
+
+  const commentText = 'Test comment';
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -28,9 +31,13 @@ describe('HabitCommentsService', () => {
   });
 
   it('should make POST request to add comment', () => {
-    const imageFiles: File[] = [];
+    const commentData: CommentFormData = {
+      entityId: 1,
+      text: commentText,
+      imageFiles: []
+    };
 
-    service.addComment(1, 'Test comment', imageFiles).subscribe((commentData) => {
+    service.addComment(commentData).subscribe((commentData) => {
       expect(commentData).toEqual(MOCK_HABIT_ADDED_COMMENT);
     });
 

--- a/src/app/main/service/habit-comments/habit-comments.service.spec.ts
+++ b/src/app/main/service/habit-comments/habit-comments.service.spec.ts
@@ -28,7 +28,9 @@ describe('HabitCommentsService', () => {
   });
 
   it('should make POST request to add comment', () => {
-    service.addComment(1, 'Test comment', 0).subscribe((commentData) => {
+    const imageFiles: File[] = [];
+
+    service.addComment(1, 'Test comment', imageFiles).subscribe((commentData) => {
       expect(commentData).toEqual(MOCK_HABIT_ADDED_COMMENT);
     });
 
@@ -58,7 +60,7 @@ describe('HabitCommentsService', () => {
   });
 
   it('should make DELETE request to delete comment', () => {
-    service.deleteComments( 2).subscribe((result) => {
+    service.deleteComments(2).subscribe((result) => {
       expect(result).toBeTrue();
     });
 
@@ -68,7 +70,7 @@ describe('HabitCommentsService', () => {
   });
 
   it('should make GET request to get replies amount', () => {
-    service.getRepliesAmount( 2).subscribe((data) => {
+    service.getRepliesAmount(2).subscribe((data) => {
       expect(data).toEqual(5);
     });
 
@@ -89,7 +91,7 @@ describe('HabitCommentsService', () => {
   });
 
   it('should make GET request to get active replies by page', () => {
-    service.getActiveRepliesByPage( 1, 0, 5).subscribe((data) => {
+    service.getActiveRepliesByPage(1, 0, 5).subscribe((data) => {
       expect(data).toEqual(MOCK_HABIT_COMMENTS_MODEL);
     });
 
@@ -108,7 +110,7 @@ describe('HabitCommentsService', () => {
   it('should make GET request to get comment likes count', () => {
     const likesCount = 15;
 
-    service.getCommentLikes( 1).subscribe((data) => {
+    service.getCommentLikes(1).subscribe((data) => {
       expect(data).toEqual(likesCount);
     });
 

--- a/src/app/main/service/habit-comments/habit-comments.service.ts
+++ b/src/app/main/service/habit-comments/habit-comments.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '@environment/environment';
 import { CommentsService } from 'src/app/main/component/comments/services/comments.service';
-import { AddedCommentDTO, CommentsModel } from 'src/app/main/component/comments/models/comments-model';
+import { AddedCommentDTO, CommentFormData, CommentsModel } from 'src/app/main/component/comments/models/comments-model';
 
 @Injectable({
   providedIn: 'root'
@@ -14,20 +14,21 @@ export class HabitCommentsService implements CommentsService {
 
   constructor(private readonly http: HttpClient) {}
 
-  addComment(habitId: number, text: string, imageFiles: File[], parentCommentId = 0): Observable<AddedCommentDTO> {
-    const formData = new FormData();
+  addComment(formData: CommentFormData): Observable<AddedCommentDTO> {
+    const { entityId, text, imageFiles, parentCommentId = 0 } = formData;
+    const formPayload = new FormData();
 
     const requestPayload = JSON.stringify({
       text: text,
       parentCommentId: parentCommentId
     });
-    formData.append('request', requestPayload);
+    formPayload.append('request', requestPayload);
 
-    imageFiles.forEach((imageFile, index) => {
-      formData.append(`images`, imageFile, imageFile.name);
+    imageFiles.forEach((file) => {
+      formPayload.append('images', file, file.name);
     });
 
-    return this.http.post<AddedCommentDTO>(`${this.backEnd}habits/${habitId}/comments`, formData);
+    return this.http.post<AddedCommentDTO>(`${this.backEnd}habits/${entityId}/comments`, formPayload);
   }
 
   getActiveCommentsByPage(habitId: number, page: number, size: number): Observable<CommentsModel> {

--- a/src/app/main/service/habit-comments/habit-comments.service.ts
+++ b/src/app/main/service/habit-comments/habit-comments.service.ts
@@ -15,7 +15,7 @@ export class HabitCommentsService implements CommentsService {
 
   constructor(
     private readonly http: HttpClient,
-    private commentService: CommentService
+    private readonly commentService: CommentService
   ) {}
 
   addComment(formData: CommentFormData): Observable<AddedCommentDTO> {

--- a/src/app/main/service/habit-comments/habit-comments.service.ts
+++ b/src/app/main/service/habit-comments/habit-comments.service.ts
@@ -5,6 +5,7 @@ import { map } from 'rxjs/operators';
 import { environment } from '@environment/environment';
 import { CommentsService } from 'src/app/main/component/comments/services/comments.service';
 import { AddedCommentDTO, CommentFormData, CommentsModel } from 'src/app/main/component/comments/models/comments-model';
+import { CommentService } from '@global-service/comment/comment.service';
 
 @Injectable({
   providedIn: 'root'
@@ -12,23 +13,14 @@ import { AddedCommentDTO, CommentFormData, CommentsModel } from 'src/app/main/co
 export class HabitCommentsService implements CommentsService {
   private readonly backEnd = environment.backendLink;
 
-  constructor(private readonly http: HttpClient) {}
+  constructor(
+    private readonly http: HttpClient,
+    private commentService: CommentService
+  ) {}
 
   addComment(formData: CommentFormData): Observable<AddedCommentDTO> {
-    const { entityId, text, imageFiles, parentCommentId = 0 } = formData;
-    const formPayload = new FormData();
-
-    const requestPayload = JSON.stringify({
-      text: text,
-      parentCommentId: parentCommentId
-    });
-    formPayload.append('request', requestPayload);
-
-    imageFiles.forEach((file) => {
-      formPayload.append('images', file, file.name);
-    });
-
-    return this.http.post<AddedCommentDTO>(`${this.backEnd}habits/${entityId}/comments`, formPayload);
+    const entityUrl = `${this.backEnd}habits/${formData.entityId}/comments`;
+    return this.commentService.addCommentByEntityId(entityUrl, formData);
   }
 
   getActiveCommentsByPage(habitId: number, page: number, size: number): Observable<CommentsModel> {

--- a/src/app/main/service/habit-comments/habit-comments.service.ts
+++ b/src/app/main/service/habit-comments/habit-comments.service.ts
@@ -14,14 +14,19 @@ export class HabitCommentsService implements CommentsService {
 
   constructor(private readonly http: HttpClient) {}
 
-  addComment(habitId: number, text: string, parentCommentId = 0): Observable<AddedCommentDTO> {
+  addComment(habitId: number, text: string, imageFiles: File[], parentCommentId = 0): Observable<AddedCommentDTO> {
     const formData = new FormData();
-    const requestPayload = {
+
+    const requestPayload = JSON.stringify({
       text: text,
       parentCommentId: parentCommentId
-    };
+    });
+    formData.append('request', requestPayload);
 
-    formData.append('request', JSON.stringify(requestPayload));
+    imageFiles.forEach((imageFile, index) => {
+      formData.append(`images`, imageFile, imageFile.name);
+    });
+
     return this.http.post<AddedCommentDTO>(`${this.backEnd}habits/${habitId}/comments`, formData);
   }
 


### PR DESCRIPTION
[#7626](https://github.com/ita-social-projects/GreenCity/issues/7626), [#7344](https://github.com/ita-social-projects/GreenCity/issues/7344)
##
Summary of work 🔥

- [x] Enabled users to add up to 5 images per comment.
- [x] Provided image preview, removal, and controls for each image.
- [x] Created a method to send comments with images to the backend using FormData.
- [x] Handled emitting updated comment data and resetting the form upon submission.
- [x] Added a dedicated image upload button and modal for image handling

##
https://github.com/user-attachments/assets/589943dd-666d-4e1b-8bf8-14a481182a13


