### PR TITLE
[Bugfix] #7675 events filters

### DIFF
--- a/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.html
+++ b/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.html
@@ -137,35 +137,12 @@
             (scrolled)="getUserEvents()"
             [infiniteScrollDisabled]="!isActiveEventsScroll"
           >
-            <ul class="news-list" *ngIf="totalEvents && !isFavoriteBtnClicked">
+            <ul class="news-list" *ngIf="totalEvents">
               <li *ngFor="let eventItem of eventsList">
                 <app-events-list-item [event]="eventItem" [userId]="userId" [isUserAssignList]="true"></app-events-list-item>
               </li>
             </ul>
-            <p class="end-page-txt" *ngIf="!eventsList.length && !this.isFavoriteBtnClicked && !this.loadingEvents">
-              {{ 'homepage.events.no-matching-left' | translate }}
-            </p>
-          </div>
-          <div
-            *ngIf="isFavoriteBtnClicked"
-            class="scrolling"
-            infinite-scroll
-            [infiniteScrollDistance]="1"
-            [infiniteScrollThrottle]="100"
-            (scrolled)="getUserFavouriteEvents()"
-            [infiniteScrollDisabled]="!isActiveFavoriteEventsScroll"
-          >
-            <ul class="news-list">
-              <li *ngFor="let eventItem of favouriteEvents">
-                <app-events-list-item
-                  [event]="eventItem"
-                  [userId]="userId"
-                  [isUserAssignList]="true"
-                  (idOfUnFavouriteEvent)="removeUnFavouriteEvent($event)"
-                ></app-events-list-item>
-              </li>
-            </ul>
-            <p class="end-page-txt" *ngIf="!favouriteEvents.length && this.isFavoriteBtnClicked && !this.loadingEvents">
+            <p class="end-page-txt" *ngIf="!eventsList.length && !this.loadingEvents">
               {{ 'homepage.events.no-matching-left' | translate }}
             </p>
           </div>

--- a/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.html
+++ b/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.html
@@ -99,32 +99,34 @@
       <mat-tab label="{{ 'homepage.events.my-space.tag-title' | translate }}">
         <hr />
         <div *ngIf="!loading; else spinner">
-          <div class="in-progress header" id="my-events" *ngIf="!isFavoriteBtnClicked">
-            <div class="buttons-wrapper">
-              <a [routerLink]="['/events/create-event']">
-                <div id="create-button-event" class="secondary-global-button s-btn">
-                  <span>{{ 'profile.dashboard.add-event' | translate }}</span>
+          <div class="in-progress">
+            <div class="in-progress header" id="my-events" *ngIf="!isFavoriteBtnClicked">
+              <div class="buttons-wrapper">
+                <a [routerLink]="['/events/create-event']">
+                  <div id="create-button-event" class="secondary-global-button s-btn">
+                    <span>{{ 'profile.dashboard.add-event' | translate }}</span>
+                  </div>
+                </a>
+                <div class="favourites" (click)="goToFavorites()">
+                  <span class="flag-active"></span>
                 </div>
-              </a>
-              <div class="favourites" (click)="goToFavorites()">
-                <span class="flag-active"></span>
+              </div>
+            </div>
+            <div *ngIf="isFavoriteBtnClicked" class="in-progress header">
+              <div class="button-arrow" (click)="escapeFromFavorites()">
+                <img [src]="images.arrowLeft" aria-hidden="true" alt="arrow" class="button-arrow-img" />
+                <div class="edit-events">{{ 'create-event.back' | translate }}</div>
               </div>
             </div>
             <div class="events-filter">
               <div class="events-types">
-                <mat-checkbox [(ngModel)]="isOnlineChecked" (ngModelChange)="onCheckboxChange('ONLINE')" color="primary" class="checkbox">
+                <mat-checkbox [(ngModel)]="isOnlineChecked" (ngModelChange)="onCheckboxChange()" color="primary" class="checkbox">
                   {{ 'homepage.events.my-space.event-type-online' | translate }}
                 </mat-checkbox>
-                <mat-checkbox [(ngModel)]="isOfflineChecked" (ngModelChange)="onCheckboxChange('OFFLINE')" color="primary" class="checkbox"
+                <mat-checkbox [(ngModel)]="isOfflineChecked" (ngModelChange)="onCheckboxChange()" color="primary" class="checkbox"
                   >{{ 'homepage.events.my-space.event-type-offline' | translate }}
                 </mat-checkbox>
               </div>
