### PR TITLE
[Bugfix]#7901, #7839, #7775 make emoji responsive and make the text that is redirecting in notifications different

### DIFF
--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.html
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.html
@@ -50,7 +50,7 @@
   [emojiSize]="20"
   [totalFrequentLines]="2"
   [darkMode]="false"
-  [style]="{ width: '506px' }"
+  [style]="{ width: emojiPickerWidth }"
   [showPreview]="false"
   *ngIf="isEmojiPickerOpen"
   (emojiClick)="onEmojiClick($event)"

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.scss
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.scss
@@ -18,7 +18,7 @@
     font-size: 18px;
     position: absolute;
     top: 0;
-    right: -15px;
+    right: -10px;
     cursor: pointer;
     color: var(--tertiary-dark-grey);
   }

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
@@ -174,7 +174,14 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
 
   updateEmojiPickerWidth(): void {
     const screenWidth = window.innerWidth;
-    this.emojiPickerWidth = screenWidth <= 640 ? '100%' : screenWidth <= 1024 ? '475px' : '506px';
+
+    if (screenWidth <= 640) {
+      this.emojiPickerWidth = '100%';
+    } else if (screenWidth <= 1024) {
+      this.emojiPickerWidth = '475px';
+    } else {
+      this.emojiPickerWidth = '506px';
+    }
   }
 
   onEmojiClick(event: EmojiEvent): void {

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
@@ -371,6 +371,5 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
   ngOnDestroy() {
     this.destroy$.next(true);
     this.destroy$.complete();
-    window.removeEventListener('resize', this.updateEmojiPickerWidth.bind(this));
   }
 }

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
@@ -38,6 +38,7 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
   isImageUploaderOpen = false;
   showImageControls = false;
   isEmojiPickerOpen = false;
+  emojiPickerWidth = '506px';
   uploadedImage: { url: string; file: File }[] = [];
 
   content: FormControl = new FormControl('', [Validators.required, this.innerHtmlMaxLengthValidator(8000)]);
@@ -163,6 +164,17 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
   toggleEmojiPickerVisibility(): void {
     this.isEmojiPickerOpen = !this.isEmojiPickerOpen;
     this.isImageUploaderOpen = false;
+    if (this.isEmojiPickerOpen) {
+      this.updateEmojiPickerWidth();
+      window.addEventListener('resize', this.updateEmojiPickerWidth.bind(this));
+    } else {
+      window.removeEventListener('resize', this.updateEmojiPickerWidth.bind(this));
+    }
+  }
+
+  updateEmojiPickerWidth(): void {
+    const screenWidth = window.innerWidth;
+    this.emojiPickerWidth = screenWidth <= 640 ? '100%' : screenWidth <= 1024 ? '475px' : '506px';
   }
 
   onEmojiClick(event: EmojiEvent): void {
@@ -352,5 +364,6 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
   ngOnDestroy() {
     this.destroy$.next(true);
     this.destroy$.complete();
+    window.removeEventListener('resize', this.updateEmojiPickerWidth.bind(this));
   }
 }

--- a/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
+++ b/src/app/main/component/comments/components/comment-textarea/comment-textarea.component.ts
@@ -40,6 +40,11 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
   isEmojiPickerOpen = false;
   emojiPickerWidth = '506px';
   uploadedImage: { url: string; file: File }[] = [];
+  private widthMap = new Map<number, string>([
+    [0, '100%'],
+    [641, '475px'],
+    [1025, '506px']
+  ]);
 
   content: FormControl = new FormControl('', [Validators.required, this.innerHtmlMaxLengthValidator(8000)]);
   suggestedUsers: TaggedUser[] = [];
