### PR TITLE
[Bugfix] #7890, #7907 round the number and add 2 digits after the point

### DIFF
--- a/src/app/shared/localized-currency-pipe/localized-currency.pipe.ts
+++ b/src/app/shared/localized-currency-pipe/localized-currency.pipe.ts
@@ -25,9 +25,10 @@ export class LocalizedCurrencyPipe implements PipeTransform, OnDestroy {
     });
   }
 
-  transform(value: any): any {
-    const roundedValue = Math.round((+value + Number.EPSILON) * 100) / 100;
-    return `${roundedValue} ${LOCALIZED_CURRENCY[this.lang]}`;
+  transform(value: any, fixedDigits: boolean = false): any {
+    const formattedValue = fixedDigits ? (+value).toFixed(2) : Math.round(+value * 100) / 100;
+
+    return `${formattedValue} ${LOCALIZED_CURRENCY[this.lang]}`;
   }
 
   ngOnDestroy() {

--- a/src/app/shared/localized-currency-pipe/localized-currency.pipe.ts
+++ b/src/app/shared/localized-currency-pipe/localized-currency.pipe.ts
@@ -25,7 +25,7 @@ export class LocalizedCurrencyPipe implements PipeTransform, OnDestroy {
     });
   }
 
-  transform(value: any, fixedDigits: boolean = false): any {
+  transform(value: number | string | null, fixedDigits: boolean = false): string | null {
     if (value == null || isNaN(Number(value))) {
       return null;
     }

--- a/src/app/shared/localized-currency-pipe/localized-currency.pipe.ts
+++ b/src/app/shared/localized-currency-pipe/localized-currency.pipe.ts
@@ -26,7 +26,8 @@ export class LocalizedCurrencyPipe implements PipeTransform, OnDestroy {
   }
 
   transform(value: any): any {
-    return `${value} ${LOCALIZED_CURRENCY[this.lang]}`;
+    const roundedValue = Math.round((+value + Number.EPSILON) * 100) / 100;
+    return `${roundedValue} ${LOCALIZED_CURRENCY[this.lang]}`;
   }
 
   ngOnDestroy() {

--- a/src/app/shared/localized-currency-pipe/localized-currency.pipe.ts
+++ b/src/app/shared/localized-currency-pipe/localized-currency.pipe.ts
@@ -16,7 +16,7 @@ export const LOCALIZED_CURRENCY = {
 })
 export class LocalizedCurrencyPipe implements PipeTransform, OnDestroy {
   private lang: string;
-  private destroy$: Subject<any> = new Subject();
+  private destroy$: Subject<void> = new Subject();
 
   constructor(translate: TranslateService, localStorageService: LocalStorageService) {
     this.lang = localStorageService.getCurrentLanguage() || translate.defaultLang;
@@ -26,13 +26,16 @@ export class LocalizedCurrencyPipe implements PipeTransform, OnDestroy {
   }
 
   transform(value: any, fixedDigits: boolean = false): any {
-    const formattedValue = fixedDigits ? (+value).toFixed(2) : Math.round(+value * 100) / 100;
+    if (value == null || isNaN(Number(value))) {
+      return null;
+    }
 
+    const formattedValue = fixedDigits ? Number(value).toFixed(2) : Math.round(Number(value) * 100) / 100;
     return `${formattedValue} ${LOCALIZED_CURRENCY[this.lang]}`;
   }
 
   ngOnDestroy() {
-    this.destroy$.next(true);
-    this.destroy$.unsubscribe();
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.html
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.html
@@ -31,7 +31,7 @@
           <li *ngFor="let bag of bags" class="main-list-item">
             <span class="bag-name" [appLangValue]="{ ua: bag.name, en: bag.nameEng }"></span>
             <span class="bag-name">{{ bag.capacity | volume }}</span>
-            <span class="bag-name">{{ bag.price | localizedCurrency }}</span>
+            <span class="bag-name">{{ bag.price | localizedCurrency: true }}</span>
             <div class="bag-name form-group count">
               <div class="quantity-input-wrapper">
                 <button (click)="changeQuantity(bag.id, -1)" type="button">
@@ -55,7 +55,7 @@
                 </button>
               </div>
             </div>
-            <span class="bag-name label-total"> {{ getBagQuantity(bag.id) * bag.price | localizedCurrency }}</span>
+            <span class="bag-name label-total"> {{ getBagQuantity(bag.id) * bag.price | localizedCurrency: true }}</span>
           </li>
         </ul>
       </div>
@@ -66,7 +66,7 @@
               <p class="total-content" [class.d-none]="orderSum === 0">
                 <span>{{ 'order-details.order-amount' | translate }}</span>
                 <span>
-                  <strong>{{ orderSum | localizedCurrency }}</strong>
+                  <strong>{{ orderSum | localizedCurrency: true }}</strong>
                 </span>
               </p>
               <p class="total-content" *ngIf="certificateUsed">
@@ -84,7 +84,7 @@
               <p class="total-content">
                 <span>{{ 'order-details.amount-due' | translate }} </span>
                 <span>
-                  <strong>{{ finalSum | localizedCurrency }}</strong>
+                  <strong>{{ finalSum | localizedCurrency: true }}</strong>
                 </span>
               </p>
             </div>


### PR DESCRIPTION
[#7890](https://github.com/ita-social-projects/GreenCity/issues/7890), [#7907](https://github.com/ita-social-projects/GreenCity/issues/7907)
##
Added logic to:

- [x] Ensure null or invalid input returns null.
- [x] The localizedCurrency pipe now includes the ability to round the number and optionally display it with two decimal places.

##
**Before**

<img width="1438" alt="Знімок екрана 2024-12-11 о 15 07 37" src="https://github.com/user-attachments/assets/7b2ce2b7-a8a0-484e-8933-0de95d75b113" />


**After**
<img width="1403" alt="Знімок екрана 2024-12-11 о 15 06 18" src="https://github.com/user-attachments/assets/af8c4794-0dc8-4873-9ac0-d9d63f209371" />

