### PR TITLE
[Bugfix] #7668 While tagging user in the reply to the comment, we have two dropdowns appeared

### DIFF
--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
@@ -66,8 +66,10 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
       .subscribe((data: TaggedUser[]) => {
         if (data.length) {
           this.suggestedUsers = data.filter((el) => el.userName.toLowerCase().includes(this.searchQuery.toLowerCase()));
-          this.menuTrigger.openMenu();
-          this.refocusTextarea();
+          if (document.activeElement === this.commentTextarea.nativeElement) {
+            this.menuTrigger.openMenu();
+            this.refocusTextarea();
+          }
         } else {
           this.menuTrigger.closeMenu();
           this.suggestedUsers = [];

--- a/src/app/main/component/places/components/more-options-filter/more-options-filter.component.scss
+++ b/src/app/main/component/places/components/more-options-filter/more-options-filter.component.scss
@@ -76,3 +76,16 @@ $font-family: lato, sans-serif;
   height: 180px;
   overflow: auto;
 }
+
+a.custom-chip {
+  font-family: var(--tertiary-font);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  text-align: left;
+  color: var(--quaternary-grey);
+}
+
+a.custom-chip.global-tag-clicked {
+  color: var(--primary-white);
+}

--- a/src/app/main/component/shared/components/tag-filter/tag-filter.component.scss
+++ b/src/app/main/component/shared/components/tag-filter/tag-filter.component.scss
@@ -17,8 +17,11 @@
   }
 
   .text {
+    color: var(--quaternary-grey);
     line-height: 20px;
     font-size: 14px;
+    font-family: var(--tertiary-font);
+    font-weight: 400;
   }
 }
 
@@ -35,7 +38,7 @@
     padding: 0;
     background: none;
 
-    .global-tag-clicked {
+    .global-tag-clicked .text {
       color: var(--primary-white);
     }
 


### PR DESCRIPTION
[#7668](https://github.com/ita-social-projects/GreenCity/issues/7668)

**before**
![Image](https://github.com/user-attachments/assets/8d95d31b-f0a6-43cb-bd96-34116638e88c)
![Image](https://github.com/user-attachments/assets/2a1291dd-bea8-49d5-a1b4-3f57c9dc1ae7)
**after**
![Image](https://github.com/user-attachments/assets/92f937d5-fc9a-45fe-aab6-f301644f9204)

Also, fixed styles in the filters, as a Tester asked