### PR TITLE
[Bugfix] #7875 User's profile picture is not displayed when the user with a custom profile picture adds a comment.

### DIFF
--- a/src/app/main/component/comments/components/add-comment/add-comment.component.spec.ts
+++ b/src/app/main/component/comments/components/add-comment/add-comment.component.spec.ts
@@ -15,17 +15,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
 import { CommentFormData } from '../../models/comments-model';
 import { mockUserData } from '@global-user/mocks/edit-profile-mock';
-
-const COMMENT_MOCK = {
-  author: {
-    name: 'username',
-    id: 1,
-    userProfilePicturePath: null
-  },
-  id: 1,
-  modifiedDate: '01.12.2022',
-  text: 'some text'
-};
+import { MOCK_COMMENTS_DTO } from '../../mocks/comments-mock';
 
 describe('AddCommentComponent', () => {
   let component: AddCommentComponent;
@@ -35,7 +25,7 @@ describe('AddCommentComponent', () => {
   profileServiceMock.getUserInfo = () => of(mockUserData);
 
   const commentsServiceMock: jasmine.SpyObj<CommentsService> = jasmine.createSpyObj('CommentsService', ['addComment']);
-  commentsServiceMock.addComment.and.returnValue(of(COMMENT_MOCK));
+  commentsServiceMock.addComment.and.returnValue(of(MOCK_COMMENTS_DTO));
 
   const socketServiceMock: SocketService = jasmine.createSpyObj('SocketService', ['onMessage', 'send', 'initiateConnection']);
   socketServiceMock.onMessage = () => new Observable();
@@ -107,7 +97,7 @@ describe('AddCommentComponent', () => {
 
     flush();
     expect(commentsServiceMock.addComment).toHaveBeenCalledWith(commentData);
-    expect(updateListSpy).toHaveBeenCalledWith(COMMENT_MOCK);
+    expect(updateListSpy).toHaveBeenCalledWith(MOCK_COMMENTS_DTO);
     expect(component.addCommentForm.value.content).toBe('');
   }));
 

--- a/src/app/main/component/comments/components/comments-container/comments-container.component.spec.ts
+++ b/src/app/main/component/comments/components/comments-container/comments-container.component.spec.ts
@@ -12,26 +12,12 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CommentsContainerComponent } from './comments-container.component';
 import { CommentsDTO, CommentsModel } from '../../models/comments-model';
 import { of } from 'rxjs';
+import { MOCK_COMMENTS_DTO } from '../../mocks/comments-mock';
 
 const MOCK_COMMENTS_MODEL: CommentsModel = {
   currentPage: 0,
   page: [{ id: 1 } as CommentsDTO],
   totalElements: 0
-};
-
-const MOCK_COMMENTS_DTO: CommentsDTO = {
-  author: {
-    id: 0,
-    name: 'fake_author',
-    userProfilePicturePath: null
-  },
-  currentUserLiked: false,
-  id: 0,
-  likes: 0,
-  modifiedDate: '',
-  replies: 0,
-  status: 'ORIGINAL',
-  text: 'fake_text'
 };
 
 describe('CommentsContainerComponent', () => {

--- a/src/app/main/component/comments/components/comments-list/comments-list.component.html
+++ b/src/app/main/component/comments/components/comments-list/comments-list.component.html
@@ -5,7 +5,7 @@
 >
   <div class="comment-avatar">
     <app-user-profile-image
-      [imgPath]="comment.author.userProfilePicturePath"
+      [imgPath]="comment.author.profilePicturePath"
       [firstName]="comment.author.name"
       [additionalImgClass]="'comments-list'"
     >

--- a/src/app/main/component/comments/components/comments-list/comments-list.component.spec.ts
+++ b/src/app/main/component/comments/components/comments-list/comments-list.component.spec.ts
@@ -24,7 +24,7 @@ describe('CommentsListComponent', () => {
         currentPage: 1,
         page: [
           {
-            author: { id: 1, name: 'Test', userProfilePicturePath: null },
+            author: { id: 1, name: 'Test', profilePicturePath: null },
             currentUserLiked: false,
             id: 1,
             likes: 5,
@@ -55,7 +55,7 @@ describe('CommentsListComponent', () => {
     author: {
       id: 1,
       name: 'Test',
-      userProfilePicturePath: null
+      profilePicturePath: null
     },
     currentUserLiked: true,
     id: 1,

--- a/src/app/main/component/comments/components/delete-comment/delete-comment.component.spec.ts
+++ b/src/app/main/component/comments/components/delete-comment/delete-comment.component.spec.ts
@@ -9,6 +9,7 @@ import { DeleteCommentComponent } from './delete-comment.component';
 import { of } from 'rxjs';
 import { CommentsService } from '../../services/comments.service';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MOCK_COMMENTS_DTO } from '../../mocks/comments-mock';
 
 class MatDialogMock {
   open() {
@@ -42,18 +43,7 @@ describe('DeleteCommentComponent', () => {
     fixture.detectChanges();
 
     component.element = {
-      author: {
-        id: 1,
-        name: 'Test',
-        userProfilePicturePath: null
-      },
-      currentUserLiked: true,
-      id: 1,
-      likes: 0,
-      modifiedDate: '111',
-      replies: 1,
-      status: 'string',
-      text: 'string'
+      ...MOCK_COMMENTS_DTO
     };
   });
 

--- a/src/app/main/component/comments/components/like-comment/like-comment.component.spec.ts
+++ b/src/app/main/component/comments/components/like-comment/like-comment.component.spec.ts
@@ -7,6 +7,7 @@ import { CommentsService } from '../../services/comments.service';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { LikeCommentComponent } from './like-comment.component';
 import { Router } from '@angular/router';
+import { MOCK_COMMENTS_DTO } from '../../mocks/comments-mock';
 
 describe('LikeCommentComponent', () => {
   let component: LikeCommentComponent;
@@ -29,21 +30,6 @@ describe('LikeCommentComponent', () => {
 
   const routerMock = { url: '' };
 
-  const commentData = {
-    author: {
-      id: 1,
-      name: 'Test',
-      userProfilePicturePath: null
-    },
-    currentUserLiked: true,
-    id: 1,
-    likes: 0,
-    modifiedDate: '111',
-    replies: 1,
-    status: 'EDITED',
-    text: 'string'
-  };
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [LikeCommentComponent],
@@ -60,7 +46,7 @@ describe('LikeCommentComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(LikeCommentComponent);
     component = fixture.componentInstance;
-    (component as any).comment = commentData;
+    (component as any).comment = MOCK_COMMENTS_DTO;
     fixture.detectChanges();
   });
 

--- a/src/app/main/component/comments/mocks/comments-mock.ts
+++ b/src/app/main/component/comments/mocks/comments-mock.ts
@@ -1,0 +1,16 @@
+import { CommentsDTO } from '../models/comments-model';
+
+export const MOCK_COMMENTS_DTO: CommentsDTO = {
+  author: {
+    id: 0,
+    name: 'fake_author',
+    profilePicturePath: null
+  },
+  currentUserLiked: false,
+  id: 0,
+  likes: 0,
+  modifiedDate: '',
+  replies: 0,
+  status: 'ORIGINAL',
+  text: 'fake_text'
+};

--- a/src/app/main/component/comments/models/comments-model.ts
+++ b/src/app/main/component/comments/models/comments-model.ts
@@ -7,7 +7,7 @@ export interface CommentsModel {
 export interface AuthorDTO {
   id: number;
   name: string;
-  userProfilePicturePath: null;
+  profilePicturePath: null;
 }
 
 export interface CommentsDTO {

--- a/src/app/main/component/comments/models/comments-model.ts
+++ b/src/app/main/component/comments/models/comments-model.ts
@@ -7,7 +7,7 @@ export interface CommentsModel {
 export interface AuthorDTO {
   id: number;
   name: string;
-  profilePicturePath: null;
+  profilePicturePath: string | null;
 }
 
 export interface CommentsDTO {

--- a/src/app/main/component/eco-news/services/eco-news-comments.service.spec.ts
+++ b/src/app/main/component/eco-news/services/eco-news-comments.service.spec.ts
@@ -37,7 +37,7 @@ xdescribe('EcoNewsCommentsService', () => {
       author: {
         id: 1,
         name: 'Some Cool Person',
-        userProfilePicturePath: 'path to cool persons img'
+        profilePicturePath: 'path to cool persons img'
       },
       id: 2,
       modifiedDate: new Date('2021-05-27T15:37:15.661Z'),
@@ -63,7 +63,7 @@ xdescribe('EcoNewsCommentsService', () => {
       author: {
         id: 1,
         name: 'Some Cool Person',
-        userProfilePicturePath: 'path to cool persons img'
+        profilePicturePath: 'path to cool persons img'
       },
       id: 0,
       modifiedDate: new Date('2021-05-27T15:37:15.661Z'),
@@ -88,7 +88,7 @@ xdescribe('EcoNewsCommentsService', () => {
       author: {
         id: 1,
         name: 'Some Cool Person',
-        userProfilePicturePath: 'path to cool persons img'
+        profilePicturePath: 'path to cool persons img'
       },
       id: 2,
       modifiedDate: new Date('2021-05-27T15:37:15.661Z'),
@@ -123,7 +123,7 @@ xdescribe('EcoNewsCommentsService', () => {
           author: {
             id: 1,
             name: 'Some Cool Person',
-            userProfilePicturePath: 'path to cool persons img'
+            profilePicturePath: 'path to cool persons img'
           },
           currentUserLiked: true,
           id: 0,

--- a/src/app/main/component/events/services/events-comments.service.spec.ts
+++ b/src/app/main/component/events/services/events-comments.service.spec.ts
@@ -37,7 +37,7 @@ describe('EventsCommentsService', () => {
       author: {
         id: 1,
         name: 'Some Cool Person',
-        userProfilePicturePath: 'path to cool persons img'
+        profilePicturePath: 'path to cool persons img'
       },
       id: 2,
       modifiedDate: new Date('2021-05-27T15:37:15.661Z'),
@@ -63,7 +63,7 @@ describe('EventsCommentsService', () => {
       author: {
         id: 1,
         name: 'Some Cool Person',
-        userProfilePicturePath: 'path to cool persons img'
+        profilePicturePath: 'path to cool persons img'
       },
       id: 0,
       modifiedDate: new Date('2021-05-27T15:37:15.661Z'),
@@ -90,7 +90,7 @@ describe('EventsCommentsService', () => {
       author: {
         id: 1,
         name: 'Some Cool Person',
-        userProfilePicturePath: 'path to cool persons img'
+        profilePicturePath: 'path to cool persons img'
       },
       id: 2,
       modifiedDate: new Date('2021-05-27T15:37:15.661Z'),
@@ -126,7 +126,7 @@ describe('EventsCommentsService', () => {
           author: {
             id: 1,
             name: 'Some Cool Person',
-            userProfilePicturePath: 'path to cool persons img'
+            profilePicturePath: 'path to cool persons img'
           },
           currentUserLiked: true,
           id: 0,

--- a/src/app/main/component/user/components/habit/mocks/habit-mock.ts
+++ b/src/app/main/component/user/components/habit/mocks/habit-mock.ts
@@ -11,7 +11,7 @@ import { HttpParams } from '@angular/common/http';
 import { AddedCommentDTO, CommentsModel } from 'src/app/main/component/comments/models/comments-model';
 
 export const MOCK_HABIT_ADDED_COMMENT: AddedCommentDTO = {
-  author: { id: 1, name: 'User', userProfilePicturePath: null },
+  author: { id: 1, name: 'User', profilePicturePath: null },
   id: 2,
   text: 'Test comment',
   modifiedDate: new Date().toISOString()
@@ -21,7 +21,7 @@ export const MOCK_HABIT_COMMENTS_MODEL: CommentsModel = {
   currentPage: 0,
   page: [
     {
-      author: { id: 1, name: 'User', userProfilePicturePath: null },
+      author: { id: 1, name: 'User', profilePicturePath: null },
       id: 1,
       text: 'Test comment',
       likes: 10,


### PR DESCRIPTION
[#7875](https://github.com/ita-social-projects/GreenCity/issues/7875)
_Changed according to responce, redid tests_
##
**Before**
<img width="1353" alt="Знімок екрана 2025-01-15 о 12 06 57" src="https://github.com/user-attachments/assets/7602769a-981a-40b5-b24a-aaaaadf15e59" />
**After**
<img width="1238" alt="Знімок екрана 2025-01-15 о 12 07 22" src="https://github.com/user-attachments/assets/27ee6803-94fd-4dfe-acbf-e4499a01de65" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

- **Models**
	- Updated `AuthorDTO` interface to use `profilePicturePath` instead of `userProfilePicturePath`

- **Mocks**
	- Added centralized `MOCK_COMMENTS_DTO` for consistent comment testing
	- Updated mock data to use new profile picture path property

- **Components**
	- Modified profile image bindings in comments-related components to use new property path

- **Tests**
	- Standardized mock data and test cases across comment-related test files
	- Updated test cases to reflect changes in the profile picture property name
<!-- end of auto-generated comment: release notes by coderabbit.ai -->