### PR TITLE
fix: Match email regexp on both back end and front end

### DIFF
--- a/src/assets/patterns/patterns.ts
+++ b/src/assets/patterns/patterns.ts
@@ -21,7 +21,7 @@ export const Patterns = {
 
   // prettier-ignore
   ubsMailPattern:
-    /^[\w.-]+@[a-zA-Z-]+(\.[a-zA-Z]{2,})+$/,
+    /^[a-zA-Z0-9.%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/,
   paymentAmountPattern: '^[0-9]+(.[0-9]{1,2})?$',
   certificateMonthCount: '^[0-9]{1,2}$',
   certificateInitialValue: '^[0-9]{1,4}$',


### PR DESCRIPTION
Fixed a regular expression used for email validation during login and registration. Now user can enter addresses like

- test@regexp101.com
- test.user+suffix@gmail.com

![image](https://github.com/user-attachments/assets/eb6c3dbd-d823-4f90-a81e-e6c9a16a2a05)
![image](https://github.com/user-attachments/assets/6b045daa-44a0-4b9e-9f74-18d2a364a12a)