### PR TITLE
[Feat] #7970 Settings and functionality of different profile privacy states 

### DIFF
--- a/src/app/main/component/comments/components/add-comment/add-comment.component.spec.ts
+++ b/src/app/main/component/comments/components/add-comment/add-comment.component.spec.ts
@@ -8,13 +8,13 @@ import { AddCommentComponent } from './add-comment.component';
 import { UserProfileImageComponent } from '@global-user/components/shared/components/user-profile-image/user-profile-image.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { CommentsService } from '../../services/comments.service';
-import { EditProfileModel } from '@global-user/models/edit-profile.model';
 import { CommentTextareaComponent } from '../comment-textarea/comment-textarea.component';
 import { PlaceholderForDivDirective } from '../../directives/placeholder-for-div.directive';
 import { SocketService } from '@global-service/socket/socket.service';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
 import { CommentFormData } from '../../models/comments-model';
+import { mockUserData } from '@global-user/mocks/edit-profile-mock';
 
 const COMMENT_MOCK = {
   author: {
@@ -31,26 +31,8 @@ describe('AddCommentComponent', () => {
   let component: AddCommentComponent;
   let fixture: ComponentFixture<AddCommentComponent>;
 
-  const defaultImagePath =
-    'https://csb10032000a548f571.blob.core.windows.net/allfiles/90370622-3311-4ff1-9462-20cc98a64d1ddefault_image.jpg';
-
-  const userData = {
-    userLocationDto: {
-      cityUa: 'Місто',
-      cityEn: 'City'
-    },
-    name: 'string',
-    userCredo: 'string',
-    profilePicturePath: defaultImagePath,
-    rating: null,
-    showEcoPlace: 'PUBLIC',
-    showLocation: 'PUBLIC',
-    showToDoList: 'PUBLIC',
-    socialNetworks: [{ id: 1, url: defaultImagePath }]
-  } as EditProfileModel;
-
   const profileServiceMock: ProfileService = jasmine.createSpyObj('ProfileService', ['getUserInfo']);
-  profileServiceMock.getUserInfo = () => of(userData);
+  profileServiceMock.getUserInfo = () => of(mockUserData);
 
   const commentsServiceMock: jasmine.SpyObj<CommentsService> = jasmine.createSpyObj('CommentsService', ['addComment']);
   commentsServiceMock.addComment.and.returnValue(of(COMMENT_MOCK));

--- a/src/app/main/component/comments/components/add-comment/add-comment.component.spec.ts
+++ b/src/app/main/component/comments/components/add-comment/add-comment.component.spec.ts
@@ -43,9 +43,9 @@ describe('AddCommentComponent', () => {
     userCredo: 'string',
     profilePicturePath: defaultImagePath,
     rating: null,
-    showEcoPlace: true,
-    showLocation: true,
-    showToDoList: true,
+    showEcoPlace: 'PUBLIC',
+    showLocation: 'PUBLIC',
+    showToDoList: 'PUBLIC',
     socialNetworks: [{ id: 1, url: defaultImagePath }]
   } as EditProfileModel;
 

--- a/src/app/main/component/user/components/habit/all-habits/all-habits.component.spec.ts
+++ b/src/app/main/component/user/components/habit/all-habits/all-habits.component.spec.ts
@@ -82,9 +82,9 @@ describe('AllHabitsComponent', () => {
     userCredo: 'string',
     profilePicturePath: defaultImagePath,
     rating: null,
-    showEcoPlace: true,
-    showLocation: true,
-    showToDoList: true,
+    showEcoPlace: 'PUBLIC',
+    showLocation: 'PUBLIC',
+    showToDoList: 'PUBLIC',
     socialNetworks: [{ id: 1, url: defaultImagePath }]
   } as EditProfileModel;
 

--- a/src/app/main/component/user/components/habit/all-habits/all-habits.component.spec.ts
+++ b/src/app/main/component/user/components/habit/all-habits/all-habits.component.spec.ts
@@ -15,11 +15,11 @@ import { EventEmitter, Injectable } from '@angular/core';
 import { ProfileService } from '@global-user/components/profile/profile-service/profile.service';
 import { Language } from 'src/app/main/i18n/Language';
 import { HABITLIST } from '../mocks/habit-mock';
-import { CUSTOMHABIT, DEFAULTHABIT, HABITSASSIGNEDLIST } from '../mocks/habit-assigned-mock';
-import { FIRSTTAGITEM, SECONDTAGITEM, TAGLIST } from '../mocks/tags-list-mock';
-import { EditProfileModel } from '@global-user/models/edit-profile.model';
+import { HABITSASSIGNEDLIST } from '../mocks/habit-assigned-mock';
+import { TAGLIST } from '../mocks/tags-list-mock';
 import { HabitsFiltersList } from '@global-user/components/habit/models/habits-filters-list';
 import { FilterOptions, FilterSelect } from 'src/app/main/interface/filter-select.interface';
+import { mockUserData } from '@global-user/mocks/edit-profile-mock';
 
 @Injectable()
 class TranslationServiceStub {
@@ -50,8 +50,6 @@ class TranslationServiceStub {
 describe('AllHabitsComponent', () => {
   let component: AllHabitsComponent;
   let fixture: ComponentFixture<AllHabitsComponent>;
-  const defaultImagePath =
-    'https://csb10032000a548f571.blob.core.windows.net/allfiles/90370622-3311-4ff1-9462-20cc98a64d1ddefault_image.jpg';
 
   const localStorageServiceMock: LocalStorageService = jasmine.createSpyObj('LocalStorageService', [
     'userIdBehaviourSubject',
@@ -74,22 +72,8 @@ describe('AllHabitsComponent', () => {
   habitServiceMock.getHabitsByFilters = () => of(HABITLIST);
   habitServiceMock.getAllTags = () => of(TAGLIST);
 
-  const userData = {
-    userLocationDto: {
-      cityUa: 'string'
-    },
-    name: 'string',
-    userCredo: 'string',
-    profilePicturePath: defaultImagePath,
-    rating: null,
-    showEcoPlace: 'PUBLIC',
-    showLocation: 'PUBLIC',
-    showToDoList: 'PUBLIC',
-    socialNetworks: [{ id: 1, url: defaultImagePath }]
-  } as EditProfileModel;
-
   const profileServiceMock: ProfileService = jasmine.createSpyObj('ProfileService', ['getUserInfo']);
-  profileServiceMock.getUserInfo = () => of(userData);
+  profileServiceMock.getUserInfo = () => of(mockUserData);
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile-form-builder.ts
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile-form-builder.ts
@@ -17,9 +17,9 @@ export class EditProfileFormBuilder {
       name: ['', Validators.maxLength(30)],
       city: ['', Validators.maxLength(85)],
       credo: ['', Validators.maxLength(170)],
-      showLocation: [false],
-      showEcoPlace: [false],
-      showToDoList: [false],
+      showLocation: ['PUBLIC'],
+      showEcoPlace: ['PUBLIC'],
+      showToDoList: ['PUBLIC'],
       socialNetworks: [''],
       emailPreferences: this.createEmailPreferencesGroup(null)
     });

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile-form-builder.ts
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile-form-builder.ts
@@ -17,9 +17,9 @@ export class EditProfileFormBuilder {
       name: ['', Validators.maxLength(30)],
       city: ['', Validators.maxLength(85)],
       credo: ['', Validators.maxLength(170)],
-      showLocation: ['PUBLIC'],
-      showEcoPlace: ['PUBLIC'],
-      showToDoList: ['PUBLIC'],
+      showLocation: ['PRIVATE'],
+      showEcoPlace: ['PRIVATE'],
+      showToDoList: ['PRIVATE'],
       socialNetworks: [''],
       emailPreferences: this.createEmailPreferencesGroup(null)
     });

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile-form-builder.ts
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile-form-builder.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ProfilePrivacyPolicy } from '@global-user/models/edit-profile-const';
 import { EditProfileModel, NotificationPreference, UserLocationDto } from '@global-user/models/edit-profile.model';
 import { LanguageService } from 'src/app/main/i18n/language.service';
 
@@ -17,9 +18,9 @@ export class EditProfileFormBuilder {
       name: ['', Validators.maxLength(30)],
       city: ['', Validators.maxLength(85)],
       credo: ['', Validators.maxLength(170)],
-      showLocation: ['PRIVATE'],
-      showEcoPlace: ['PRIVATE'],
-      showToDoList: ['PRIVATE'],
+      showLocation: [ProfilePrivacyPolicy.PRIVATE],
+      showEcoPlace: [ProfilePrivacyPolicy.PRIVATE],
+      showToDoList: [ProfilePrivacyPolicy.PRIVATE],
       socialNetworks: [''],
       emailPreferences: this.createEmailPreferencesGroup(null)
     });

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.html
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.html
@@ -52,9 +52,9 @@
           <p class="title">{{ 'user.edit-profile.privacy' | translate }}</p>
           <ul>
             <li *ngFor="let setting of privacySettingsList">
-              <label class="label-wrapper">
+              <div class="text-wrapper">
                 {{ setting.label | translate }}
-              </label>
+              </div>
               <div class="input-blocks">
                 <div class="input-wrapper">
                   <mat-select class="state-select" [formControlName]="setting.formControlName">

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.html
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.html
@@ -51,26 +51,19 @@
         <div class="privacy-wrapper">
           <p class="title">{{ 'user.edit-profile.privacy' | translate }}</p>
           <ul>
-            <li>
+            <li *ngFor="let setting of privacySettingsList">
               <label class="label-wrapper">
-                <input type="checkbox" formControlName="showLocation" />
-                <span class="checkmark"></span>
-                {{ 'user.edit-profile.location' | translate }}
+                {{ setting.label | translate }}
               </label>
-            </li>
-            <li>
-              <label class="label-wrapper">
-                <input type="checkbox" formControlName="showEcoPlace" />
-                <span class="checkmark"></span>
-                {{ 'user.edit-profile.eco-place' | translate }}
-              </label>
-            </li>
-            <li>
-              <label class="label-wrapper">
-                <input type="checkbox" formControlName="showToDoList" />
-                <span class="checkmark"></span>
-                {{ 'user.edit-profile.to-do-list' | translate }}
-              </label>
+              <div class="input-blocks">
+                <div class="input-wrapper">
+                  <mat-select class="state-select" [formControlName]="setting.formControlName">
+                    <mat-option class="option-state" *ngFor="let option of privacyOptions" [value]="option.value">
+                      {{ option.translationKey | translate }}
+                    </mat-option>
+                  </mat-select>
+                </div>
+              </div>
             </li>
           </ul>
         </div>

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.scss
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.scss
@@ -1,5 +1,3 @@
-@import 'src/typography/_resp.scss';
-
 .checkbox-container {
   .checkmark {
     border: 1px solid var(--quaternary-grey);
@@ -177,7 +175,7 @@ h2 {
       gap: 55px;
       margin-bottom: 9px;
 
-      @include responsiveMobileFirst(sm) {
+      @media screen and (max-width: 576px) {
         flex-direction: column;
         gap: 15px;
         align-items: stretch;

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.scss
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.scss
@@ -1,3 +1,5 @@
+@import 'src/typography/_resp.scss';
+
 .checkbox-container {
   .checkmark {
     border: 1px solid var(--quaternary-grey);
@@ -175,7 +177,7 @@ h2 {
       gap: 55px;
       margin-bottom: 9px;
 
-      @media screen and (max-width: 576px) {
+      @include responsiveMobileFirst(sm) {
         flex-direction: column;
         gap: 15px;
         align-items: stretch;
@@ -189,7 +191,7 @@ h2 {
         margin-bottom: 0;
       }
 
-      .label-wrapper {
+      .text-wrapper {
         font-family: var(--tertiary-font);
         font-size: 14px;
         color: var(--quaternary-dark-grey);
@@ -354,7 +356,7 @@ h2 {
         li {
           margin-bottom: 26px;
 
-          .label-wrapper {
+          .text-wrapper {
             font-size: 14px;
           }
 

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.scss
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.scss
@@ -175,6 +175,16 @@ h2 {
       gap: 55px;
       margin-bottom: 9px;
 
+      @media screen and (max-width: 576px) {
+        flex-direction: column;
+        gap: 15px;
+        align-items: stretch;
+
+        .input-blocks {
+          width: 100%;
+        }
+      }
+
       &:last-child {
         margin-bottom: 0;
       }

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.scss
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.scss
@@ -145,10 +145,7 @@ h2 {
   letter-spacing: 0.2px;
 }
 
-.privacy-wrapper,
-.email-preferences {
-  @extend .checkbox-container;
-
+.section-wrapper {
   border-bottom: 1px solid #e1e5e3;
   margin-top: 40px;
   padding-bottom: 34px;
@@ -162,6 +159,58 @@ h2 {
     color: var(--quaternary-dark-grey);
     margin-bottom: 32px;
   }
+}
+
+.privacy-wrapper {
+  @extend .section-wrapper;
+
+  ul {
+    padding: 0;
+    list-style: none;
+
+    li {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 55px;
+      margin-bottom: 9px;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+
+      .label-wrapper {
+        font-family: var(--tertiary-font);
+        font-size: 14px;
+        color: var(--quaternary-dark-grey);
+        flex: 1;
+      }
+
+      .input-blocks {
+        flex-shrink: 0;
+        width: 240px;
+        display: flex;
+        justify-content: flex-start;
+
+        .input-wrapper {
+          width: 100%;
+        }
+      }
+    }
+  }
+
+  .state-select {
+    text-overflow: ellipsis;
+    padding: 5px 15px;
+    font-size: 14px;
+    height: 36px;
+    width: 100%;
+  }
+}
+
+.email-preferences {
+  @extend .checkbox-container;
+  @extend .section-wrapper;
 
   ul {
     margin-bottom: 0;

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.spec.ts
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.spec.ts
@@ -264,9 +264,9 @@ describe('EditProfileComponent', () => {
         userCredo: 'My Credo is to make small steps that leads to huge impact. Let’s change the world together.',
         profilePicturePath: './assets/img/profileAvatarBig.png',
         rating: 658,
-        showEcoPlace: true,
-        showLocation: true,
-        showToDoList: true,
+        showEcoPlace: 'PUBLIC',
+        showLocation: 'PUBLIC',
+        showToDoList: 'PUBLIC',
         socialNetworks: [{ id: 220, url: 'http://instagram.com/profile' }]
       } as EditProfileModel;
     });

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.spec.ts
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.spec.ts
@@ -21,6 +21,7 @@ import { SharedMainModule } from '@shared/shared-main.module';
 import { InputGoogleAutocompleteComponent } from '@shared/components/input-google-autocomplete/input-google-autocomplete.component';
 import { MatSelectModule } from '@angular/material/select';
 import { ProfilePrivacyPolicy } from '@global-user/models/edit-profile-const';
+import { mockUserData } from '@global-user/mocks/edit-profile-mock';
 
 class Test {}
 
@@ -259,17 +260,7 @@ describe('EditProfileComponent', () => {
     beforeEach(() => {
       editProfileService = fixture.debugElement.injector.get(EditProfileService);
       profileService = fixture.debugElement.injector.get(ProfileService);
-      mockUserInfo = {
-        userLocationDto: { cityEn: 'Lviv' },
-        name: 'John',
-        userCredo: 'My Credo is to make small steps that leads to huge impact. Let’s change the world together.',
-        profilePicturePath: './assets/img/profileAvatarBig.png',
-        rating: 658,
-        showEcoPlace: 'PUBLIC',
-        showLocation: 'PUBLIC',
-        showToDoList: 'PUBLIC',
-        socialNetworks: [{ id: 220, url: 'http://instagram.com/profile' }]
-      } as EditProfileModel;
+      mockUserInfo = { ...mockUserData, name: 'John' };
     });
 
     it('getInitialValue should call ProfileService', () => {
@@ -287,7 +278,8 @@ describe('EditProfileComponent', () => {
 
   describe('Privacy Settings Tests', () => {
     it('should validate all privacy levels', () => {
-      const privacyLevels = ['PUBLIC', 'PRIVATE', 'FRIENDS_ONLY'];
+      const privacyLevels = Object.values(ProfilePrivacyPolicy);
+
       privacyLevels.forEach((level) => {
         component.editProfileForm.patchValue({
           showLocation: level,

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.spec.ts
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.spec.ts
@@ -20,6 +20,7 @@ import { Router } from '@angular/router';
 import { SharedMainModule } from '@shared/shared-main.module';
 import { InputGoogleAutocompleteComponent } from '@shared/components/input-google-autocomplete/input-google-autocomplete.component';
 import { MatSelectModule } from '@angular/material/select';
+import { ProfilePrivacyPolicy } from '@global-user/models/edit-profile-const';
 
 class Test {}
 
@@ -281,6 +282,20 @@ describe('EditProfileComponent', () => {
       const spy = spyOn(editProfileService, 'postDataUserProfile').and.returnValue(of(mockUserInfo));
       component.onSubmit();
       expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Privacy Settings Tests', () => {
+    it('should validate all privacy levels', () => {
+      const privacyLevels = ['PUBLIC', 'PRIVATE', 'FRIENDS_ONLY'];
+      privacyLevels.forEach((level) => {
+        component.editProfileForm.patchValue({
+          showLocation: level,
+          showEcoPlace: level,
+          showToDoList: level
+        });
+        expect(component.editProfileForm.valid).toBeTrue();
+      });
     });
   });
 });

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.ts
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.ts
@@ -20,7 +20,13 @@ import { FormBaseComponent } from '@shared/components/form-base/form-base.compon
 import { ReplaySubject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { Patterns } from 'src/assets/patterns/patterns';
-import { emailPreferencesList, periodicityOptions, privacyOptions, privacySettingsList } from '@global-user/models/edit-profile-const';
+import {
+  ProfilePrivacyPolicy,
+  emailPreferencesList,
+  periodicityOptions,
+  privacyOptions,
+  privacySettingsList
+} from '@global-user/models/edit-profile-const';
 
 @Component({
   selector: 'app-edit-profile',
@@ -195,9 +201,9 @@ export class EditProfileComponent extends FormBaseComponent implements OnInit, O
       coordinates: { longitude: this.coordinates.longitude, latitude: this.coordinates.latitude },
       name: form.value.name,
       userCredo: form.value.credo,
-      showLocation: this.editProfileForm.value.showLocation || 'PUBLIC',
-      showEcoPlace: this.editProfileForm.value.showEcoPlace || 'PUBLIC',
-      showToDoList: this.editProfileForm.value.showToDoList || 'PUBLIC',
+      showLocation: this.editProfileForm.value.showLocation || ProfilePrivacyPolicy.PRIVATE,
+      showEcoPlace: this.editProfileForm.value.showEcoPlace || ProfilePrivacyPolicy.PRIVATE,
+      showToDoList: this.editProfileForm.value.showToDoList || ProfilePrivacyPolicy.PRIVATE,
       socialNetworks: this.socialNetworksToServer,
       emailPreferences: emailPreferences.length > 0 ? emailPreferences : null
     };

--- a/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.ts
+++ b/src/app/main/component/user/components/profile/edit-profile/edit-profile.component.ts
@@ -20,7 +20,7 @@ import { FormBaseComponent } from '@shared/components/form-base/form-base.compon
 import { ReplaySubject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { Patterns } from 'src/assets/patterns/patterns';
-import { emailPreferencesList, periodicityOptions } from '@global-user/models/edit-profile-const';
+import { emailPreferencesList, periodicityOptions, privacyOptions, privacySettingsList } from '@global-user/models/edit-profile-const';
 
 @Component({
   selector: 'app-edit-profile',
@@ -39,6 +39,8 @@ export class EditProfileComponent extends FormBaseComponent implements OnInit, O
   placeService: PlaceService;
   emailPreferencesList = emailPreferencesList;
   periodicityOptions = periodicityOptions;
+  privacyOptions = privacyOptions;
+  privacySettingsList = privacySettingsList;
   private editProfileService: EditProfileService;
   private profileService: ProfileService;
   private snackBar: MatSnackBarComponent;
@@ -193,9 +195,9 @@ export class EditProfileComponent extends FormBaseComponent implements OnInit, O
       coordinates: { longitude: this.coordinates.longitude, latitude: this.coordinates.latitude },
       name: form.value.name,
       userCredo: form.value.credo,
-      showLocation: !!form.value.showLocation,
-      showEcoPlace: !!form.value.showEcoPlace,
-      showToDoList: !!form.value.showToDoList,
+      showLocation: this.editProfileForm.value.showLocation || 'PUBLIC',
+      showEcoPlace: this.editProfileForm.value.showEcoPlace || 'PUBLIC',
+      showToDoList: this.editProfileForm.value.showToDoList || 'PUBLIC',
       socialNetworks: this.socialNetworksToServer,
       emailPreferences: emailPreferences.length > 0 ? emailPreferences : null
     };

--- a/src/app/main/component/user/components/profile/profile-service/profile.service.spec.ts
+++ b/src/app/main/component/user/components/profile/profile-service/profile.service.spec.ts
@@ -7,6 +7,7 @@ import { TestBed } from '@angular/core/testing';
 import { ProfileService } from './profile.service';
 import { environment } from '@environment/environment';
 import { FactOfTheDay } from '@global-user/models/factOfTheDay';
+import { mockUserData } from '@global-user/mocks/edit-profile-mock';
 
 describe('ProfileService', () => {
   const backUserLink = environment.backendUserLink;
@@ -75,17 +76,7 @@ describe('ProfileService', () => {
 
   describe('test for method which get info about user', () => {
     it('should return user info', () => {
-      const userInfo = {
-        city: 'Lviv',
-        firstName: 'Anton',
-        userCredo: 'Eco',
-        profilePicturePath: 'somepath',
-        rating: 1999,
-        showEcoPlace: true,
-        showLocation: false,
-        showToDoList: true,
-        socialNetworks: []
-      };
+      const userInfo = { ...mockUserData, name: 'John', rating: 1999 };
 
       profileService.getUserInfo().subscribe((info) => {
         expect(info.rating).toBe(1999);

--- a/src/app/main/component/user/components/profile/profile-service/profile.service.ts
+++ b/src/app/main/component/user/components/profile/profile-service/profile.service.ts
@@ -8,6 +8,8 @@ import { ProfileStatistics } from '@user-models/profile-statistiscs';
 import { EditProfileModel } from '@user-models/edit-profile.model';
 import { mainLink, mainUserLink } from 'src/app/main/links';
 import { Patterns } from 'src/assets/patterns/patterns';
+import { FriendStatusValues, UserDataAsFriend } from '@global-user/models/friend.model';
+import { ProfilePrivacyPolicy } from '@global-user/models/edit-profile-const';
 
 @Injectable({
   providedIn: 'root'
@@ -70,5 +72,18 @@ export class ProfileService {
     const regex = Patterns.socialMediaPattern;
     const match = regex.exec(url);
     return match?.[1] || null;
+  }
+
+  isContentVisible(privacySetting: string, isCurrentUser: boolean, userAsFriend?: UserDataAsFriend): boolean {
+    switch (privacySetting) {
+      case ProfilePrivacyPolicy.PRIVATE:
+        return isCurrentUser;
+      case ProfilePrivacyPolicy.FRIENDS_ONLY:
+        return isCurrentUser || userAsFriend?.friendStatus === FriendStatusValues.FRIEND;
+      case ProfilePrivacyPolicy.PUBLIC:
+        return true;
+      default:
+        return false;
+    }
   }
 }

--- a/src/app/main/component/user/components/profile/profile-service/profile.service.ts
+++ b/src/app/main/component/user/components/profile/profile-service/profile.service.ts
@@ -75,6 +75,10 @@ export class ProfileService {
   }
 
   isContentVisible(privacySetting: ProfilePrivacyPolicy, isCurrentUser: boolean, userAsFriend?: UserDataAsFriend): boolean {
+    if (!privacySetting) {
+      return false;
+    }
+
     switch (privacySetting) {
       case ProfilePrivacyPolicy.PRIVATE:
         return isCurrentUser;

--- a/src/app/main/component/user/components/profile/profile-service/profile.service.ts
+++ b/src/app/main/component/user/components/profile/profile-service/profile.service.ts
@@ -5,7 +5,7 @@ import { FactOfTheDay } from '@global-user/models/factOfTheDay';
 import { HttpClient } from '@angular/common/http';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { ProfileStatistics } from '@user-models/profile-statistiscs';
-import { EditProfileModel, PrivacyState } from '@user-models/edit-profile.model';
+import { EditProfileModel } from '@user-models/edit-profile.model';
 import { mainLink, mainUserLink } from 'src/app/main/links';
 import { Patterns } from 'src/assets/patterns/patterns';
 import { FriendStatusValues, UserDataAsFriend } from '@global-user/models/friend.model';
@@ -74,7 +74,7 @@ export class ProfileService {
     return match?.[1] || null;
   }
 
-  isContentVisible(privacySetting: PrivacyState, isCurrentUser: boolean, userAsFriend?: UserDataAsFriend): boolean {
+  isContentVisible(privacySetting: ProfilePrivacyPolicy, isCurrentUser: boolean, userAsFriend?: UserDataAsFriend): boolean {
     switch (privacySetting) {
       case ProfilePrivacyPolicy.PRIVATE:
         return isCurrentUser;

--- a/src/app/main/component/user/components/profile/profile-service/profile.service.ts
+++ b/src/app/main/component/user/components/profile/profile-service/profile.service.ts
@@ -5,7 +5,7 @@ import { FactOfTheDay } from '@global-user/models/factOfTheDay';
 import { HttpClient } from '@angular/common/http';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
 import { ProfileStatistics } from '@user-models/profile-statistiscs';
-import { EditProfileModel } from '@user-models/edit-profile.model';
+import { EditProfileModel, PrivacyState } from '@user-models/edit-profile.model';
 import { mainLink, mainUserLink } from 'src/app/main/links';
 import { Patterns } from 'src/assets/patterns/patterns';
 import { FriendStatusValues, UserDataAsFriend } from '@global-user/models/friend.model';
@@ -74,7 +74,7 @@ export class ProfileService {
     return match?.[1] || null;
   }
 
-  isContentVisible(privacySetting: string, isCurrentUser: boolean, userAsFriend?: UserDataAsFriend): boolean {
+  isContentVisible(privacySetting: PrivacyState, isCurrentUser: boolean, userAsFriend?: UserDataAsFriend): boolean {
     switch (privacySetting) {
       case ProfilePrivacyPolicy.PRIVATE:
         return isCurrentUser;

--- a/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.html
+++ b/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.html
@@ -26,6 +26,7 @@
     </p>
     <p
       class="location"
+      *ngIf="isContentVisible(userInfo?.showLocation)"
       appCustomTooltip
       #tooltipLocation="matTooltip"
       [appCustomTooltip]="getUserCity(userInfo.userLocationDto)"

--- a/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.spec.ts
+++ b/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.spec.ts
@@ -56,9 +56,9 @@ describe('ProfileHeaderComponent', () => {
       userCredo: 'credo',
       profilePicturePath: '',
       rating: 2,
-      showEcoPlace: false,
-      showLocation: false,
-      showToDoList: false,
+      showEcoPlace: 'PUBLIC',
+      showLocation: 'PUBLIC',
+      showToDoList: 'PUBLIC',
       socialNetworks: [{ id: 220, url: 'http://instagram' }]
     } as EditProfileModel;
     fixture.detectChanges();

--- a/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.spec.ts
+++ b/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.spec.ts
@@ -119,4 +119,18 @@ describe('ProfileHeaderComponent', () => {
     expect(languageServiceMock.getUserCity).toHaveBeenCalledWith(userLocationDto);
     expect(result).toEqual('Kyiv, Країна');
   });
+
+  it('should display city only to friends when showLocation is FRIENDS_ONLY', () => {
+    component.userInfo.showLocation = 'FRIENDS_ONLY';
+    spyOn(component, 'isContentVisible').and.returnValue(true);
+    const result = component.getUserCity(userLocationDto);
+    expect(result).toBe('Місто, Країна');
+  });
+
+  it('should display city when showLocation is PUBLIC', () => {
+    component.userInfo.showLocation = 'PUBLIC';
+    spyOn(component, 'isContentVisible').and.returnValue(true);
+    const result = component.getUserCity(userLocationDto);
+    expect(result).toBe('Місто, Країна');
+  });
 });

--- a/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.spec.ts
+++ b/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.spec.ts
@@ -7,7 +7,7 @@ import { BehaviorSubject } from 'rxjs';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TranslateModule, TranslateStore } from '@ngx-translate/core';
 import { ProfileService } from 'src/app/main/component/user/components/profile/profile-service/profile.service';
-import { EditProfileModel, UserLocationDto } from '@global-user/models/edit-profile.model';
+import { UserLocationDto } from '@global-user/models/edit-profile.model';
 import { LanguageService } from 'src/app/main/i18n/language.service';
 import { Language } from 'src/app/main/i18n/Language';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -15,6 +15,8 @@ import { UserProfileImageComponent } from '@global-user/components/shared/compon
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { UserOnlineStatusService } from '@global-user/services/user-online-status.service';
 import { routes } from 'src/app/app-routing.module';
+import { ProfilePrivacyPolicy } from '@global-user/models/edit-profile-const';
+import { mockUserData } from '@global-user/mocks/edit-profile-mock';
 
 describe('ProfileHeaderComponent', () => {
   let component: ProfileHeaderComponent;
@@ -48,19 +50,7 @@ describe('ProfileHeaderComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ProfileHeaderComponent);
     component = fixture.componentInstance;
-    component.userInfo = {
-      userLocationDto: {
-        cityEn: 'City'
-      },
-      name: 'name',
-      userCredo: 'credo',
-      profilePicturePath: '',
-      rating: 2,
-      showEcoPlace: 'PUBLIC',
-      showLocation: 'PUBLIC',
-      showToDoList: 'PUBLIC',
-      socialNetworks: [{ id: 220, url: 'http://instagram' }]
-    } as EditProfileModel;
+    component.userInfo = { ...mockUserData, name: 'John' };
     fixture.detectChanges();
     profileService = TestBed.inject(ProfileService);
     profileService.icons = {
@@ -121,14 +111,14 @@ describe('ProfileHeaderComponent', () => {
   });
 
   it('should display city only to friends when showLocation is FRIENDS_ONLY', () => {
-    component.userInfo.showLocation = 'FRIENDS_ONLY';
+    component.userInfo.showLocation = ProfilePrivacyPolicy.FRIENDS_ONLY;
     spyOn(component, 'isContentVisible').and.returnValue(true);
     const result = component.getUserCity(userLocationDto);
     expect(result).toBe('Місто, Країна');
   });
 
   it('should display city when showLocation is PUBLIC', () => {
-    component.userInfo.showLocation = 'PUBLIC';
+    component.userInfo.showLocation = ProfilePrivacyPolicy.PUBLIC;
     spyOn(component, 'isContentVisible').and.returnValue(true);
     const result = component.getUserCity(userLocationDto);
     expect(result).toBe('Місто, Країна');

--- a/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.ts
+++ b/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.ts
@@ -10,7 +10,6 @@ import { LanguageService } from 'src/app/main/i18n/language.service';
 import { UserOnlineStatusService } from '@global-user/services/user-online-status.service';
 import { UserDataAsFriend, UsersCategOnlineStatus } from '@global-user/models/friend.model';
 import { UserFriendsService } from '@global-user/services/user-friends.service';
-import { ProfilePrivacyPolicy } from '@global-user/models/edit-profile-const';
 
 @Component({
   selector: 'app-profile-header',
@@ -40,12 +39,12 @@ export class ProfileHeaderComponent implements OnInit, OnDestroy {
   showEditButton: boolean;
 
   constructor(
-    private localStorageService: LocalStorageService,
-    private route: ActivatedRoute,
-    private profileService: ProfileService,
-    private langService: LanguageService,
-    private userOnlineStatusService: UserOnlineStatusService,
-    private userFriendsService: UserFriendsService
+    private readonly localStorageService: LocalStorageService,
+    private readonly route: ActivatedRoute,
+    private readonly profileService: ProfileService,
+    private readonly langService: LanguageService,
+    private readonly userOnlineStatusService: UserOnlineStatusService,
+    private readonly userFriendsService: UserFriendsService
   ) {}
 
   ngOnInit() {

--- a/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.ts
+++ b/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Input, OnDestroy } from '@angular/core';
 import { Subject, Subscription } from 'rxjs';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
-import { EditProfileModel, UserLocationDto } from '@user-models/edit-profile.model';
+import { EditProfileModel, PrivacyState, UserLocationDto } from '@user-models/edit-profile.model';
 import { ProfileStatistics } from '@global-user/models/profile-statistiscs';
 import { ActivatedRoute } from '@angular/router';
 import { takeUntil } from 'rxjs/operators';
@@ -10,6 +10,7 @@ import { LanguageService } from 'src/app/main/i18n/language.service';
 import { UserOnlineStatusService } from '@global-user/services/user-online-status.service';
 import { UserDataAsFriend, UsersCategOnlineStatus } from '@global-user/models/friend.model';
 import { UserFriendsService } from '@global-user/services/user-friends.service';
+import { ProfilePrivacyPolicy } from '@global-user/models/edit-profile-const';
 
 @Component({
   selector: 'app-profile-header',
@@ -111,7 +112,10 @@ export class ProfileHeaderComponent implements OnInit, OnDestroy {
     }));
   }
 
-  isContentVisible(privacySetting: string): boolean {
+  isContentVisible(privacySetting: PrivacyState): boolean {
+    if (!privacySetting) {
+      return false;
+    }
     return this.profileService.isContentVisible(privacySetting, this.isCurrentUserProfile, this.userAsFriend);
   }
 

--- a/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.ts
+++ b/src/app/main/component/user/components/profile/profile-widget/profile-header/profile-header.component.ts
@@ -48,32 +48,25 @@ export class ProfileHeaderComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.initializeUserId();
+    this.setupUserDetails();
     this.buildSocialNetworksChart();
     this.checkEditButtonVisibility();
-    this.setProfileUserId();
-    this.checkCurrentUserProfile();
-    this.handleUserOnlineStatus();
-    this.fetchUserDataAsFriend();
+    this.icons = this.profileService.icons;
   }
 
-  private initializeUserId() {
+  private setupUserDetails() {
     this.userId$ = this.localStorageService.userIdBehaviourSubject.pipe(takeUntil(this.destroy$)).subscribe((userId) => {
       this.userId = userId;
+      this.profileUserId = +this.route.snapshot.params.userId;
+      this.isCurrentUserProfile = !this.profileUserId || this.profileUserId === this.userId;
+
+      this.handleUserOnlineStatus();
+      this.fetchUserDataAsFriend();
     });
   }
 
   private checkEditButtonVisibility() {
     this.showEditButton = this.route.snapshot.params.userName === this.userInfo.name;
-    this.icons = this.profileService.icons;
-  }
-
-  private setProfileUserId() {
-    this.profileUserId = +this.route.snapshot.params.userId;
-  }
-
-  private checkCurrentUserProfile() {
-    this.isCurrentUserProfile = !this.profileUserId || this.profileUserId === this.userId;
   }
 
   private handleUserOnlineStatus() {
@@ -134,9 +127,6 @@ export class ProfileHeaderComponent implements OnInit, OnDestroy {
   }
 
   isContentVisible(privacySetting: ProfilePrivacyPolicy): boolean {
-    if (!privacySetting) {
-      return false;
-    }
     return this.profileService.isContentVisible(privacySetting, this.isCurrentUserProfile, this.userAsFriend);
   }
 

--- a/src/app/main/component/user/components/profile/profile.component.spec.ts
+++ b/src/app/main/component/user/components/profile/profile.component.spec.ts
@@ -7,22 +7,19 @@ import { of } from 'rxjs';
 import { ProfileService } from './profile-service/profile.service';
 
 import { ProfileComponent } from './profile.component';
+import { mockUserData } from '@global-user/mocks/edit-profile-mock';
 
 describe('ProfileComponent', () => {
   let component: ProfileComponent;
   let fixture: ComponentFixture<ProfileComponent>;
 
-  const fakeItem = {
-    city: 'fakeCity',
-    showToDoList: false
-  };
   const liveAnnouncerMock = jasmine.createSpyObj('announcer', ['announce']);
   const localStorageServiceMock = jasmine.createSpyObj('localStorageService', ['getCurrentLanguage', 'setCurentPage']);
   localStorageServiceMock.getCurrentLanguage.and.returnValue('ua');
   localStorageServiceMock.languageSubject = of('en');
   const profileServiceMock = jasmine.createSpyObj('profileService', ['getUserInfo', 'getUserProfileStatistics']);
   profileServiceMock.getUserProfileStatistics.and.returnValue(of('fakeStatistics' as any));
-  profileServiceMock.getUserInfo.and.returnValue(of(fakeItem as any));
+  profileServiceMock.getUserInfo.and.returnValue(of(mockUserData));
   const translateServiceMock = jasmine.createSpyObj('translate', ['setDefaultLang']);
 
   beforeEach(waitForAsync(() => {
@@ -71,6 +68,6 @@ describe('ProfileComponent', () => {
 
   it('showUserInfo makes expected calls', () => {
     component.showUserInfo();
-    expect(component.userInfo).toEqual(fakeItem as any);
+    expect(component.userInfo).toEqual(mockUserData);
   });
 });

--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.html
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.html
@@ -6,8 +6,8 @@
       <app-friendship-buttons [userAsFriend]="userAsFriend"></app-friendship-buttons>
     </div>
     <app-users-achievements class="app-users-achivements"></app-users-achievements>
-    <app-eco-places class="app-eco-places" *ngIf="userInfo.showEcoPlace"></app-eco-places>
-    <app-to-do-list class="app-to-do-list" *ngIf="userInfo.showToDoList"></app-to-do-list>
+    <app-eco-places class="app-eco-places" *ngIf="isContentVisible(userInfo?.showEcoPlace)"></app-eco-places>
+    <app-to-do-list class="app-to-do-list" *ngIf="isContentVisible(userInfo?.showToDoList)"></app-to-do-list>
   </div>
   <div class="container">
     <div class="content">

--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.spec.ts
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.spec.ts
@@ -7,6 +7,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { BehaviorSubject, of, Subject } from 'rxjs';
 import { FriendProfilePageComponent } from './friend-profile-page.component';
 import { FRIENDS, UserAsFriend } from '@global-user/mocks/friends-mock';
+import { HttpClientModule } from '@angular/common/http';
 
 describe('FriendProfilePageComponent', () => {
   let component: FriendProfilePageComponent;
@@ -50,9 +51,9 @@ describe('FriendProfilePageComponent', () => {
         { provide: ActivatedRoute, useValue: activatedRouteMock },
         { provide: Router, useValue: {} },
         { provide: LocalStorageService, useValue: localStorageServiceMock },
-        { privide: TranslateService, useValue: translateServiseMock }
+        { provide: TranslateService, useValue: translateServiseMock }
       ],
-      imports: [TranslateModule.forRoot()],
+      imports: [HttpClientModule, TranslateModule.forRoot()],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
   });

--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.ts
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.ts
@@ -75,9 +75,6 @@ export class FriendProfilePageComponent implements OnInit, OnDestroy {
   }
 
   isContentVisible(privacySetting: ProfilePrivacyPolicy): boolean {
-    if (!privacySetting) {
-      return false;
-    }
     return this.profileService.isContentVisible(privacySetting, this.loggedInUserId === this.profileUserId, this.userAsFriend);
   }
 

--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.ts
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
-import { EditProfileModel } from '@global-user/models/edit-profile.model';
+import { EditProfileModel, PrivacyState } from '@global-user/models/edit-profile.model';
 import { ProfileStatistics } from '@global-user/models/profile-statistiscs';
 import { UserFriendsService } from '@global-user/services/user-friends.service';
 import { UserDataAsFriend, FriendStatusValues } from '@global-user/models/friend.model';
@@ -9,6 +9,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ProfileService } from '@global-user/components/profile/profile-service/profile.service';
+import { ProfilePrivacyPolicy } from '@global-user/models/edit-profile-const';
 
 @Component({
   selector: 'app-friend-profile-page',
@@ -73,7 +74,10 @@ export class FriendProfilePageComponent implements OnInit, OnDestroy {
       });
   }
 
-  isContentVisible(privacySetting: string): boolean {
+  isContentVisible(privacySetting: PrivacyState): boolean {
+    if (!privacySetting) {
+      return false;
+    }
     return this.profileService.isContentVisible(privacySetting, this.loggedInUserId === this.profileUserId, this.userAsFriend);
   }
 

--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.ts
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { LocalStorageService } from '@global-service/localstorage/local-storage.service';
-import { EditProfileModel, PrivacyState } from '@global-user/models/edit-profile.model';
+import { EditProfileModel } from '@global-user/models/edit-profile.model';
 import { ProfileStatistics } from '@global-user/models/profile-statistiscs';
 import { UserFriendsService } from '@global-user/services/user-friends.service';
 import { UserDataAsFriend, FriendStatusValues } from '@global-user/models/friend.model';
@@ -9,6 +9,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ProfileService } from '@global-user/components/profile/profile-service/profile.service';
+import { ProfilePrivacyPolicy } from '@global-user/models/edit-profile-const';
 
 @Component({
   selector: 'app-friend-profile-page',
@@ -73,7 +74,7 @@ export class FriendProfilePageComponent implements OnInit, OnDestroy {
       });
   }
 
-  isContentVisible(privacySetting: PrivacyState): boolean {
+  isContentVisible(privacySetting: ProfilePrivacyPolicy): boolean {
     if (!privacySetting) {
       return false;
     }

--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.ts
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.ts
@@ -9,7 +9,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ProfileService } from '@global-user/components/profile/profile-service/profile.service';
-import { ProfilePrivacyPolicy } from '@global-user/models/edit-profile-const';
 
 @Component({
   selector: 'app-friend-profile-page',
@@ -27,11 +26,11 @@ export class FriendProfilePageComponent implements OnInit, OnDestroy {
   friendStatus = FriendStatusValues;
 
   constructor(
-    private userFriendsService: UserFriendsService,
-    private route: ActivatedRoute,
-    private translate: TranslateService,
-    private localStorageService: LocalStorageService,
-    private profileService: ProfileService
+    private readonly userFriendsService: UserFriendsService,
+    private readonly route: ActivatedRoute,
+    private readonly translate: TranslateService,
+    private readonly localStorageService: LocalStorageService,
+    private readonly profileService: ProfileService
   ) {}
 
   ngOnInit() {

--- a/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.ts
+++ b/src/app/main/component/user/components/profile/users-friends/friend-dashboard/friend-profile-page/friend-profile-page.component.ts
@@ -8,6 +8,7 @@ import { UserDataAsFriend, FriendStatusValues } from '@global-user/models/friend
 import { TranslateService } from '@ngx-translate/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { ProfileService } from '@global-user/components/profile/profile-service/profile.service';
 
 @Component({
   selector: 'app-friend-profile-page',
@@ -28,7 +29,8 @@ export class FriendProfilePageComponent implements OnInit, OnDestroy {
     private userFriendsService: UserFriendsService,
     private route: ActivatedRoute,
     private translate: TranslateService,
-    private localStorageService: LocalStorageService
+    private localStorageService: LocalStorageService,
+    private profileService: ProfileService
   ) {}
 
   ngOnInit() {
@@ -69,6 +71,10 @@ export class FriendProfilePageComponent implements OnInit, OnDestroy {
       .subscribe((data) => {
         this.progress = data;
       });
+  }
+
+  isContentVisible(privacySetting: string): boolean {
+    return this.profileService.isContentVisible(privacySetting, this.loggedInUserId === this.profileUserId, this.userAsFriend);
   }
 
   ngOnDestroy() {

--- a/src/app/main/component/user/mocks/edit-profile-mock.ts
+++ b/src/app/main/component/user/mocks/edit-profile-mock.ts
@@ -1,0 +1,19 @@
+import { ProfilePrivacyPolicy } from '@global-user/models/edit-profile-const';
+import { EditProfileModel } from '@global-user/models/edit-profile.model';
+
+export const defaultImagePath =
+  'https://csb10032000a548f571.blob.core.windows.net/allfiles/90370622-3311-4ff1-9462-20cc98a64d1ddefault_image.jpg';
+
+export const mockUserData: EditProfileModel = {
+  userLocationDto: {
+    cityUa: 'Місто'
+  },
+  name: 'string',
+  userCredo: 'string',
+  profilePicturePath: defaultImagePath,
+  rating: null,
+  showEcoPlace: ProfilePrivacyPolicy.PUBLIC,
+  showLocation: ProfilePrivacyPolicy.PUBLIC,
+  showToDoList: ProfilePrivacyPolicy.PUBLIC,
+  socialNetworks: [{ id: 1, url: defaultImagePath }]
+} as EditProfileModel;

--- a/src/app/main/component/user/models/edit-profile-const.ts
+++ b/src/app/main/component/user/models/edit-profile-const.ts
@@ -14,3 +14,21 @@ export const periodicityOptions = [
   { value: 'WEEKLY', label: 'weekly' },
   { value: 'NEVER', label: 'never' }
 ];
+
+export enum ProfilePrivacyPolicy {
+  PRIVATE = 'PRIVATE',
+  FRIENDS_ONLY = 'FRIENDS_ONLY',
+  PUBLIC = 'PUBLIC'
+}
+
+export const privacyOptions = [
+  { value: ProfilePrivacyPolicy.PRIVATE, translationKey: 'user.edit-profile.privacy-options.private' },
+  { value: ProfilePrivacyPolicy.FRIENDS_ONLY, translationKey: 'user.edit-profile.privacy-options.friends_only' },
+  { value: ProfilePrivacyPolicy.PUBLIC, translationKey: 'user.edit-profile.privacy-options.public' }
+];
+
+export const privacySettingsList = [
+  { label: 'user.edit-profile.location', formControlName: 'showLocation' },
+  { label: 'user.edit-profile.eco-place', formControlName: 'showEcoPlace' },
+  { label: 'user.edit-profile.to-do-list', formControlName: 'showToDoList' }
+];

--- a/src/app/main/component/user/models/edit-profile.model.ts
+++ b/src/app/main/component/user/models/edit-profile.model.ts
@@ -4,9 +4,9 @@ export class EditProfileModel {
   userCredo: string;
   profilePicturePath: string;
   rating: number | null;
-  showEcoPlace: string;
-  showLocation: string;
-  showToDoList: string;
+  showEcoPlace: PrivacyState;
+  showLocation: PrivacyState;
+  showToDoList: PrivacyState;
   socialNetworks: Array<{ id: number; url: string }>;
   notificationPreferences: NotificationPreference[];
 }
@@ -15,9 +15,9 @@ export class EditProfileDto {
   coordinates: Coordinates;
   name: string;
   userCredo: string;
-  showEcoPlace: string;
-  showLocation: string;
-  showToDoList: string;
+  showEcoPlace: PrivacyState;
+  showLocation: PrivacyState;
+  showToDoList: PrivacyState;
   socialNetworks: Array<string>;
   emailPreferences: NotificationPreference[];
 }
@@ -43,3 +43,5 @@ export interface NotificationPreference {
   emailPreference: string;
   periodicity: string;
 }
+
+export type PrivacyState = 'PUBLIC' | 'PRIVATE' | 'FRIENDS_ONLY';

--- a/src/app/main/component/user/models/edit-profile.model.ts
+++ b/src/app/main/component/user/models/edit-profile.model.ts
@@ -1,12 +1,14 @@
+import { ProfilePrivacyPolicy } from './edit-profile-const';
+
 export class EditProfileModel {
   userLocationDto: UserLocationDto | null;
   name: string;
   userCredo: string;
   profilePicturePath: string;
   rating: number | null;
-  showEcoPlace: PrivacyState;
-  showLocation: PrivacyState;
-  showToDoList: PrivacyState;
+  showEcoPlace: ProfilePrivacyPolicy;
+  showLocation: ProfilePrivacyPolicy;
+  showToDoList: ProfilePrivacyPolicy;
   socialNetworks: Array<{ id: number; url: string }>;
   notificationPreferences: NotificationPreference[];
 }
@@ -15,9 +17,9 @@ export class EditProfileDto {
   coordinates: Coordinates;
   name: string;
   userCredo: string;
-  showEcoPlace: PrivacyState;
-  showLocation: PrivacyState;
-  showToDoList: PrivacyState;
+  showEcoPlace: ProfilePrivacyPolicy;
+  showLocation: ProfilePrivacyPolicy;
+  showToDoList: ProfilePrivacyPolicy;
   socialNetworks: Array<string>;
   emailPreferences: NotificationPreference[];
 }
@@ -43,5 +45,3 @@ export interface NotificationPreference {
   emailPreference: string;
   periodicity: string;
 }
-
-export type PrivacyState = 'PUBLIC' | 'PRIVATE' | 'FRIENDS_ONLY';

--- a/src/app/main/component/user/models/edit-profile.model.ts
+++ b/src/app/main/component/user/models/edit-profile.model.ts
@@ -4,9 +4,9 @@ export class EditProfileModel {
   userCredo: string;
   profilePicturePath: string;
   rating: number | null;
-  showEcoPlace: boolean;
-  showLocation: boolean;
-  showToDoList: boolean;
+  showEcoPlace: string;
+  showLocation: string;
+  showToDoList: string;
   socialNetworks: Array<{ id: number; url: string }>;
   notificationPreferences: NotificationPreference[];
 }
@@ -15,9 +15,9 @@ export class EditProfileDto {
   coordinates: Coordinates;
   name: string;
   userCredo: string;
-  showEcoPlace: boolean;
-  showLocation: boolean;
-  showToDoList: boolean;
+  showEcoPlace: string;
+  showLocation: string;
+  showToDoList: string;
   socialNetworks: Array<string>;
   emailPreferences: NotificationPreference[];
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -842,6 +842,11 @@
         "weekly": "weekly",
         "never": "never"
       },
+      "privacy-options": {
+        "private": "Show only me",
+        "friends_only": "Show me and friends",
+        "public": "Show everyone"
+      },
       "btn": {
         "cancel": "Cancel",
         "save": "Save",
@@ -1317,7 +1322,7 @@
     "my-space": "My Space",
     "follow-us": "Follow us",
     "events": "Events",
-    "ubs-courier":"UBS Courier"
+    "ubs-courier": "UBS Courier"
   },
   "event": {
     "btn-top": "More",

--- a/src/assets/i18n/ua.json
+++ b/src/assets/i18n/ua.json
@@ -851,6 +851,11 @@
         "weekly": "щотижня",
         "never": "ніколи"
       },
+      "privacy-options": {
+        "private": "Показувати тільки мені",
+        "friends_only": "Показувати мені та друзям",
+        "public": "Показувати всім"
+      },
       "btn": {
         "cancel": "Скасувати",
         "save": "Зберегти",
@@ -1353,7 +1358,7 @@
     "my-space": "Мій Кабінет",
     "follow-us": "Приєднуйтесь до нас",
     "events": "Події",
-    "ubs-courier":"UBS Кур'єр"
+    "ubs-courier": "UBS Кур'єр"
   },
   "accessibility": {
     "skip-to-the-main-content": "перейти до основного контенту"


### PR DESCRIPTION
[#7970](https://github.com/ita-social-projects/GreenCity/issues/7970)

<img width="838" alt="Знімок екрана 2025-01-30 о 11 19 46" src="https://github.com/user-attachments/assets/91cddc06-fcd8-4b65-b1b8-525efd0673d5" />
<img width="1388" alt="Знімок екрана 2025-01-30 о 11 19 59" src="https://github.com/user-attachments/assets/2b5ec04a-a8b1-43d9-a8cd-9d6d68f750b2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced privacy settings for user profile.
	- Added granular control over visibility of profile sections (location, eco places, to-do list).
	- Introduced privacy options: Private, Friends Only, and Public.

- **Improvements**
	- Updated user interface for privacy settings with dropdown selections.
	- Implemented dynamic content visibility based on user preferences.
	- Refined test setups to utilize mock user data for improved maintainability.

- **Localization**
	- Added translations for new privacy options in English and Ukrainian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->