### PR TITLE
[Fix] #7836 admin can edit all comments

### DIFF
--- a/src/app/ubs/ubs-admin/components/shared/components/comment-pop-up/comment-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/shared/components/comment-pop-up/comment-pop-up.component.html
@@ -1,0 +1,14 @@
+<div class="wrapper">
+  <div class="set_comment_container">
+    <h3>{{ header }}</h3>
+    <div class="set_comment">
+      <form [formGroup]="commentForm">
+        <textarea formControlName="comment" placeholder="{{ 'order-edit.comment.placeholder' | translate }}" cols="50" rows="6"></textarea>
+      </form>
+    </div>
+    <div class="comment_btns">
+      <button class="cancel" [mat-dialog-close]="false">{{ 'order-edit.btn.cancel' | translate }}</button>
+      <button (click)="onSubmit()" class="save">{{ 'order-edit.btn.save' | translate }}</button>
+    </div>
+  </div>
+</div>

--- a/src/app/ubs/ubs-admin/components/shared/components/comment-pop-up/comment-pop-up.component.scss
+++ b/src/app/ubs/ubs-admin/components/shared/components/comment-pop-up/comment-pop-up.component.scss
@@ -1,0 +1,56 @@
+* {
+  font-family: var(--ubs-quaternary-font);
+}
+
+.wrapper {
+  .set_comment_container {
+    border-radius: 10px;
+    font-size: 16px;
+
+    h3 {
+      font-size: 20px;
+      font-weight: 600;
+    }
+
+    .comment_btns {
+      display: flex;
+      justify-content: space-between;
+    }
+  }
+
+  .set_comment {
+    padding-block: 20px;
+    display: flex;
+    justify-content: space-between;
+
+    textarea {
+      padding: 10px;
+      border: 1px solid var(--ubs-tertiary-grey);
+      border-radius: 5px;
+      resize: none;
+      outline: none;
+    }
+
+    textarea:focus {
+      border: 1px solid var(--ubs-tertiary-grey);
+    }
+  }
+}
+
+.cancel {
+  background: white;
+  border-radius: 5px;
+  border: none;
+  color: var(--ubs-primary-black);
+  font-weight: 600;
+}
+
+.save {
+  height: 43px;
+  background: var(--ubs-button-light-green);
+  border-radius: 5px;
+  border: 1px solid var(--ubs-button-light-green);
+  padding: 0 30px;
+  color: var(--ubs-tertiary-dark-grey);
+  font-weight: 600;
+}

