### PR TITLE
[Bugfix] #7761 Close friends popup on click outside

### DIFF
--- a/src/app/main/component/user/components/profile/profile-dashboard/one-habit/one-habit.component.ts
+++ b/src/app/main/component/user/components/profile/profile-dashboard/one-habit/one-habit.component.ts
@@ -9,7 +9,7 @@ import { Subject } from 'rxjs';
 import { DatePipe } from '@angular/common';
 import { HabitAssignInterface } from '@global-user/components/habit/models/interfaces/habit-assign.interface';
 import { FriendProfilePicturesArrayModel } from '@global-user/models/friend.model';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { FriendsListPopUpComponent } from '@global-user/components/shared/components/friends-list-pop-up/friends-list-pop-up.component';
 import { habitImages } from 'src/app/main/image-pathes/habits-images';
 
@@ -168,13 +168,18 @@ export class OneHabitComponent implements OnInit, OnDestroy {
   }
 
   onDialogOpen() {
-    this.dialog.open(FriendsListPopUpComponent, {
+    const dialogRef: MatDialogRef<FriendsListPopUpComponent> = this.dialog.open(FriendsListPopUpComponent, {
       data: {
         friends: this.friends,
         habitId: this.habit.habit.id
       },
       width: '400px',
-      height: '400px'
+      height: '400px',
+      hasBackdrop: true
+    });
+
+    dialogRef.backdropClick().subscribe(() => {
+      dialogRef.close();
     });
   }
 


### PR DESCRIPTION
[#7761](https://github.com/ita-social-projects/GreenCity/issues/7761)

**Added Backdrop and Close on Click Outside for Friends List Dialog**

Description:
- Enabled a backdrop for the FriendsListPopUpComponent dialog to improve user focus and modal behavior.
- Configured the dialog to close when clicking outside (on the backdrop) for a more intuitive user experience.

**Result:**

https://github.com/user-attachments/assets/675172ff-6498-4d6b-ac30-9aa9853b8c29

