### PR TITLE
[Bugfix] #7764 Redundant "There are no more events for now" message in the saved events list

### DIFF
--- a/src/app/main/component/events/components/events-list/events-list.component.html
+++ b/src/app/main/component/events/components/events-list/events-list.component.html
@@ -144,7 +144,9 @@
       (scrolled)="getEvents()"
     ></app-spinner>
     <app-spinner *ngIf="isLoading && !eventsList.length" infiniteScroll [infiniteScrollThrottle]="500"></app-spinner>
-    <p class="end-page-txt" *ngIf="!hasNextPage && !noEventsMatch && !isLoading">{{ 'homepage.events.no-event-left' | translate }}</p>
+    <p class="end-page-txt" *ngIf="!hasNextPage && !noEventsMatch && !isLoading && !bookmarkSelected">
+      {{ 'homepage.events.no-event-left' | translate }}
+    </p>
     <p class="end-page-txt" *ngIf="noEventsMatch">{{ 'homepage.events.no-matching-left' | translate }}</p>
   </div>
 </div>

--- a/src/app/main/component/events/components/events-list/events-list.component.html
+++ b/src/app/main/component/events/components/events-list/events-list.component.html
@@ -144,7 +144,7 @@
       (scrolled)="getEvents()"
     ></app-spinner>
     <app-spinner *ngIf="isLoading && !eventsList.length" infiniteScroll [infiniteScrollThrottle]="500"></app-spinner>
-    <p class="end-page-txt" *ngIf="!hasNextPage && !noEventsMatch && !isLoading && !bookmarkSelected">
+    <p class="end-page-txt" *ngIf="isShow(!hasNextPage)">
       {{ 'homepage.events.no-event-left' | translate }}
     </p>
     <p class="end-page-txt" *ngIf="noEventsMatch">{{ 'homepage.events.no-matching-left' | translate }}</p>

--- a/src/app/main/component/events/components/events-list/events-list.component.ts
+++ b/src/app/main/component/events/components/events-list/events-list.component.ts
@@ -453,6 +453,10 @@ export class EventsListComponent implements OnInit, OnDestroy {
     return formattedValue ? { key, value: formattedValue } : null;
   }
 
+  isShow(condition: boolean): boolean {
+    return condition && !this.noEventsMatch && !this.isLoading && !this.bookmarkSelected;
+  }
+
   private checkUserSingIn(): void {
     this.userOwnAuthService.credentialDataSubject.subscribe((data) => {
       this.isLoggedIn = !!data?.userId;


### PR DESCRIPTION
[#7764](https://github.com/ita-social-projects/GreenCity/issues/7764)
##
Before
<img width="1434" alt="Знімок екрана 2024-11-19 о 17 23 04" src="https://github.com/user-attachments/assets/7f4f9252-1e2e-48a1-b83c-fda0ac8d6355">

<img width="1440" alt="Знімок екрана 2024-11-19 о 17 22 44" src="https://github.com/user-attachments/assets/607d8c90-c4c0-401e-b559-747029ca6b02">

##
After
<img width="1392" alt="Знімок екрана 2024-11-19 о 17 21 15" src="https://github.com/user-attachments/assets/a338ce2f-9f12-4756-8eb3-c9481837fa03">
<img width="1435" alt="Знімок екрана 2024-11-19 о 17 21 29" src="https://github.com/user-attachments/assets/6d59b572-3876-4043-98a0-77d4222eb3fa">