-            </div>
-          </div>
-          <div *ngIf="isFavoriteBtnClicked" class="in-progress header">
-            <div class="button-arrow" (click)="escapeFromFavorites()">
-              <img [src]="images.arrowLeft" aria-hidden="true" alt="arrow" class="button-arrow-img" />
-              <div class="edit-events">{{ 'create-event.back' | translate }}</div>
             </div>
           </div>
           <div
@@ -140,6 +142,9 @@
                 <app-events-list-item [event]="eventItem" [userId]="userId" [isUserAssignList]="true"></app-events-list-item>
               </li>
             </ul>
+            <p class="end-page-txt" *ngIf="!eventsList.length && !this.isFavoriteBtnClicked && !this.loadingEvents">
+              {{ 'homepage.events.no-matching-left' | translate }}
+            </p>
           </div>
           <div
             *ngIf="isFavoriteBtnClicked"
@@ -160,6 +165,9 @@
                 ></app-events-list-item>
               </li>
             </ul>
+            <p class="end-page-txt" *ngIf="!favouriteEvents.length && this.isFavoriteBtnClicked && !this.loadingEvents">
+              {{ 'homepage.events.no-matching-left' | translate }}
+            </p>
           </div>
 
           <div class="no-data" *ngIf="!this.totalEvents">

--- a/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.scss
+++ b/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.scss
@@ -102,6 +102,16 @@ a {
   }
 }
 