@@ -164,6 +169,7 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
   toggleEmojiPickerVisibility(): void {
     this.isEmojiPickerOpen = !this.isEmojiPickerOpen;
     this.isImageUploaderOpen = false;
+
     if (this.isEmojiPickerOpen) {
       this.updateEmojiPickerWidth();
       window.addEventListener('resize', this.updateEmojiPickerWidth.bind(this));
@@ -175,12 +181,10 @@ export class CommentTextareaComponent implements OnInit, AfterViewInit, OnChange
   updateEmojiPickerWidth(): void {
     const screenWidth = window.innerWidth;
 
-    if (screenWidth <= 640) {
-      this.emojiPickerWidth = '100%';
-    } else if (screenWidth <= 1024) {
-      this.emojiPickerWidth = '475px';
-    } else {
-      this.emojiPickerWidth = '506px';
+    for (const [breakpoint, width] of this.widthMap) {
+      if (screenWidth >= breakpoint) {
+        this.emojiPickerWidth = width;
+      }
     }
   }
 

--- a/src/app/main/component/user/directives/notific-content-replace.directive.spec.ts
+++ b/src/app/main/component/user/directives/notific-content-replace.directive.spec.ts
@@ -45,7 +45,9 @@ describe('NotificContentReplaceDirective', () => {
     component.notification = { ...notification, ...{ bodyText: '{user1} and {user2} liked your post' } };
     fixture.detectChanges();
     expect(paragrEl.textContent).toBe('testUser1 and testUser2 liked your post');
-    expect(paragrEl.innerHTML).toBe(`<a data-userid="2">testUser1</a> and <a data-userid="3">testUser2</a> liked your post`);
+    expect(paragrEl.innerHTML).toBe(
+      `<a data-userid="2" style="font-family: var(--tertiary-font);">testUser1</a> and <a data-userid="3" style="font-family: var(--tertiary-font);">testUser2</a> liked your post`
+    );
   });
 
   it('should leave placeholders as is if replacements are missing', () => {
@@ -61,7 +63,9 @@ describe('NotificContentReplaceDirective', () => {
     };
     fixture.detectChanges();
     expect(paragrEl.textContent).toBe('testUser1,testUser2 interacted with your post');
-    expect(paragrEl.innerHTML).toBe('<a data-userid="2">testUser1</a>,<a data-userid="3">testUser2</a> interacted with your post');
+    expect(paragrEl.innerHTML).toBe(
+      '<a data-userid="2" style="font-family: var(--tertiary-font);">testUser1</a>,<a data-userid="3" style="font-family: var(--tertiary-font);">testUser2</a> interacted with your post'
+    );
   });
 
   it('should use body text when there are no property to set', () => {
@@ -74,7 +78,7 @@ describe('NotificContentReplaceDirective', () => {
     component.notification = { ...notification, ...{ bodyText: 'commented event {message}' } };
     fixture.detectChanges();
     expect(paragrEl.textContent).toBe('commented event test message');
-    expect(paragrEl.innerHTML).toBe('commented event test message');
+    expect(paragrEl.innerHTML).toBe('commented event <span style="font-family: var(--tertiary-font);">test message</span>');
   });
 
   it('should add property value to the content and anchor tag', () => {
@@ -84,6 +88,8 @@ describe('NotificContentReplaceDirective', () => {
     };
     fixture.detectChanges();
     expect(paragrEl.textContent).toBe('testUser1,testUser2 commented event test message');
-    expect(paragrEl.innerHTML).toBe('<a data-userid="2">testUser1</a>,<a data-userid="3">testUser2</a> commented event test message');
+    expect(paragrEl.innerHTML).toBe(
+      '<a data-userid="2" style="font-family: var(--tertiary-font);">testUser1</a>,<a data-userid="3" style="font-family: var(--tertiary-font);">testUser2</a> commented event <span style="font-family: var(--tertiary-font);">test message</span>'
+    );
   });
 });

--- a/src/app/main/component/user/directives/notific-content-replace.directive.spec.ts
+++ b/src/app/main/component/user/directives/notific-content-replace.directive.spec.ts
@@ -42,11 +42,16 @@ describe('NotificContentReplaceDirective', () => {
   }));
 
   it('should display multiple user replacements', () => {
-    component.notification = { ...notification, ...{ bodyText: '{user1} and {user2} liked your post' } };
+    component.notification = {
+      ...notification,
+      ...{ bodyText: '{user1} and {user2} liked your post' }
+    };
     fixture.detectChanges();
     expect(paragrEl.textContent).toBe('testUser1 and testUser2 liked your post');
     expect(paragrEl.innerHTML).toBe(
-      `<a data-userid="2" style="font-family: var(--tertiary-font);">testUser1</a> and <a data-userid="3" style="font-family: var(--tertiary-font);">testUser2</a> liked your post`
+      `<a data-userid="2" style="font-family: var(--tertiary-font);">testUser1</a>` +
+        ` and <a data-userid="3" style="font-family: var(--tertiary-font);">testUser2</a>` +
+        ` liked your post`
     );
   });
 
@@ -59,12 +64,18 @@ describe('NotificContentReplaceDirective', () => {
   it('should handle multiple users in a single string replacement', () => {
     component.notification = {
       ...notification,
-      ...{ bodyText: '{user1},{user2} interacted with your post', actionUserId: [2, 3], actionUserText: ['testUser1', 'testUser2'] }
+      ...{
+        bodyText: '{user1},{user2} interacted with your post',
+        actionUserId: [2, 3],
+        actionUserText: ['testUser1', 'testUser2']
+      }
     };
     fixture.detectChanges();
     expect(paragrEl.textContent).toBe('testUser1,testUser2 interacted with your post');
     expect(paragrEl.innerHTML).toBe(
-      '<a data-userid="2" style="font-family: var(--tertiary-font);">testUser1</a>,<a data-userid="3" style="font-family: var(--tertiary-font);">testUser2</a> interacted with your post'
+      `<a data-userid="2" style="font-family: var(--tertiary-font);">testUser1</a>,` +
+        `<a data-userid="3" style="font-family: var(--tertiary-font);">testUser2</a>` +
+        ` interacted with your post`
     );
   });
 
@@ -84,12 +95,18 @@ describe('NotificContentReplaceDirective', () => {
   it('should add property value to the content and anchor tag', () => {
     component.notification = {
       ...notification,
-      ...{ bodyText: '{user1},{user2} commented event {message}', actionUserId: [2, 3], actionUserText: ['testUser1', 'testUser2'] }
+      ...{
+        bodyText: '{user1},{user2} commented event {message}',
+        actionUserId: [2, 3],
+        actionUserText: ['testUser1', 'testUser2']
+      }
     };
     fixture.detectChanges();
     expect(paragrEl.textContent).toBe('testUser1,testUser2 commented event test message');
     expect(paragrEl.innerHTML).toBe(
-      '<a data-userid="2" style="font-family: var(--tertiary-font);">testUser1</a>,<a data-userid="3" style="font-family: var(--tertiary-font);">testUser2</a> commented event <span style="font-family: var(--tertiary-font);">test message</span>'
+      `<a data-userid="2" style="font-family: var(--tertiary-font);">testUser1</a>,` +
+        `<a data-userid="3" style="font-family: var(--tertiary-font);">testUser2</a>` +
+        ` commented event <span style="font-family: var(--tertiary-font);">test message</span>`
     );
   });
 });

--- a/src/app/main/component/user/directives/notific-content-replace.directive.ts
+++ b/src/app/main/component/user/directives/notific-content-replace.directive.ts
@@ -60,14 +60,16 @@ export class NotificContentReplaceDirective implements OnChanges {
     text: string,
     attributes: Record<string, string | number> | null
   ): string {
+    const style = 'style="font-family: var(--tertiary-font);"';
+
     if (!attributes) {
-      return content.replace(`{${placeholder}}`, text);
+      return content.replace(`{${placeholder}}`, `<span ${style}>${text}</span>`);
     }
 
     const attrString = Object.entries(attributes)
       .map(([key, value]) => `data-${key}="${value}"`)
       .join(' ');
 
-    return content.replace(`{${placeholder}}`, `<a ${attrString}>${text}</a>`);
+    return content.replace(`{${placeholder}}`, `<a ${attrString} ${style}>${text}</a>`);
   }
 }


### PR DESCRIPTION
[#7901](https://github.com/ita-social-projects/GreenCity/issues/7901), [#7839](https://github.com/ita-social-projects/GreenCity/issues/7839), [7775](https://github.com/ita-social-projects/GreenCity/issues/7775)

**Emoji**

https://github.com/user-attachments/assets/fef75c75-caae-4b30-9935-dd3e00e7d2c8

**Notifications before**
<img width="1129" alt="Знімок екрана 2024-12-10 о 11 44 39" src="https://github.com/user-attachments/assets/c39f8174-c825-419f-bd63-848a000b80d1">

**Notifications after**
![Image](https://github.com/user-attachments/assets/f813558f-6fe0-4241-afc1-3e7488bef6b6)