### PR TITLE
refactor: Deprecated .subscribe() signature

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,17 +38,17 @@ export function appInitializerFactory(translate: TranslateService, injector: Inj
 
         const selectedLanguage = languageService.getCurrentLanguage();
 
-        translate.use(selectedLanguage).subscribe(
-          () => {
+        translate.use(selectedLanguage).subscribe({
+          next: () => {
             console.log(`Successfully initialized '${selectedLanguage}' language.`);
           },
-          (err) => {
+          error: (err) => {
             console.error(`Problem with '${selectedLanguage}' language initialization.`, { err });
           },
-          () => {
+          complete: () => {
             resolve(null);
           }
-        );
+        });
       });
     });
 }

--- a/src/app/main/component/auth/components/confirm-restore-password/confirm-restore-password.component.ts
+++ b/src/app/main/component/auth/components/confirm-restore-password/confirm-restore-password.component.ts
@@ -85,17 +85,17 @@ export class ConfirmRestorePasswordComponent implements OnInit {
     this.restoreDto.password = this.confirmRestorePasswordForm.value.password;
     this.restoreDto.token = this.token;
     this.restoreDto.isUbs = this.isUbs;
-    this.changePasswordService.restorePassword(this.restoreDto).subscribe(
-      (data) => {
+    this.changePasswordService.restorePassword(this.restoreDto).subscribe({
+      next: (data) => {
         this.form = data;
         this.router.navigate(this.isUbs ? ['ubs'] : ['']);
         this.snackBar.openSnackBar(this.isUbs ? 'successConfirmPasswordUbs' : 'successConfirmPassword');
       },
-      (error) => {
+      error: (error) => {
         this.form = error;
         this.snackBar.openSnackBar('sendNewLetter');
       }
-    );
+    });
   }
 
   setPasswordBackendErr(): void {

--- a/src/app/main/component/auth/components/sign-up/sign-up.component.ts
+++ b/src/app/main/component/auth/components/sign-up/sign-up.component.ts
@@ -111,14 +111,14 @@ export class SignUpComponent implements OnInit, OnDestroy, OnChanges {
     this.userOwnSignUpService
       .signUp(userOwnRegister, this.currentLanguage)
       .pipe(takeUntil(this.destroy))
-      .subscribe(
-        (data: SuccessSignUpDto) => {
+      .subscribe({
+        next: (data: SuccessSignUpDto) => {
           this.onSubmitSuccess(data);
         },
-        (error: HttpErrorResponse) => {
+        error: (error: HttpErrorResponse) => {
           this.onSubmitError(error);
         }
-      );
+      });
   }
 
   signUpWithGoogle(): void {

--- a/src/app/main/component/home/components/eco-events/eco-events.component.ts
+++ b/src/app/main/component/home/components/eco-events/eco-events.component.ts
@@ -20,13 +20,13 @@ export class EcoEventsComponent implements OnInit {
   }
 
   private loadLatestNews(): void {
-    this.newsService.loadLatestNews().subscribe(
-      (data: NewsDto[]) => {
+    this.newsService.loadLatestNews().subscribe({
+      next: (data: NewsDto[]) => {
         this.latestNews = data;
       },
-      (error) => {
+      error: (error) => {
         throw error;
       }
-    );
+    });
   }
 }

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.ts
@@ -78,15 +78,15 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
   inviteFriends(event: Event) {
     event.preventDefault();
     if (this.habitId && this.selectedFriends.length) {
-      this.userFriendsService.inviteFriendsToHabit(this.habitId, this.selectedFriends).subscribe(
-        () => {
+      this.userFriendsService.inviteFriendsToHabit(this.habitId, this.selectedFriends).subscribe({
+        next: () => {
           this.invitationSent = true;
           this.setAddedFriends();
         },
-        (error) => {
+        error: (error) => {
           this.snackBar.openSnackBar('snack-bar.error.default');
         }
-      );
+      });
     }
   }
 

--- a/src/app/main/component/user/components/habit/user-log-component/user-log.component.ts
+++ b/src/app/main/component/user/components/habit/user-log-component/user-log.component.ts
@@ -23,15 +23,15 @@ export class UserLogComponent implements OnInit {
 
   ngOnInit() {
     this.retrieveUserLog();
-    this.habitStatisticService.habitStatistics.subscribe(
-      () => {
+    this.habitStatisticService.habitStatistics.subscribe({
+      next: () => {
         this.retrieveUserLog();
       },
-      (error) => {
+      error: (error) => {
         this.hasStatistic = false;
         console.log('Error!', error);
       }
-    );
+    });
   }
 
   nowDate() {

--- a/src/app/main/component/user/components/habit/user-log-component/user-log.component.ts
+++ b/src/app/main/component/user/components/habit/user-log-component/user-log.component.ts
@@ -57,17 +57,17 @@ export class UserLogComponent implements OnInit {
   }
 
   private retrieveUserLog() {
-    this.$userLog = this.habitStatisticService.getUserLog().subscribe(
-      (data) => {
+    this.$userLog = this.habitStatisticService.getUserLog().subscribe({
+      next: (data) => {
         this.hasStatistic = true;
         this.$creationDate = data.creationDate;
         this.initializeNotTakenItemsStatistics(data);
       },
-      (error) => {
+      error: (error) => {
         this.hasStatistic = false;
         console.log('Error!', error);
       }
-    );
+    });
   }
 
   private initializeNotTakenItemsStatistics(data: any) {

--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/all-friends/all-friends.component.ts
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/all-friends/all-friends.component.ts
@@ -68,19 +68,19 @@ export class AllFriendsComponent implements OnInit, OnDestroy {
       this.userFriendsService
         .getFriendsByName(value)
         .pipe(takeUntil(this.destroy$))
-        .subscribe(
-          (data: FriendArrayModel) => {
+        .subscribe({
+          next: (data: FriendArrayModel) => {
             this.emptySearchList = !data.page.length;
             this.friends = data.page;
             this.isFetching = false;
             this.searchMode = false;
           },
-          (error) => {
+          error: (error) => {
             this.matSnackBar.openSnackBar('snack-bar.error.default');
             this.isFetching = false;
             this.searchMode = false;
           }
-        );
+        });
     } else {
       this.searchMode = false;
       this.emptySearchList = false;

--- a/src/app/main/service/habit-statistic/habit-statistic.service.ts
+++ b/src/app/main/service/habit-statistic/habit-statistic.service.ts
@@ -34,23 +34,23 @@ export class HabitStatisticService implements OnLogout {
   }
 
   loadHabitStatistics(language: string) {
-    this.http.get<HabitDto[]>(`${userLink}/${this.userId}/habits?language=${language}`).subscribe(
-      (data) => {
+    this.http.get<HabitDto[]>(`${userLink}/${this.userId}/habits?language=${language}`).subscribe({
+      next: (data) => {
         this.dataStore.habitStatistics = data;
         this.$habitStatistics.next({ ...this.dataStore }.habitStatistics);
       },
-      () => console.log('Can not load habit statistic.')
-    );
+      error: () => console.log('Can not load habit statistic.')
+    });
   }
 
   loadAvailableHabits(language: string) {
-    this.http.get<AvailableHabitDto[]>(`${userLink}/${this.userId}/habit-dictionary/available?language=${language}`).subscribe(
-      (data) => {
+    this.http.get<AvailableHabitDto[]>(`${userLink}/${this.userId}/habit-dictionary/available?language=${language}`).subscribe({
+      next: (data) => {
         this.dataStore.availableHabits = data;
         this.$availableHabits.next({ ...this.dataStore }.availableHabits);
       },
-      () => console.log('Can not load available habits.')
-    );
+      error: () => console.log('Can not load available habits.')
+    });
   }
 
   setNewHabitsState(args) {
@@ -62,27 +62,27 @@ export class HabitStatisticService implements OnLogout {
   }
 
   createHabits(language: string) {
-    this.http.post<any>(`${userLink}/${this.userId}/habit?language=${language}`, this.dataStore.newHabits).subscribe(
-      () => {
+    this.http.post<any>(`${userLink}/${this.userId}/habit?language=${language}`, this.dataStore.newHabits).subscribe({
+      next: () => {
         this.clearDataStore(language);
       },
-      () => console.log('Can not assign new habit for this user')
-    );
+      error: () => console.log('Can not assign new habit for this user')
+    });
   }
 
   deleteHabit(habitId: number, language: string) {
-    this.http.delete<any>(`${userLink}/${this.userId}/habit/${habitId}`).subscribe(
-      () => {
+    this.http.delete<any>(`${userLink}/${this.userId}/habit/${habitId}`).subscribe({
+      next: () => {
         this.loadAvailableHabits(language);
         this.loadHabitStatistics(language);
       },
-      () => console.log('Can not remove habit for this user')
-    );
+      error: () => console.log('Can not remove habit for this user')
+    });
   }
 
   updateHabitStatistic(habitStatisticDto: HabitStatisticsDto) {
-    this.http.patch<HabitStatisticsDto>(`${habitStatisticLink}${habitStatisticDto.id}`, habitStatisticDto).subscribe(
-      (data) => {
+    this.http.patch<HabitStatisticsDto>(`${habitStatisticLink}${habitStatisticDto.id}`, habitStatisticDto).subscribe({
+      next: (data) => {
         let index: number;
 
         this.dataStore.habitStatistics.forEach((item, i) => {
@@ -100,15 +100,15 @@ export class HabitStatisticService implements OnLogout {
           }
         });
       },
-      () => console.log('Can not update habit statistic')
-    );
+      error: () => console.log('Can not update habit statistic')
+    });
   }
 
   createHabitStatistic(habitStatistics: HabitStatisticsDto) {
     const toSend: any = habitStatistics;
     toSend.createdOn = new Date().toISOString();
-    this.http.post<HabitStatisticsDto>(`${habitStatisticLink}`, toSend).subscribe(
-      (data) => {
+    this.http.post<HabitStatisticsDto>(`${habitStatisticLink}`, toSend).subscribe({
+      next: (data) => {
         this.dataStore.habitStatistics.forEach((habit, habitIndex) => {
           if (habit.id === habitStatistics.habitId) {
             habit.habitStatistics.forEach((stat, statIndex) => {
@@ -126,8 +126,8 @@ export class HabitStatisticService implements OnLogout {
           }
         });
       },
-      () => console.log('Can not create habit statistic')
-    );
+      error: () => console.log('Can not create habit statistic')
+    });
   }
 
   getUserLog(): Observable<any> {

--- a/src/app/ubs/ubs-admin/components/add-payment/add-payment.component.ts
+++ b/src/app/ubs/ubs-admin/components/add-payment/add-payment.component.ts
@@ -207,16 +207,16 @@ export class AddPaymentComponent implements OnInit, OnDestroy {
         ),
         takeUntil(this.destroySub)
       )
-      .subscribe(
-        (data: IPaymentInfoDto) => {
+      .subscribe({
+        next: (data: IPaymentInfoDto) => {
           data.amount /= 100;
           this.dialogRef.close(data);
         },
-        (err) => {
+        error: (err) => {
           console.error('error', err);
           this.isUploading = false;
         }
-      );
+      });
   }
 
   filesDropped(files: FileHandle[]): void {
@@ -342,14 +342,14 @@ export class AddPaymentComponent implements OnInit, OnDestroy {
           this.orderService
             .deleteManualPayment(this.payment.id)
             .pipe(takeUntil(this.destroySub))
-            .subscribe(
-              () => {
+            .subscribe({
+              next: () => {
                 this.dialogRef.close(this.payment.id);
               },
-              () => {
+              error: () => {
                 this.isDeleting = false;
               }
-            );
+            });
         }
       });
   }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-edit-form/ubs-admin-employee-edit-form.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-edit-form/ubs-admin-employee-edit-form.component.ts
@@ -133,12 +133,12 @@ export class UbsAdminEmployeeEditFormComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.employeeService.getAllPositions().subscribe(
-      (roles) => {
+    this.employeeService.getAllPositions().subscribe({
+      next: (roles) => {
         this.roles = roles;
       },
-      (error) => console.error('Observer for role got an error: ' + error)
-    );
+      error: (error) => console.error('Observer for role got an error: ' + error)
+    });
     this.store
       .select((state: IAppState): Employees => state.employees.employees)
       .pipe(skip(1))

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-permissions-form/ubs-admin-employee-permissions-form.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-permissions-form/ubs-admin-employee-permissions-form.component.ts
@@ -143,17 +143,17 @@ export class UbsAdminEmployeePermissionsFormComponent implements OnInit, OnDestr
       .filter(([, selected]) => selected)
       .map(([perm]) => perm);
 
-    this.employeeService.updatePermissions(this.employee.email, selectedPermissions).subscribe(
-      () => {
+    this.employeeService.updatePermissions(this.employee.email, selectedPermissions).subscribe({
+      next: () => {
         this.isUpdating = false;
         this.snackBar.openSnackBar('successUpdateUbsData');
         this.dialogRef.close(true);
       },
-      (error) => {
+      error: (error) => {
         this.snackBar.openSnackBar('error', error);
         this.dialogRef.close(false);
       }
-    );
+    });
   }
 
   managePermissionSettings(actionType: string): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee.component.ts
@@ -202,15 +202,15 @@ export class UbsAdminEmployeeComponent implements OnInit, OnDestroy {
     this.ubsAdminEmployeeService
       .getAllPositions()
       .pipe(takeUntil(this.destroy$))
-      .subscribe(
-        (roles) => {
+      .subscribe({
+        next: (roles) => {
           this.employeePositions = roles;
           this.positionName = this.employeePositions.map((position: EmployeePositions) =>
             this.languageService.getLangValue(position.name, position.nameEn)
           );
         },
-        (error) => console.error('Observer for role got an error: ' + error)
-      );
+        error: (error) => console.error('Observer for role got an error: ' + error)
+      });
   }
 
   getContacts(): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-notification/ubs-admin-notification.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-notification/ubs-admin-notification.component.ts
@@ -86,12 +86,12 @@ export class UbsAdminNotificationComponent implements OnInit, OnDestroy {
     this.notificationsService
       .getNotificationTemplate(id)
       .pipe(take(1))
-      .subscribe(
-        (notification: NotificationTemplate) => {
+      .subscribe({
+        next: (notification: NotificationTemplate) => {
           this.notification = formatUnixCron(notification);
         },
-        () => this.navigateToNotificationList()
-      );
+        error: () => this.navigateToNotificationList()
+      });
   }
 
   navigateToNotificationList(): void {

--- a/src/app/ubs/ubs-user/ubs-user-bonuses/ubs-user-bonuses.component.ts
+++ b/src/app/ubs/ubs-user/ubs-user-bonuses/ubs-user-bonuses.component.ts
@@ -40,19 +40,19 @@ export class UbsUserBonusesComponent implements OnInit, OnDestroy {
     this.bonusesService
       .getUserBonusesWithPaymentHistory()
       .pipe(takeUntil(this.destroy))
-      .subscribe(
-        (res: BonusesModel) => {
+      .subscribe({
+        next: (res: BonusesModel) => {
           this.bonusesList = res.ubsUserBonuses;
           this.dataSource.data = res.ubsUserBonuses;
           this.totalBonuses = res.userBonuses;
           this.isLoading = false;
         },
-        (error) => {
+        error: (error) => {
           this.isLoading = false;
           this.snackBar.openSnackBar('error');
           return throwError(error);
         }
-      );
+      });
   }
 
   sortData(sort: Sort) {

--- a/src/app/ubs/ubs-user/ubs-user-messages/ubs-user-messages.component.ts
+++ b/src/app/ubs/ubs-user/ubs-user-messages/ubs-user-messages.component.ts
@@ -58,17 +58,17 @@ export class UbsUserMessagesComponent implements OnInit, OnDestroy {
     this.userMessagesService
       .getNotification(this.page - 1, this.pageSize)
       .pipe(takeUntil(this.destroy))
-      .subscribe(
-        (response) => {
+      .subscribe({
+        next: (response) => {
           this.notifications = response.page;
           this.count = response.totalElements;
           this.isAnyMessages = this.notifications.length > 0;
           this.isLoadSpinner = this.isLoadBar = false;
         },
-        (error) => {
+        error: (error) => {
           console.log(error);
         }
-      );
+      });
   }
 
   setRead(notificationId: number, isRead: boolean) {

--- a/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-order-payment-pop-up/ubs-user-order-payment-pop-up.component.ts
+++ b/src/app/ubs/ubs-user/ubs-user-orders-list/ubs-user-order-payment-pop-up/ubs-user-order-payment-pop-up.component.ts
@@ -132,8 +132,8 @@ export class UbsUserOrderPaymentPopUpComponent implements OnInit {
   calculateCertificate(certificate: FormControl | AbstractControl): void {
     this.userCertificate.certificateSum = 0;
     this.userCertificate.certificateStatusActive = false;
-    this.orderService.processCertificate(certificate.value.certificateCode).subscribe(
-      (response: ICertificateResponse) => {
+    this.orderService.processCertificate(certificate.value.certificateCode).subscribe({
+      next: (response: ICertificateResponse) => {
         if (response.certificateStatus === 'ACTIVE') {
           this.userCertificate.certificateSum = response.points;
           certificate.value.certificateSum = response.points;
@@ -155,7 +155,7 @@ export class UbsUserOrderPaymentPopUpComponent implements OnInit {
         this.userCertificate.dateOfUse.push(this.certificateDateTreat(response.dateOfUse));
         certificate.value.certificateStatus = response.certificateStatus;
       },
-      (error) => {
+      error: (error) => {
         if (error.status === 404) {
           this.userCertificate.certificateError = true;
         }
@@ -163,7 +163,7 @@ export class UbsUserOrderPaymentPopUpComponent implements OnInit {
         this.userCertificate.expirationDate.push(null);
         this.userCertificate.dateOfUse.push(null);
       }
-    );
+    });
   }
 
   private calculateUserOrderSumWithCertificate(certificateSum: number): void {
@@ -265,8 +265,8 @@ export class UbsUserOrderPaymentPopUpComponent implements OnInit {
     this.localStorageService.setUserPagePayment(true);
 
     if (this.formPaymentSystem.value === 'Liqpay') {
-      this.orderService.processOrderFondyFromUserOrderList(this.orderClientDto).subscribe(
-        (response: ResponceOrderFondyModel) => {
+      this.orderService.processOrderFondyFromUserOrderList(this.orderClientDto).subscribe({
+        next: (response: ResponceOrderFondyModel) => {
           if (response.link) {
             this.processWayForPay(response);
           } else {
@@ -274,10 +274,10 @@ export class UbsUserOrderPaymentPopUpComponent implements OnInit {
             this.dialogRef.close();
           }
         },
-        () => {
+        error: () => {
           this.dataLoadingLiqPay = false;
         }
-      );
+      });
     }
   }
 

--- a/src/app/ubs/ubs-user/ubs-user-profile-page/ubs-profile-change-password-pop-up/ubs-profile-change-password-pop-up.component.ts
+++ b/src/app/ubs/ubs-user/ubs-user-profile-page/ubs-profile-change-password-pop-up/ubs-profile-change-password-pop-up.component.ts
@@ -71,15 +71,15 @@ export class UbsProfileChangePasswordPopUpComponent implements OnInit {
           )
         )
       )
-      .subscribe(
-        (_) => {
+      .subscribe({
+        next: (_) => {
           this.snackBar.openSnackBar('successConfirmPasswordUbs');
           this.dialogRef.close();
         },
-        (error) => {
+        error: (error) => {
           this.initForm();
           this.hasWrongCurrentPassword = true;
         }
-      );
+      });
   }
 }

--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
@@ -59,20 +59,20 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
         this.orderService
           .getUbsOrderStatus()
           .pipe(takeUntil(this.destroy$))
-          .subscribe(
-            (response) => {
+          .subscribe({
+            next: (response) => {
               this.orderResponseError = response?.result === 'error';
               this.orderStatusDone = !this.orderResponseError;
               this.orderId = response.order_id ? response.order_id.split('_')[0] : this.localStorageService.getUbsPaymentOrderId();
               this.renderView();
               this.isSpinner = false;
             },
-            (error) => {
+            error: (error) => {
               this.orderResponseError = true;
               this.isSpinner = false;
               console.log(error);
             }
-          );
+          });
       }
     });
   }

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -95,14 +95,14 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
     this.orderService
       .processCertificate(code)
       .pipe(take(1))
-      .subscribe(
-        (response: ICertificateResponse) => {
+      .subscribe({
+        next: (response: ICertificateResponse) => {
           this.store.dispatch(AddCertificate({ certificate: CCertificate.ofResponse(response) }));
         },
-        () => {
+        error: () => {
           this.store.dispatch(AddCertificate({ certificate: CCertificate.ofError(code) }));
         }
-      );
+      });
   }
 
   addNewCertificate(): void {


### PR DESCRIPTION
Deprecation message: Instead of passing separate callback arguments, use an observer argument. Signatures taking separate callback arguments will be removed in v8. Details: https://rxjs.dev/deprecations/subscribe-arguments

This deprecation was introduced in RxJS 6.4. (https://github.com/ng-docs/rxjs.dev/blob/master/CHANGELOG.md#640-2019-01-30)