+.end-page-txt {
+  font-family: var(--primary-font);
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 30px;
+  letter-spacing: 0.2px;
+  text-align: center;
+  margin: 0 auto 2rem;
+}
+
 .news-list {
   list-style: none;
   padding-left: 0;

--- a/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.spec.ts
+++ b/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.spec.ts
@@ -216,9 +216,9 @@ describe('ProfileDashboardComponent', () => {
   });
 
   it('should remove unfavourite event from array', () => {
-    component.favouriteEvents = mockFavouriteEvents;
+    component.eventsList = mockFavouriteEvents;
     component.removeUnFavouriteEvent(14);
-    expect(component.favouriteEvents.length).toEqual(1);
+    expect(component.eventsList.length).toEqual(1);
   });
 
   it('should toggle isFavoriteBtnClicked property on escapeFromFavorites method', () => {
@@ -229,17 +229,17 @@ describe('ProfileDashboardComponent', () => {
     expect(component.isFavoriteBtnClicked).toBeFalse();
   });
 
-  it('should set isFavoriteBtnClicked to true and call getUserFavouriteEvents when goToFavorites is called', () => {
-    spyOn(component, 'getUserFavouriteEvents');
+  it('should set isFavoriteBtnClicked to true and call getUserEvents when goToFavorites is called', () => {
+    spyOn(component, 'getUserEvents');
     component.goToFavorites();
     expect(component.isFavoriteBtnClicked).toBeTrue();
-    expect(component.getUserFavouriteEvents).toHaveBeenCalled();
+    expect(component.getUserEvents).toHaveBeenCalled();
   });
 
   it('should call getUserFavoriteEvents and set favouriteEvents when getUserFavouriteEvents is called', waitForAsync(() => {
     const spy = spyOn(eventsServiceMock, 'getEvents').and.returnValue(of(mockEvent));
-    component.getUserFavouriteEvents();
+    component.getUserEvents();
     expect(spy).toHaveBeenCalled();
-    expect(component.favouriteEvents).toEqual(mockEvent.page);
+    expect(component.eventsList).toEqual(mockEvent.page);
   }));
 });

--- a/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.spec.ts
+++ b/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.spec.ts
@@ -16,7 +16,7 @@ import { EventType } from 'src/app/ubs/ubs/services/event-type.enum';
 import { mockEvent, mockFavouriteEvents, mockHabitAssign } from '@assets/mocks/events/mock-events';
 import { mockHabits } from '@assets/mocks/habit/mock-habit-calendar';
 
-xdescribe('ProfileDashboardComponent', () => {
+describe('ProfileDashboardComponent', () => {
   let component: ProfileDashboardComponent;
   let fixture: ComponentFixture<ProfileDashboardComponent>;
 
@@ -85,18 +85,18 @@ xdescribe('ProfileDashboardComponent', () => {
     expect(spy2).toHaveBeenCalledTimes(1);
   });
 
-  it('onInit news should have expected result', () => {
+  it('onInit news should have expected result', waitForAsync(() => {
     component.ngOnInit();
     component.authorNews$.subscribe((item: any) => {
       expect(component.news[0]).toEqual({ newsId: 1 } as any);
     });
-  });
+  }));
 
   it('should update eventType and call getUserEvents when online event is checked', () => {
     const eventType = EventType.ONLINE;
     component.isOnlineChecked = true;
     const spy = spyOn(component, 'getUserEvents');
-    component.onCheckboxChange(eventType);
+    component.onCheckboxChange();
     expect(component.isOnlineChecked).toBe(true);
     expect(component.isOfflineChecked).toBe(false);
     expect(component.eventType).toBe(eventType);
@@ -107,7 +107,7 @@ xdescribe('ProfileDashboardComponent', () => {
     const eventType = EventType.OFFLINE;
     component.isOfflineChecked = true;
     const spy = spyOn(component, 'getUserEvents');
-    component.onCheckboxChange(eventType);
+    component.onCheckboxChange();
     expect(component.isOnlineChecked).toBe(false);
     expect(component.isOfflineChecked).toBe(true);
     expect(component.eventType).toBe(eventType);
@@ -120,6 +120,18 @@ xdescribe('ProfileDashboardComponent', () => {
     expect(component.isOnlineChecked).toBe(false);
     expect(component.isOfflineChecked).toBe(false);
     expect(component.eventType).toBe('');
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should update eventType and call getUserEvents when offline and online event is checked', () => {
+    const eventType = EventType.ONLINE_OFFLINE;
+    component.isOfflineChecked = true;
+    component.isOnlineChecked = true;
+    const spy = spyOn(component, 'getUserEvents');
+    component.onCheckboxChange();
+    expect(component.isOnlineChecked).toBe(true);
+    expect(component.isOfflineChecked).toBe(true);
+    expect(component.eventType).toBe(eventType);
     expect(spy).toHaveBeenCalled();
   });
 
@@ -139,21 +151,21 @@ xdescribe('ProfileDashboardComponent', () => {
     expect(HabitAssignServiceMock.habitsInProgress).toEqual([{ id: 2 }] as any);
   });
 
-  it('executeRequests habitsInProgress.duration to be 20', () => {
+  it('executeRequests habitsInProgress.duration to be 20', waitForAsync(() => {
     mockHabits.status = 'INPROGRESS';
     HabitAssignServiceMock.getAssignedHabits = () => of([mockHabits]);
     component.executeRequests();
     expect(HabitAssignServiceMock.habitsInProgress[0].duration).toBe(20);
-  });
+  }));
 
-  it('executeRequests habitsAcquired to be 2', () => {
+  it('executeRequests habitsAcquired to be 2', waitForAsync(() => {
     const spy = spyOn(component, 'setHabitsForView');
     mockHabits.status = 'ACQUIRED';
     HabitAssignServiceMock.getAssignedHabits = () => of([mockHabits]);
     component.executeRequests();
     expect(component.habitsAcquired[0].workingDays).toBe(2);
     expect(spy).toHaveBeenCalledTimes(1);
-  });
+  }));
 
   it('setHabitsForView should return array length', () => {
     component.numberOfHabitsOnView = 2;
@@ -224,10 +236,10 @@ xdescribe('ProfileDashboardComponent', () => {
     expect(component.getUserFavouriteEvents).toHaveBeenCalled();
   });
 
-  it('should call getUserFavoriteEvents and set favouriteEvents when getUserFavouriteEvents is called', () => {
-    eventsServiceMock.getUserFavoriteEvents.and.returnValue(of(mockEvent));
+  it('should call getUserFavoriteEvents and set favouriteEvents when getUserFavouriteEvents is called', waitForAsync(() => {
+    const spy = spyOn(eventsServiceMock, 'getEvents').and.returnValue(of(mockEvent));
     component.getUserFavouriteEvents();
-    expect(eventsServiceMock.getUserFavoriteEvents).toHaveBeenCalledWith(0, component.eventsPerPage, component.userId);
+    expect(spy).toHaveBeenCalled();
     expect(component.favouriteEvents).toEqual(mockEvent.page);
-  });
+  }));
 });

--- a/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.ts
+++ b/src/app/main/component/user/components/profile/profile-dashboard/profile-dashboard.component.ts
@@ -37,13 +37,11 @@ export class ProfileDashboardComponent implements OnInit, OnDestroy {
   };
   isActiveNewsScroll = false;
   isActiveEventsScroll = false;
-  isActiveFavoriteEventsScroll = false;
   userId: number;
   news: EcoNewsModel[];
   isOnlineChecked = false;
   isOfflineChecked = false;
   eventsList: EventResponse[] = [];
-  favouriteEvents: EventResponse[] = [];
   eventsPerPage = 6;
   eventsPage = 1;
   favoriteEventsPage = 0;
@@ -59,7 +57,6 @@ export class ProfileDashboardComponent implements OnInit, OnDestroy {
   private destroyed$: ReplaySubject<any> = new ReplaySubject<any>(1);
   private hasNext = true;
   private hasNextPageOfEvents = true;
-  private hasNextPageOfFavoriteEvents = true;
   private currentPage: number;
   private newsCount = 5;
 
@@ -118,12 +115,9 @@ export class ProfileDashboardComponent implements OnInit, OnDestroy {
     }
 
     this.eventsList = [];
-    this.favouriteEvents = [];
     this.eventsPage = 0;
-    this.favoriteEventsPage = 0;
     this.hasNextPageOfEvents = true;
-    this.hasNextPageOfFavoriteEvents = true;
-    this.isFavoriteBtnClicked ? this.getUserFavouriteEvents() : this.getUserEvents();
+    this.getUserEvents();
   }
 
   cleanState() {
@@ -132,27 +126,23 @@ export class ProfileDashboardComponent implements OnInit, OnDestroy {
 
     this.eventType = '';
     this.eventsPage = 0;
-    this.favoriteEventsPage = 0;
+
+    this.eventsList = [];
     this.hasNextPageOfEvents = true;
-    this.hasNextPageOfFavoriteEvents = true;
   }
 
   escapeFromFavorites(): void {
     this.isFavoriteBtnClicked = !this.isFavoriteBtnClicked;
-    this.isActiveEventsScroll = true;
-    this.isActiveFavoriteEventsScroll = false;
 
     this.cleanState();
+    this.getUserEvents();
   }
 
   goToFavorites(): void {
     this.isFavoriteBtnClicked = true;
-    this.isActiveEventsScroll = false;
-    this.isActiveFavoriteEventsScroll = true;
 
     this.cleanState();
-
-    this.getUserFavouriteEvents();
+    this.getUserEvents();
   }
 
   initGetUserEvents(): void {
@@ -180,29 +170,8 @@ export class ProfileDashboardComponent implements OnInit, OnDestroy {
     return params;
   }
 
-  getUserFavouriteEvents(): void {
-    if (this.hasNextPageOfFavoriteEvents && !this.loadingEvents) {
-      this.loadingEvents = true;
-      this.eventService
-        .getEvents(this.getHttpParams(this.favoriteEventsPage))
-        .pipe(take(1))
-        .subscribe({
-          next: (res: EventResponseDto) => {
-            this.favouriteEvents.push(...res.page);
-
-            this.favoriteEventsPage++;
-            this.hasNextPageOfFavoriteEvents = res.hasNext;
-            this.isActiveFavoriteEventsScroll = res.hasNext;
-          },
-          complete: () => {
-            this.loadingEvents = false;
-          }
-        });
-    }
-  }
-
   removeUnFavouriteEvent(id: number): void {
-    this.favouriteEvents = this.favouriteEvents.filter((event) => event.id !== id);
+    this.eventsList = this.eventsList.filter((event) => event.id !== id);
   }
 
   getUserEvents(): void {
@@ -280,8 +249,7 @@ export class ProfileDashboardComponent implements OnInit, OnDestroy {
 
   tabChanged(tabChangeEvent: MatTabChangeEvent): void {
     this.isActiveNewsScroll = tabChangeEvent.index === 1;
-    this.isActiveEventsScroll = tabChangeEvent.index === 2 && !this.isFavoriteBtnClicked;
-    this.isActiveFavoriteEventsScroll = tabChangeEvent.index === 2 && this.isFavoriteBtnClicked;
+    this.isActiveEventsScroll = tabChangeEvent.index === 2;
   }
 
   onScroll(): void {


### PR DESCRIPTION
[#7675](https://github.com/ita-social-projects/GreenCity/issues/7675)

What`s done:

1. User can select both `online` and `offline` filters to search for events with status ONLINE_OFFLINE
2. Added those filters for favorite events

**_Result:_**
https://github.com/user-attachments/assets/b27d9c63-e110-4348-8fc4-13a001b52ed2

