### PR TITLE
[Bugfix] #7987 Fixed incorrect vertical alignment in the calendar

### DIFF
--- a/src/app/main/component/user/components/profile/calendar/calendar.component.scss
+++ b/src/app/main/component/user/components/profile/calendar/calendar.component.scss
@@ -1,3 +1,5 @@
+@import 'src/typography/_resp.scss';
+
 .calendar {
   display: block;
   background: var(--primary-white);
@@ -210,17 +212,19 @@
   border-radius: 4px;
 }
 
-@media (min-width: 1024px) and (max-width: 1199px) {
+@include responsiveRange(xl, 3xl) {
   .calendar {
-    .top {
-      .days {
-        grid-template-columns: repeat(7, 30px);
+    &.habit {
+      .top {
+        .days {
+          grid-template-columns: repeat(7, 46px);
+        }
       }
     }
   }
 }
 
-@media (max-width: 1023px) {
+@include responsivePCFirst(xl) {
   .calendar {
     .top {
       .days {


### PR DESCRIPTION
[#7987](https://github.com/ita-social-projects/GreenCity/issues/7987)
##
**before**
<img width="1161" alt="Знімок екрана 2025-01-07 о 12 02 42" src="https://github.com/user-attachments/assets/3839829f-c368-4b74-9054-846321e9cfe9" />

**after**
<img width="1208" alt="Знімок екрана 2025-01-07 о 12 02 54" src="https://github.com/user-attachments/assets/08cd4850-65e1-479d-b134-a18af6c725a1" />