--- a/src/app/ubs/ubs-admin/components/shared/components/comment-pop-up/comment-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/shared/components/comment-pop-up/comment-pop-up.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CommentPopUpComponent } from './comment-pop-up.component';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { TranslateModule } from '@ngx-translate/core';
+import { ReactiveFormsModule } from '@angular/forms';
+
+describe('CommentPopUpComponent', () => {
+  let component: CommentPopUpComponent;
+  let fixture: ComponentFixture<CommentPopUpComponent>;
+
+  const MatDialogRefMock = {
+    close: () => {}
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [CommentPopUpComponent],
+      imports: [MatDialogModule, ReactiveFormsModule, TranslateModule.forRoot()],
+      providers: [{ provide: MatDialogRef, useValue: MatDialogRefMock }]
+    });
+    fixture = TestBed.createComponent(CommentPopUpComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/ubs/ubs-admin/components/shared/components/comment-pop-up/comment-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/shared/components/comment-pop-up/comment-pop-up.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-comment-pop-up',
+  templateUrl: './comment-pop-up.component.html',
+  styleUrls: ['./comment-pop-up.component.scss']
+})
+export class CommentPopUpComponent implements OnInit {
+  @Input() header: string;
+  @Input() comment: string;
+
+  commentForm: FormGroup;
+
+  constructor(public fb: FormBuilder, private dialogRef: MatDialogRef<CommentPopUpComponent>) {}
+
+  ngOnInit(): void {
+    this.initForm();
+  }
+
+  initForm(): void {
+    this.commentForm = this.fb.group({
+      comment: [this.comment, [Validators.maxLength(255)]]
+    });
+  }
+
+  onSubmit(): void {
+    const data = this.commentForm.get('comment').value;
+    this.dialogRef.close(data);
+  }
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.html
@@ -163,7 +163,7 @@
       </div>
       <div class="form-group comment">
         <label for="address-comment">{{ 'address-details.comment-label' | translate }}</label>
-        <textarea class="form-control" id="address-comment" rows="3" placeholder="{{ addressComment }}" disabled></textarea>
+        <textarea class="form-control" formControlName="addressComment" id="address-comment" rows="3"></textarea>
       </div>
     </div>
   </form>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.ts
@@ -18,7 +18,6 @@ import { OrderService } from 'src/app/ubs/ubs/services/order.service';
   styleUrls: ['./ubs-admin-address-details.component.scss']
 })
 export class UbsAdminAddressDetailsComponent implements OnInit, OnDestroy {
-  @Input() addressComment: string;
   @Input() addressExportDetailsDto: FormGroup;
   @Input() generalInfo: IGeneralOrderInfo;
   @Input() isEmployeeCanEditOrder: boolean;
@@ -91,6 +90,10 @@ export class UbsAdminAddressDetailsComponent implements OnInit, OnDestroy {
 
   get addressDistrictEng() {
     return this.addressExportDetailsDto.get('addressDistrictEng');
+  }
+
+  get addressComment() {
+    return this.addressExportDetailsDto.get('addressComment');
   }
 
   openDetails(): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.html
@@ -215,7 +215,6 @@
             formControlName="customerComment"
             placeholder="{{ 'order-details.client-comment.placeholder' | translate }}"
             id="customer-comment"
-            disabled
           >
           </textarea>
         </div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-details-form/ubs-admin-order-details-form.component.ts
@@ -1,6 +1,6 @@
 import { OrderService } from 'src/app/ubs/ubs-admin/services/order.service';
 import { Component, Input, OnInit, OnChanges, SimpleChanges, Output, EventEmitter } from '@angular/core';
-import { FormGroup, FormBuilder, FormArray, FormControl, Validators } from '@angular/forms';
+import { FormGroup, FormBuilder, FormArray, FormControl, Validators, AbstractControl } from '@angular/forms';
 import { IOrderDetails, IOrderInfo } from '../../models/ubs-admin.interface';
 import { Masks, Patterns } from 'src/assets/patterns/patterns';
 import { OrderStatus, PaymnetStatus } from 'src/app/ubs/ubs/order-status.enum';
@@ -59,6 +59,10 @@ export class UbsAdminOrderDetailsFormComponent implements OnInit, OnChanges {
   @Input() updateBonusAccount: number;
 
   constructor(private fb: FormBuilder, private orderService: OrderService, private langService: LanguageService) {}
+
+  get customerComment(): AbstractControl {
+    return this.orderDetailsForm.get('customerComment');
+  }
 
   ngOnChanges(changes: SimpleChanges) {
     const curStatus = changes.orderStatusInfo?.currentValue;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
@@ -34,7 +34,6 @@
         </app-ubs-admin-order-client-info>
         <app-ubs-admin-address-details
           [addressExportDetailsDto]="getFormGroup('addressExportDetailsDto')"
-          [addressComment]="orderInfo.addressComment"
           [generalInfo]="generalInfo"
           [isEmployeeCanEditOrder]="isEmployeeCanEditOrder"
         >

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -292,7 +292,8 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
         ],
         addressDistrict: [{ value: this.addressInfo.addressDistrict, disabled: this.isStatus }],
         addressDistrictEng: [{ value: this.addressInfo.addressDistrictEng, disabled: this.isStatus }],
-        addressRegionDistrictList: [this.addressInfo.addressRegionDistrictList]
+        addressRegionDistrictList: [this.addressInfo.addressRegionDistrictList],
+        addressComment: [this.orderInfo.addressComment]
       }),
       exportDetailsDto: this.fb.group({
         dateExport: [this.exportInfo.dateExport ? formatDate(this.exportInfo.dateExport, 'yyyy-MM-dd', this.currentLanguage) : ''],
@@ -483,6 +484,9 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
 
     if (changedValues.orderDetailsForm) {
       changedValues.orderDetailDto = this.formatBagsValue(changedValues.orderDetailsForm);
+      if (changedValues.orderDetailsForm.customerComment) {
+        changedValues.orderDetailDto.userComment = changedValues.orderDetailsForm.customerComment;
+      }
       const keyEcoNumberFromShop = 'ecoNumberFromShop';
       if (changedValues.orderDetailsForm.storeOrderNumbers || this.deleteNumberOrderFromEcoShop) {
         changedValues[keyEcoNumberFromShop] = {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-input/table-cell-input.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-input/table-cell-input.component.html
@@ -1,0 +1,11 @@
+<div
+  class="comment"
+  #tooltip="matTooltip"
+  matTooltip="{{ data }}"
+  (mouseenter)="onMouseEnter($event, tooltip)"
+  (mouseleave)="tooltip.hide()"
+>
+  <span>{{ data }}</span>
+  <span *ngIf="!isEditable && !isBlocked && !isUneditableStatus" class="pointer" (keydown.enter)="edit()" (click)="edit()">&#9998;</span>
+  <mat-spinner class="spinner" *ngIf="isBlocked" strokeWidth="3" diameter="20"></mat-spinner>
+</div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-input/table-cell-input.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-input/table-cell-input.component.scss
@@ -1,0 +1,26 @@
+.comment {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 0 10px;
+  margin: 0 10px;
+  cursor: default;
+  position: relative;
+}
+
+.pointer {
+  cursor: pointer;
+  position: absolute;
+  right: 0;
+}
+
+.spinner {
+  position: absolute;
+  right: 0;
+  top: 20%;
+}
+
+div {
+  width: 100%;
+  height: 100%;
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-input/table-cell-input.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-input/table-cell-input.component.spec.ts
@@ -1,0 +1,91 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TableCellInputComponent } from './table-cell-input.component';
+import { of } from 'rxjs';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { TranslateModule } from '@ngx-translate/core';
+import { AdminTableService } from '../../../services/admin-table.service';
+import { IColumnBelonging } from '../../../models/ubs-admin.interface';
+import { IAlertInfo } from '../../../models/edit-cell.model';
+
+describe('TableCellInputComponent', () => {
+  let component: TableCellInputComponent;
+  let fixture: ComponentFixture<TableCellInputComponent>;
+  let adminTableService: jasmine.SpyObj<AdminTableService>;
+
+  beforeEach(() => {
+    const adminTableServiceSpy = jasmine.createSpyObj('AdminTableService', ['howChangeCell', 'blockOrders', 'showTooltip']);
+    const matDialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
+
+    const mockModalRef = {
+      componentInstance: {
+        header: '',
+        comment: ''
+      },
+      afterClosed: jasmine.createSpy().and.returnValue(of('New Comment'))
+    };
+
+    matDialogSpy.open.and.returnValue(mockModalRef as any);
+
+    TestBed.configureTestingModule({
+      declarations: [TableCellInputComponent],
+      imports: [MatDialogModule, MatTooltipModule, TranslateModule.forRoot()],
+      providers: [
+        { provide: AdminTableService, useValue: adminTableServiceSpy },
+        { provide: MatDialog, useValue: matDialogSpy }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TableCellInputComponent);
+    component = fixture.componentInstance;
+    adminTableService = TestBed.inject(AdminTableService) as jasmine.SpyObj<AdminTableService>;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should call showBlockedInfo.emit() when orders are blocked', () => {
+    const mockColumn: IColumnBelonging = { key: 'test', ua: 'Test', en: 'Test' };
+    const mockData = 'Test Comment';
+    component.column = mockColumn;
+    component.id = 1;
+    component.ordersToChange = [1, 2, 3];
+    component.isAllChecked = true;
+    component.isUneditableStatus = false;
+    component.data = mockData;
+
+    adminTableService.howChangeCell.and.returnValue([1, 2, 3]);
+    adminTableService.blockOrders.and.returnValue(of([{ message: 'Blocked' } as unknown as IAlertInfo]));
+
+    spyOn(component.showBlockedInfo, 'emit');
+
+    component.edit();
+
+    expect(component.showBlockedInfo.emit).toHaveBeenCalledWith([{ message: 'Blocked' }]);
+    expect(component.isBlocked).toBeFalsy();
+    expect(component.isEditable).toBeFalsy();
+  });
+
+  it('should call onMouseEnter() and show tooltip', () => {
+    const event = new MouseEvent('mouseenter');
+    const tooltip = {};
+
+    component.onMouseEnter(event, tooltip);
+
+    expect(adminTableService.showTooltip).toHaveBeenCalledWith(event, tooltip, '12px Lato, sans-serif');
+  });
+
+  it('should emit showBlockedInfo when blockOrders returns data', () => {
+    const mockResponse: IAlertInfo[] = [{ orderId: 10, userName: 'user' }];
+    adminTableService.howChangeCell.and.returnValue([10]);
+    adminTableService.blockOrders.and.returnValue(of(mockResponse));
+    spyOn(component.showBlockedInfo, 'emit');
+
+    component.edit();
+
+    expect(component.isEditable).toBeFalsy();
+    expect(component.isBlocked).toBeFalsy();
+    expect(component.showBlockedInfo.emit).toHaveBeenCalledWith(mockResponse);
+  });
+});

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-input/table-cell-input.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-input/table-cell-input.component.ts
@@ -1,0 +1,85 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommentPopUpComponent } from '../../shared/components/comment-pop-up/comment-pop-up.component';
+import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
+import { AdminTableService } from '../../../services/admin-table.service';
+import { IColumnBelonging } from '../../../models/ubs-admin.interface';
+import { IAlertInfo, IEditCell } from '../../../models/edit-cell.model';
+import { catchError, take } from 'rxjs/operators';
+import { of } from 'rxjs';
+@Component({
+  selector: 'app-table-cell-input',
+  templateUrl: './table-cell-input.component.html',
+  styleUrls: ['./table-cell-input.component.scss']
+})
+export class TableCellInputComponent {
+  @Input() column: IColumnBelonging;
+  @Input() id: number;
+  @Input() ordersToChange: number[];
+  @Input() isAllChecked: boolean;
+  @Input() isUneditableStatus: boolean;
+  @Input() data: string;
+
+  @Output() cancelEdit = new EventEmitter();
+  @Output() editCommentCell = new EventEmitter();
+  @Output() showBlockedInfo = new EventEmitter();
+
+  isEditable: boolean;
+  isBlocked: boolean;
+
+  private typeOfChange: number[];
+  private readonly font = '12px Lato, sans-serif';
+
+  private dialogConfig = new MatDialogConfig();
+
+  constructor(private adminTableService: AdminTableService, private localStorageService: LocalStorageService, public dialog: MatDialog) {}
+
+  edit(): void {
+    this.isEditable = false;
+    this.isBlocked = true;
+
+    this.typeOfChange = this.adminTableService.howChangeCell(this.isAllChecked, this.ordersToChange, this.id);
+    this.adminTableService
+      .blockOrders(this.typeOfChange)
+      .pipe(
+        take(1),
+        catchError(() => {
+          this.isBlocked = false;
+          this.isEditable = true;
+          return of([]);
+        })
+      )
+      .subscribe((res: IAlertInfo[]) => {
+        this.isBlocked = false;
+        if (res && res[0]) {
+          this.showBlockedInfo.emit(res);
+        } else {
+          this.isEditable = true;
+          this.openPopUp();
+        }
+      });
+  }
+
+  private openPopUp(): void {
+    this.dialogConfig.disableClose = true;
+    const modalRef = this.dialog.open(CommentPopUpComponent, this.dialogConfig);
+    modalRef.componentInstance.header = this.localStorageService.getCurrentLanguage() === 'ua' ? this.column.ua : this.column.en;
+    modalRef.componentInstance.comment = this.data;
+    modalRef.afterClosed().subscribe((data) => {
+      if (data) {
+        const newCommentValue: IEditCell = {
+          id: this.id,
+          nameOfColumn: this.column.key,
+          newValue: data
+        };
+        this.editCommentCell.emit(newCommentValue);
+      }
+      this.cancelEdit.emit(this.typeOfChange);
+      this.isEditable = false;
+    });
+  }
+
+  onMouseEnter(event: MouseEvent, tooltip: any): void {
+    this.adminTableService.showTooltip(event, tooltip, this.font);
+  }
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-readonly/table-cell-readonly.comoponent.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-readonly/table-cell-readonly.comoponent.spec.ts
@@ -5,11 +5,12 @@ import { ServerTranslatePipe } from 'src/app/shared/translate-pipe/translate-pip
 import { TableCellReadonlyComponent } from './table-cell-readonly.component';
 import { Language } from 'src/app/main/i18n/Language';
 import { TableKeys } from '../../../services/table-keys.enum';
-import { MouseEvents } from 'src/app/shared/mouse-events';
+import { AdminTableService } from '../../../services/admin-table.service';
 
 describe('TableCellReadonlyComponent', () => {
   let component: TableCellReadonlyComponent;
   let fixture: ComponentFixture<TableCellReadonlyComponent>;
+  const adminTableServiceSpy = jasmine.createSpyObj('AdminTableService', ['howChangeCell', 'blockOrders', 'showTooltip']);
 
   const fakeStrValue = '20л - 0шт; 120л - 3шт';
   const fakeColumn = {
@@ -22,6 +23,7 @@ describe('TableCellReadonlyComponent', () => {
     TestBed.configureTestingModule({
       imports: [MatTooltipModule],
       declarations: [TableCellReadonlyComponent, ServerTranslatePipe],
+      providers: [{ provide: AdminTableService, useValue: adminTableServiceSpy }],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
   }));
@@ -83,58 +85,5 @@ describe('TableCellReadonlyComponent', () => {
 
       expect(component.data).toBe('0.00 UAH');
     });
-  });
-
-  it('should not show tooltip if textContainerWidth is greater than or equal to textWidth', () => {
-    const event = {
-      target: {
-        offsetWidth: 100,
-        innerText: 'Short text'
-      }
-    };
-    const tooltip = {
-      show: jasmine.createSpy('show')
-    };
-
-    component.calculateTextWidth(event, tooltip);
-
-    expect(tooltip.show).not.toHaveBeenCalled();
-  });
-
-  it('should not show tooltip if the difference between textContainerWidth and textWidth is greater than or equal to maxLength', () => {
-    const event = {
-      target: {
-        offsetWidth: 120,
-        innerText: 'Long text'
-      }
-    };
-    const tooltip = {
-      show: jasmine.createSpy('show')
-    };
-    const maxLength = 20;
-
-    component.calculateTextWidth(event, tooltip, maxLength);
-
-    expect(tooltip.show).not.toHaveBeenCalled();
-  });
-
-  it('should hide tooltip if lengthStr is not greater than maxLength', () => {
-    const event = {
-      stopImmediatePropagation: jasmine.createSpy('stopImmediatePropagation'),
-      target: {
-        innerText: 'Short text'
-      }
-    };
-    const tooltip = {
-      toggle: jasmine.createSpy('toggle'),
-      hide: jasmine.createSpy('hide')
-    };
-    const maxLength = 50;
-
-    component.showTooltip(event, tooltip, maxLength);
-
-    expect(event.stopImmediatePropagation).toHaveBeenCalled();
-    expect(tooltip.toggle).not.toHaveBeenCalled();
-    expect(tooltip.hide).toHaveBeenCalled();
   });
 });

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-readonly/table-cell-readonly.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-readonly/table-cell-readonly.component.html
@@ -8,7 +8,7 @@
     #tooltip="matTooltip"
     matTooltip="{{ title | serverTranslate: lang }}"
     matTooltipClass="my-custom-tooltip"
-    (mouseenter)="showTooltip($event, tooltip)"
+    (mouseenter)="onMouseEnter($event, tooltip)"
     (mouseleave)="tooltip.hide()"
   >
     {{ (dataObj ? dataObj : data) | serverTranslate: lang }}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-readonly/table-cell-readonly.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/table-cell-readonly/table-cell-readonly.component.ts
@@ -5,6 +5,7 @@ import { Language } from 'src/app/main/i18n/Language';
 import { TableKeys } from '../../../services/table-keys.enum';
 import { Patterns } from 'src/assets/patterns/patterns';
 import { PaymnetStatus } from 'src/app/ubs/ubs/order-status.enum';
+import { AdminTableService } from '../../../services/admin-table.service';
 
 @Component({
   selector: 'app-table-cell-readonly',
@@ -22,7 +23,9 @@ export class TableCellReadonlyComponent implements OnInit, OnChanges {
   halfpaid: boolean;
   public dataObj: IColumnBelonging = null;
   public data: string | number | { ua: string; en: string } | null;
-  private font = '12px Lato, sans-serif';
+  private readonly font = '12px Lato, sans-serif';
+
+  constructor(private adminTableService: AdminTableService) {}
 
   ngOnInit(): void {
     if (this.optional?.length) {
@@ -72,25 +75,7 @@ export class TableCellReadonlyComponent implements OnInit, OnChanges {
     }
   }
 
-  showTooltip(event: any, tooltip: any, maxLength: number = 50): void {
-    event.stopImmediatePropagation();
-    const lengthStr = event.target?.innerText.split('').length;
-    if (lengthStr > maxLength) {
-      tooltip.toggle();
-    }
-
-    event.type === MouseEvents.MouseEnter ? this.calculateTextWidth(event, tooltip) : tooltip.hide();
-  }
-
-  calculateTextWidth(event: any, tooltip: any, maxLength: number = 40): void {
-    const textContainerWidth = event.target.offsetWidth;
-    const canvas = document.createElement('canvas');
-    const context = canvas.getContext('2d');
-    context.font = this.font;
-    const textWidth = Math.round(context.measureText(event.target.innerText).width);
-
-    if (textContainerWidth < textWidth || Math.abs(textContainerWidth - textWidth) < maxLength) {
-      tooltip.show();
-    }
+  onMouseEnter(event: MouseEvent, tooltip: any): void {
+    this.adminTableService.showTooltip(event, tooltip, this.font);
   }
 }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.html
@@ -308,6 +308,20 @@
           (isTimePickerOpened)="setIsTimePickerOpened($event)"
         >
         </app-table-cell-time>
+        <app-table-cell-input
+          *ngIf="column.editType === 'INLINE'"
+          [data]="row[column.title.key]"
+          [column]="column.title"
+          [id]="row.id"
+          [ordersToChange]="idsToChange"
+          [isAllChecked]="allChecked"
+          [isUneditableStatus]="checkStatusOfOrders(row.id)"
+          (cancelEdit)="cancelEditCell($event)"
+          (editCommentCell)="editCell($event)"
+          (showBlockedInfo)="showBlockedMessage($event)"
+          class="column_cell"
+        >
+        </app-table-cell-input>
         <mat-checkbox
           *ngIf="column.editType === 'CHECKBOX'"
           [disabled]="checkStatusOfOrders(row.id)"

--- a/src/app/ubs/ubs-admin/services/admin-table.service.spec.ts
+++ b/src/app/ubs/ubs-admin/services/admin-table.service.spec.ts
@@ -368,4 +368,63 @@ describe('AdminTableService', () => {
     expect(req.request.method).toBe('GET');
     req.flush(preference);
   });
+
+  it('should not show tooltip if textContainerWidth is greater than or equal to textWidth', () => {
+    const event = new MouseEvent('mouseover');
+    spyOn(event, 'stopImmediatePropagation');
+    Object.defineProperty(event, 'target', {
+      value: { innerText: 'Short text' },
+      writable: true
+    });
+
+    const tooltip = {
+      show: jasmine.createSpy('show')
+    };
+    const font = '12px Lato, sans-serif';
+
+    service.calculateTextWidth(event, tooltip, font);
+
+    expect(tooltip.show).not.toHaveBeenCalled();
+  });
+
+  it('should not show tooltip if the difference between textContainerWidth and textWidth is greater than or equal to maxLength', () => {
+    const event = new MouseEvent('mouseover');
+    spyOn(event, 'stopImmediatePropagation');
+    Object.defineProperty(event, 'target', {
+      value: { innerText: 'Short text' },
+      writable: true
+    });
+
+    const tooltip = {
+      show: jasmine.createSpy('show')
+    };
+    const font = '12px Lato, sans-serif';
+    const maxLength = 20;
+
+    service.calculateTextWidth(event, tooltip, font, maxLength);
+
+    expect(tooltip.show).not.toHaveBeenCalled();
+  });
+
+  it('should hide tooltip if lengthStr is not greater than maxLength', () => {
+    const event = new MouseEvent('mouseover');
+    spyOn(event, 'stopImmediatePropagation');
+    Object.defineProperty(event, 'target', {
+      value: { innerText: 'Short text' },
+      writable: true
+    });
+
+    const tooltip = {
+      toggle: jasmine.createSpy('toggle'),
+      hide: jasmine.createSpy('hide')
+    };
+    const font = '12px Lato, sans-serif';
+    const maxLength = 50;
+
+    service.showTooltip(event, tooltip, font, maxLength);
+
+    expect(event.stopImmediatePropagation).toHaveBeenCalled();
+    expect(tooltip.toggle).not.toHaveBeenCalled();
+    expect(tooltip.hide).toHaveBeenCalled();
+  });
 });

--- a/src/app/ubs/ubs-admin/services/admin-table.service.ts
+++ b/src/app/ubs/ubs-admin/services/admin-table.service.ts
@@ -6,6 +6,7 @@ import { IBigOrderTable, IFilteredColumn, IFilteredColumnValue } from '../models
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import * as moment from 'moment';
+import { MouseEvents } from 'src/app/shared/mouse-events';
 
 @Injectable({
   providedIn: 'root'
@@ -289,6 +290,29 @@ export class AdminTableService {
       }
     });
     this.filters = this.filters.filter((filteredElem) => !filteredElem[colName]);
+  }
+
+  showTooltip(event: MouseEvent, tooltip: any, font: string, maxLength = 50): void {
+    event.stopImmediatePropagation();
+    const target = event.target as HTMLElement;
+    const lengthStr = target?.innerText.split('').length;
+    if (lengthStr > maxLength) {
+      tooltip.toggle();
+    }
+
+    event.type === MouseEvents.MouseEnter ? this.calculateTextWidth(event, tooltip, font) : tooltip.hide();
+  }
+
+  calculateTextWidth(event: MouseEvent, tooltip: any, font: string, maxLength = 40): void {
+    const target = event.target as HTMLElement;
+    const textContainerWidth = target?.offsetWidth;
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+    context.font = font;
+    const textWidth = Math.round(context.measureText(target?.innerText).width);
+    if (textContainerWidth < textWidth || Math.abs(textContainerWidth - textWidth) < maxLength) {
+      tooltip.show();
+    }
   }
 
   setUbsAdminOrdersTableColumnsWidthPreference(preference: Map<string, number>) {

--- a/src/app/ubs/ubs-admin/ubs-admin.module.ts
+++ b/src/app/ubs/ubs-admin/ubs-admin.module.ts
@@ -99,6 +99,8 @@ import { ClickOutsideDirective } from './derictives/clickOutside.directive';
 import { MatMenuModule } from '@angular/material/menu';
 import { ChatModule } from 'src/app/chat/chat.module';
 import { UbsAdminConfirmStatusChangePopUpComponent } from './components/ubs-admin-confirm-status-change-pop-up/ubs-admin-confirm-status-change-pop-up.component';
+import { CommentPopUpComponent } from './components/shared/components/comment-pop-up/comment-pop-up.component';
+import { TableCellInputComponent } from './components/ubs-admin-table/table-cell-input/table-cell-input.component';
 
 @NgModule({
   declarations: [
@@ -166,7 +168,9 @@ import { UbsAdminConfirmStatusChangePopUpComponent } from './components/ubs-admi
     UbsAdminNotificationSettingsComponent,
     ConfirmationDialogComponent,
     TariffSelectorComponent,
-    UbsAdminConfirmStatusChangePopUpComponent
+    UbsAdminConfirmStatusChangePopUpComponent,
+    CommentPopUpComponent,
+    TableCellInputComponent
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
**Issue:** [#7836](https://github.com/ita-social-projects/GreenCity/issues/7836)
**Summary of changes:**
- Added the ability to change all types of order comments on separate order page
- Added popup for adding/editing different types of order comments


