### PR TITLE
[Bugfix] #7874, #7876 When user opens pop up, the friends he already invited to habit are disabled and invite all works as expected

### DIFF
--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.spec.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.spec.ts
@@ -10,6 +10,7 @@ import { FRIENDS, FIRSTFRIEND, SECONDFRIEND } from '@global-user/mocks/friends-m
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { HabitService } from '../../../../../../../service/habit/habit.service';
 
 describe('HabitInviteFriendsPopUpComponent', () => {
   let component: HabitInviteFriendsPopUpComponent;
@@ -26,11 +27,16 @@ describe('HabitInviteFriendsPopUpComponent', () => {
   userFriendsServiceMock.inviteFriendsToHabit = jasmine.createSpy('inviteFriendsToHabit').and.returnValue(of({}));
   userFriendsServiceMock.addedFriends = [];
 
+  const mockHabitService = {
+    getFriendsWithInvitations: jasmine.createSpy('getFriendsWithInvitations').and.returnValue(of({ page: [] }))
+  };
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [HabitInviteFriendsPopUpComponent],
       imports: [HttpClientTestingModule, TranslateModule.forRoot(), MatDialogModule, MatCheckboxModule],
       providers: [
+        { provide: HabitService, useValue: mockHabitService },
         { provide: LocalStorageService, useValue: localStorageServiceMock },
         { provide: Router, useValue: routerSpy },
         { provide: MatSnackBarComponent, useValue: MatSnackBarMock },
@@ -56,24 +62,6 @@ describe('HabitInviteFriendsPopUpComponent', () => {
     const spy2 = spyOn(component, 'getFriends');
     component.ngOnInit();
     expect(spy2).toHaveBeenCalled();
-  });
-
-  describe('setFriendDisable', () => {
-    it('should return true if the friend is in the addedFriends list and invitationSent is false', () => {
-      const friendId = 1;
-      userFriendsServiceMock.addedFriends = [FIRSTFRIEND, SECONDFRIEND];
-      component.invitationSent = false;
-      const result = component.setFriendDisable(friendId);
-      expect(result).toBe(false);
-    });
-
-    it('should return true if invitationSent is true, regardless of addedFriends', () => {
-      const friendId = 1;
-      userFriendsServiceMock.addedFriends = [FIRSTFRIEND, SECONDFRIEND];
-      component.invitationSent = true;
-      const result = component.setFriendDisable(friendId);
-      expect(result).toBe(true);
-    });
   });
 
   xit('should update allAdd status', () => {

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.spec.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.spec.ts
@@ -10,7 +10,7 @@ import { FRIENDS, FIRSTFRIEND, SECONDFRIEND } from '@global-user/mocks/friends-m
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { HabitService } from '../../../../../../../service/habit/habit.service';
+import { HabitService } from '@global-service/habit/habit.service';
 
 describe('HabitInviteFriendsPopUpComponent', () => {
   let component: HabitInviteFriendsPopUpComponent;

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.ts
@@ -24,7 +24,7 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
   allAdd = false;
   searchIcon = searchIcon;
   habitId: number;
-  
+
   constructor(
     private readonly userFriendsService: UserFriendsService,
     private readonly localStorageService: LocalStorageService,
@@ -60,7 +60,7 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
 
   onFriendCheckboxChange(friendId: number, isChecked: boolean) {
     const friend = this.friends.find((f) => f.id === friendId);
-    if (friend && !friend.hasInvitation) { 
+    if (friend && !friend.hasInvitation) {
       friend.added = isChecked;
       this.toggleFriendSelection(friendId, isChecked);
       this.updateAllAdd();
@@ -93,9 +93,9 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
 
   setFriendDisable(friendId: number): boolean {
     const friend = this.friends.find((f) => f.id === friendId);
-    return friend ? friend.hasInvitation : false; 
+    return friend ? friend.hasInvitation : false;
   }
-  
+
   setAllFriendsDisable(): boolean {
     return this.friends.every((friend) => friend.hasInvitation);
   }
@@ -112,6 +112,7 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
     this.allAdd = added;
     this.friends.forEach((friend) => {
       if (!this.isFriendAddedAlready(friend.id) && !friend.hasInvitation) {
+        friend.added = added;
         this.toggleFriendSelection(friend.id, added);
       }
     });
@@ -135,5 +136,5 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.destroyed$.next(true);
     this.destroyed$.complete();
-  }   
+  }
 }

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.ts
@@ -82,7 +82,6 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
     if (this.habitId && this.selectedFriends.length) {
       this.userFriendsService.inviteFriendsToHabit(this.habitId, this.selectedFriends).subscribe({
         next: () => {
-          
           this.dialogRef.close();
         },
         error: (error) => {
@@ -98,7 +97,7 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
   }
   
   setAllFriendsDisable(): boolean {
-      return this.friends.every((friend) => friend.hasInvitation);
+    return this.friends.every((friend) => friend.hasInvitation);
   }
 
   updateAllAdd() {
@@ -136,5 +135,5 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.destroyed$.next(true);
     this.destroyed$.complete();
-  }
+  }   
 }

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.ts
@@ -7,7 +7,7 @@ import { Subject } from 'rxjs';
 import { searchIcon } from 'src/app/main/image-pathes/places-icons';
 import { takeUntil } from 'rxjs/operators';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
-import { HabitService } from '../../../../../../../service/habit/habit.service';
+import { HabitService } from '@global-service/habit/habit.service';
 
 @Component({
   selector: 'app-habit-invite-friends-pop-up',

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends-pop-up/habit-invite-friends-pop-up.component.ts
@@ -7,6 +7,7 @@ import { Subject } from 'rxjs';
 import { searchIcon } from 'src/app/main/image-pathes/places-icons';
 import { takeUntil } from 'rxjs/operators';
 import { MatSnackBarComponent } from '@global-errors/mat-snack-bar/mat-snack-bar.component';
+import { HabitService } from '../../../../../../../service/habit/habit.service';
 
 @Component({
   selector: 'app-habit-invite-friends-pop-up',
@@ -23,11 +24,11 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
   allAdd = false;
   searchIcon = searchIcon;
   habitId: number;
-  invitationSent = false;
-
+  
   constructor(
     private readonly userFriendsService: UserFriendsService,
     private readonly localStorageService: LocalStorageService,
+    private readonly habitService: HabitService,
     @Inject(MAT_DIALOG_DATA) public data: any,
     private readonly snackBar: MatSnackBarComponent,
     private readonly dialogRef: MatDialogRef<HabitInviteFriendsPopUpComponent>
@@ -48,8 +49,8 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
   }
 
   getFriends() {
-    this.userFriendsService
-      .getAllFriends()
+    this.habitService
+      .getFriendsWithInvitations(this.habitId, 0, 10)
       .pipe(takeUntil(this.destroyed$))
       .subscribe((data: FriendArrayModel) => {
         this.friends = data.page;
@@ -59,7 +60,7 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
 
   onFriendCheckboxChange(friendId: number, isChecked: boolean) {
     const friend = this.friends.find((f) => f.id === friendId);
-    if (friend) {
+    if (friend && !friend.hasInvitation) { 
       friend.added = isChecked;
       this.toggleFriendSelection(friendId, isChecked);
       this.updateAllAdd();
@@ -81,13 +82,7 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
     if (this.habitId && this.selectedFriends.length) {
       this.userFriendsService.inviteFriendsToHabit(this.habitId, this.selectedFriends).subscribe({
         next: () => {
-          this.invitationSent = true;
-          const updatedFriends = [
-            ...this.data.friends,
-            ...this.selectedFriends.map((id) => this.friends.find((friend) => friend.id === id))
-          ];
-
-          this.data.onFriendsUpdated(updatedFriends);
+          
           this.dialogRef.close();
         },
         error: (error) => {
@@ -98,14 +93,12 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
   }
 
   setFriendDisable(friendId: number): boolean {
-    const isAlreadyAdded = this.data.friends?.some(({ id }) => id === friendId);
-    const isRecentlyAdded = this.userFriendsService.addedFriends?.some(({ id }) => id === friendId);
-
-    return isAlreadyAdded || this.invitationSent || isRecentlyAdded;
+    const friend = this.friends.find((f) => f.id === friendId);
+    return friend ? friend.hasInvitation : false; 
   }
-
+  
   setAllFriendsDisable(): boolean {
-    return this.invitationSent || this.userFriendsService.addedFriends?.length === this.friends?.length;
+      return this.friends.every((friend) => friend.hasInvitation);
   }
 
   updateAllAdd() {
@@ -119,7 +112,7 @@ export class HabitInviteFriendsPopUpComponent implements OnInit, OnDestroy {
   setAll(added: boolean) {
     this.allAdd = added;
     this.friends.forEach((friend) => {
-      if (!this.isFriendAddedAlready(friend.id)) {
+      if (!this.isFriendAddedAlready(friend.id) && !friend.hasInvitation) {
         this.toggleFriendSelection(friend.id, added);
       }
     });

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends.component.ts
@@ -46,9 +46,7 @@ export class HabitInviteFriendsComponent implements OnInit, OnDestroy {
       data: {
         habitId: this.habitId,
         friends: [...this.friends],
-        onFriendsUpdated: (newFriends: FriendProfilePicturesArrayModel[]) => {
-          this.friends = newFriends;
-        }
+       
       }
     });
 

--- a/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends.component.ts
+++ b/src/app/main/component/user/components/habit/add-new-habit/habit-invite-friends/habit-invite-friends.component.ts
@@ -45,8 +45,7 @@ export class HabitInviteFriendsComponent implements OnInit, OnDestroy {
       hasBackdrop: true,
       data: {
         habitId: this.habitId,
-        friends: [...this.friends],
-       
+        friends: [...this.friends]
       }
     });
 

--- a/src/app/main/component/user/models/friend.model.ts
+++ b/src/app/main/component/user/models/friend.model.ts
@@ -14,6 +14,7 @@ export interface FriendModel {
   chatId?: number;
   isOnline?: boolean;
   friendsChatDto?: { chatId?: number };
+  hasInvitation?:boolean;
 }
 
 export type FriendStatus = 'FRIEND' | 'REQUEST' | 'REJECTED' | null;

--- a/src/app/main/service/habit/habit.service.ts
+++ b/src/app/main/service/habit/habit.service.ts
@@ -11,6 +11,7 @@ import { ToDoList } from '@global-user/models/to-do-list.interface';
 import { CustomHabitDtoRequest, CustomHabit } from '@global-user/components/habit/models/interfaces/custom-habit.interface';
 import { FriendProfilePicturesArrayModel } from '@global-user/models/friend.model';
 import { FileHandle } from '@eco-news-models/create-news-interface';
+import { FriendArrayModel } from '../../component/user/models/friend.model';
 
 @Injectable({
   providedIn: 'root'
@@ -78,6 +79,12 @@ export class HabitService {
 
   getFriendsTrakingSameHabitByHabitAssignId(assignId: number): Observable<FriendProfilePicturesArrayModel[]> {
     return this.http.get<FriendProfilePicturesArrayModel[]>(`${habitLink}/${assignId}/friends/profile-pictures`);
+  }
+
+  getFriendsWithInvitations(habitId: number, page: number, size: number): Observable<FriendArrayModel> {
+    return this.http.get<FriendArrayModel>(
+      `${habitLink}/friends?habitId=${habitId}&page=${page}&size=${size}`
+    );
   }
 
   deleteCustomHabit(id: number): Observable<CustomHabitDtoRequest> {


### PR DESCRIPTION
[#7874](https://github.com/ita-social-projects/GreenCity/issues/7874), [#7876](https://github.com/ita-social-projects/GreenCity/issues/7876) 

- An error occurred when inviting a friend who was already invited to a habit.

- Clicking the "Invite All" button selected all checkboxes, but the "Invite Friends" button remained disabled.

##
**Result**
#### After discussing with the backend team, a new endpoint was created to fetch friends with a hasInvitation flag. This allows identifying which friends have already been invited.
- [x] Updated Endpoint in getFriends()
- [x] Modified onFriendCheckboxChange() to prevent changes for friends with active invitations.
- [x] Updated setFriendDisable() to use the hasInvitation flag instead of multiple conditions.
- [x] Ensured setAll() only applies to friends without invitations.



https://github.com/user-attachments/assets/d0f0df72-ee1d-4e45-9867-1f27ba6e94a1



