### PR TITLE
[Bugfix] #7733 When we have an unchecked checkbox of notification we need the ability to change from never to another periodicity

### DIFF
--- a/src/app/main/component/shared/components/input-google-autocomplete/input-google-autocomplete.component.ts
+++ b/src/app/main/component/shared/components/input-google-autocomplete/input-google-autocomplete.component.ts
@@ -33,6 +33,7 @@ export class InputGoogleAutocompleteComponent implements OnInit, OnDestroy, Cont
 
   disabled = false;
   touched = false;
+  isCitySelected = false;
   predictionList: GooglePrediction[];
   autocompleteService: GoogleAutoService;
   placeId: string;
@@ -70,11 +71,15 @@ export class InputGoogleAutocompleteComponent implements OnInit, OnDestroy, Cont
   }
 
   onUserChange() {
-    this.inputValue.setValue('');
-    this.onChange('');
-    this.markAsTouched();
-    this.predictionSelected.emit(null);
-    this.selectedPredictionCoordinates.emit({ longitude: null, latitude: null });
+    setTimeout(() => {
+      if (!this.isCitySelected) {
+        this.inputValue.setValue('');
+        this.onChange('');
+        this.markAsTouched();
+        this.predictionSelected.emit(null);
+        this.selectedPredictionCoordinates.emit({ longitude: null, latitude: null });
+      }
+    }, 100);
   }
 
   writeValue(value: any): void {
@@ -130,6 +135,7 @@ export class InputGoogleAutocompleteComponent implements OnInit, OnDestroy, Cont
       this.returnCoordinatesFromPrediction(prediction);
     }
 
+    this.isCitySelected = true;
     this.predictionSelected.emit(prediction);
   }
 

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile-form-builder.ts
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile-form-builder.ts
@@ -37,11 +37,24 @@ export class EditProfileFormBuilder {
       )
     );
 
+    this.setupEmailPreferenceListeners(emailPrefsGroup);
+
     if (preferences) {
       this.initializeEmailPreferences(emailPrefsGroup, preferences);
     }
 
     return emailPrefsGroup;
+  }
+
+  private setupEmailPreferenceListeners(group: FormGroup): void {
+    this.emailPreferences.forEach((pref) => {
+      const periodicityControl = group.get(`periodicity${this.capitalizeFirstLetter(pref)}`);
+      const checkboxControl = group.get(pref);
+
+      periodicityControl?.valueChanges.subscribe((value) => {
+        checkboxControl?.setValue(value !== 'NEVER', { emitEvent: false });
+      });
+    });
   }
 
   initializeEmailPreferences(group: FormGroup, preferences: NotificationPreference[]): void {

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.spec.ts
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.spec.ts
@@ -1,7 +1,7 @@
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA } from '@angular/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -239,11 +239,12 @@ describe('EditProfileComponent', () => {
 
     describe('The formControl: city should be marked as valid if the value:', () => {
       for (let i = 0; i < validCity.length; i++) {
-        it(`${i + 1}-st - ${validCity[i]}.`, () => {
+        it(`${i + 1}-st - ${validCity[i]}.`, fakeAsync(() => {
           const control = component.editProfileForm.get('city');
           control.setValue(validCity[i]);
+          tick(100);
           expect(control.valid).toBeTruthy();
-        });
+        }));
       }
     });
   });


### PR DESCRIPTION
[#7713](https://github.com/ita-social-projects/GreenCity/issues/7713)
##
Fixed - When typing some non-existent city, we still can click on the save button

##
[#7733](https://github.com/ita-social-projects/GreenCity/issues/7733)
##
Fixed - While having unchecked checkbox in the email notifications, change from never to another periodicity, click save
The checkbox is unchecked and the periodicity is never
now - The checkbox is checked and the periodicity which has been chosen is there
