### PR TITLE
[Bugfix] #7655 Add like feature to the event

### DIFF
--- a/src/app/main/component/events/components/event-details/event-details.component.html
+++ b/src/app/main/component/events/components/event-details/event-details.component.html
@@ -45,6 +45,17 @@
             <div>{{ event.dates[0]['startDate'] | dateLocalisation }}</div>
             <div>|</div>
             <div>{{ 'homepage.events.author' | translate }} {{ organizerName }}</div>
+            <div class="like-wr">
+              <img *ngIf="!userId" class="event-like disable" [src]="likesType.like" alt="like" />
+              <img
+                *ngIf="userId"
+                (click)="onLikeEvent()"
+                class="event-like"
+                [src]="isLiked ? likesType.liked : likesType.like"
+                alt="like"
+              />
+              <span class="numerosity-likes">{{ event.likes }}</span>
+            </div>
           </div>
         </div>
         <div class="right-side">

--- a/src/app/main/component/events/components/event-details/event-details.component.scss
+++ b/src/app/main/component/events/components/event-details/event-details.component.scss
@@ -510,6 +510,30 @@
   gap: 24px;
 }
 
+.like-wr {
+  margin-left: 20px;
+  display: flex;
+  align-items: center;
+
+  .event-like {
+    cursor: pointer;
+    width: 20px;
+    height: 20px;
+  }
+
+  .numerosity-likes {
+    font-family: var(--primary-font);
+    font-size: 16px;
+    color: var(--secondary-grey);
+    opacity: 0.6;
+    margin-left: 10px;
+  }
+
+  .disable {
+    cursor: default;
+  }
+}
+
 @media screen and (max-width: 575px) {
   .edit-buttons,
   .m-btn {

--- a/src/app/main/component/events/components/event-details/event-details.component.scss
+++ b/src/app/main/component/events/components/event-details/event-details.component.scss
@@ -519,6 +519,8 @@
     cursor: pointer;
     width: 20px;
     height: 20px;
+    position:relative;
+    bottom:4px;
   }
 
   .numerosity-likes {
@@ -527,6 +529,7 @@
     color: var(--secondary-grey);
     opacity: 0.6;
     margin-left: 10px;
+   
   }
 
   .disable {

--- a/src/app/main/component/events/components/event-details/event-details.component.spec.ts
+++ b/src/app/main/component/events/components/event-details/event-details.component.spec.ts
@@ -5,7 +5,7 @@ import { EventDetailsComponent } from './event-details.component';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { RouterTestingModule } from '@angular/router/testing';
-import { BehaviorSubject, of, throwError } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { EventsService } from '../../services/events.service';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
@@ -37,6 +37,7 @@ describe('EventDetailsComponent', () => {
   let component: EventDetailsComponent;
   let fixture: ComponentFixture<EventDetailsComponent>;
   let dialogSpy: jasmine.SpyObj<MatDialog>;
+
   const storeMock = jasmine.createSpyObj('store', ['select', 'dispatch']);
   storeMock.select = () => of(eventStateMock);
   const snackBarMock = jasmine.createSpyObj('MatSnackBarComponent', ['openSnackBar']);

--- a/src/app/main/component/events/components/event-details/event-details.component.spec.ts
+++ b/src/app/main/component/events/components/event-details/event-details.component.spec.ts
@@ -233,20 +233,6 @@ describe('EventDetailsComponent', () => {
     expect(component.isLiked).toBe(true);
   });
 
-  it('should increase likes when isLiked is false', () => {
-    component.isLiked = false;
-    component.event = { likes: 100 } as EventResponse;
-    component.onLikeEvent();
-    expect(component.event.likes).toBe(101);
-  });
-
-  it('should decrease likes when isLiked is true', () => {
-    component.isLiked = true;
-    component.event = { likes: 100 } as EventResponse;
-    component.onLikeEvent();
-    expect(component.event.likes).toBe(99);
-  });
-
   it('should correctly toggle likes and isLiked based on the current state', () => {
     component.event = { likes: 10 } as EventResponse;
     component.eventId = 2;

--- a/src/app/main/component/events/components/event-details/event-details.component.spec.ts
+++ b/src/app/main/component/events/components/event-details/event-details.component.spec.ts
@@ -39,8 +39,7 @@ describe('EventDetailsComponent', () => {
   let dialogSpy: jasmine.SpyObj<MatDialog>;
   const storeMock = jasmine.createSpyObj('store', ['select', 'dispatch']);
   storeMock.select = () => of(eventStateMock);
-  let snackBarMock: jasmine.SpyObj<MatSnackBarComponent>;
-  snackBarMock = jasmine.createSpyObj('MatSnackBarComponent', ['openSnackBar']);
+  const snackBarMock = jasmine.createSpyObj('MatSnackBarComponent', ['openSnackBar']);
 
   const EventsServiceMock = jasmine.createSpyObj('eventService', [
     'getEventById ',

--- a/src/app/main/component/events/components/event-details/event-details.component.ts
+++ b/src/app/main/component/events/components/event-details/event-details.component.ts
@@ -138,7 +138,7 @@ export class EventDetailsComponent implements OnInit, OnDestroy {
   }
 
   onLikeEvent(): void {
-    const updatedLikes = this.isLiked ? this.event.likes - 1 : this.event.likes + 1;
+    const updatedLikes = this.event.likes + (this.isLiked ? -1 : 1);
     this.isLiked = !this.isLiked;
     this.postToggleEventLike(updatedLikes);
   }

--- a/src/app/main/component/events/components/events-list/events-list.component.ts
+++ b/src/app/main/component/events/components/events-list/events-list.component.ts
@@ -396,7 +396,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
     let params = new HttpParams().append('page', this.page.toString()).append('size', this.eventsPerPage.toString());
 
     const paramsToAdd = [
-      this.appendIfNotEmpty('user-id', this.userId.toString()),
+      this.appendIfNotEmpty('user-id', this.userId?.toString()),
       this.appendIfNotEmpty('title', title),
       this.appendIfNotEmpty('type', this.selectedLocationFiltersList.find((city) => city === 'Online') || ''),
       this.appendIfNotEmpty(

--- a/src/app/main/component/events/models/events.interface.ts
+++ b/src/app/main/component/events/models/events.interface.ts
@@ -197,6 +197,7 @@ export interface PagePreviewDTO {
   open: boolean;
   isRelevant?: boolean;
   id?: number;
+  likes?: number;
   editorText: string;
   organizer?: OrganizerInfo;
   dates: Dates[];

--- a/src/app/main/component/events/services/events.service.ts
+++ b/src/app/main/component/events/services/events.service.ts
@@ -158,7 +158,7 @@ export class EventsService implements OnDestroy {
   }
 
   getAllAttendees(eventId: number): Observable<EventAttender[]> {
-    return this.http.get<any>(`${this.backEnd}events/${eventId}/attenders`);
+    return this.http.get<EventAttender[]>(`${this.backEnd}events/${eventId}/attenders`);
   }
 
   getFormattedAddress(coordinates: LocationResponse): string {

--- a/src/app/main/component/events/services/events.service.ts
+++ b/src/app/main/component/events/services/events.service.ts
@@ -133,6 +133,14 @@ export class EventsService implements OnDestroy {
     return this.http.get<EventResponse>(`${this.backEnd}events/${eventId}`);
   }
 
+  getIsLikedByUser(eventId: number): Observable<boolean> {
+    return this.http.get<boolean>(`${this.backEnd}events/${eventId}/likes`);
+  }
+
+  postToggleLike(eventId: number): Observable<any> {
+    return this.http.post(`${this.backEnd}events/${eventId}/like`, {});
+  }
+
   deleteEvent(eventId: number): Observable<any> {
     return this.http.delete(`${this.backEnd}events/${eventId}`);
   }


### PR DESCRIPTION
[#7606](https://github.com/ita-social-projects/GreenCity/issues/7606), [#7655](https://github.com/ita-social-projects/GreenCity/issues/7655)
##
Summary of work 🔥
- [x] Created a like button with an icon that changes based on the user's interaction. If userId is undefined, the button appears disabled.
- [x] getIsLiked: Initializes the isLiked state by checking if the user has already liked the event.
- [x] onLikeEvent: Toggles the isLiked status and updates the event.likes count.
- [x] postToggleEventLike: Sends a like/unlike request and adjusts the like count; shows an error if the request fails.
##
https://github.com/user-attachments/assets/e9191a18-41e2-4cd4-bf95-f1421bbb7470




