### PR TITLE
[Bugfix] #6272 Add online status display in "my friends" 

### DIFF
--- a/src/app/main/component/user/components/profile/users-friends/users-friends.component.html
+++ b/src/app/main/component/user/components/profile/users-friends/users-friends.component.html
@@ -24,6 +24,7 @@
             [firstName]="friend.name"
             class="friend-img"
             [additionalImgClass]="'friend-user-profile'"
+            [isOnline]="isFriendOnline(friend.id)"
           >
           </app-user-profile-image>
           <p class="friend-name">{{ friend.name | firststringword | maxTextLength: 10 }}</p>

--- a/src/app/main/component/user/components/profile/users-friends/users-friends.component.spec.ts
+++ b/src/app/main/component/user/components/profile/users-friends/users-friends.component.spec.ts
@@ -15,6 +15,7 @@ import { Language } from 'src/app/main/i18n/Language';
 import { FriendModel } from '@user-models/friend.model';
 import { Router } from '@angular/router';
 import { FriendStatusValues } from '@user-models/friend.model';
+import { UserOnlineStatusService } from '@global-user/services/user-online-status.service';
 
 describe('UsersFriendsComponent', () => {
   let renderer: Renderer2;
@@ -39,6 +40,11 @@ describe('UsersFriendsComponent', () => {
 
   const userFriendsServiceMock: UserFriendsService = jasmine.createSpyObj('UserFriendsService', ['getAllFriends']);
   userFriendsServiceMock.getAllFriends = () => of(FRIENDS);
+  const userOnlineStatusServiceMock = {
+    addUsersId: jasmine.createSpy('addUsersId'),
+    checkIsOnline: jasmine.createSpy('checkIsOnline').and.returnValue(true),
+    usersOnlineStatus$: new BehaviorSubject([])
+  };
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -48,7 +54,8 @@ describe('UsersFriendsComponent', () => {
       providers: [
         Renderer2,
         { provide: LocalStorageService, useValue: localStorageServiceMock },
-        { provide: UserFriendsService, useValue: userFriendsServiceMock }
+        { provide: UserFriendsService, useValue: userFriendsServiceMock },
+        { provide: UserOnlineStatusService, useValue: userOnlineStatusServiceMock }
       ]
     }).compileComponents();
   }));
@@ -152,5 +159,14 @@ describe('UsersFriendsComponent', () => {
     window.dispatchEvent(new Event('resize'));
     fixture.detectChanges();
     expect(calculateFriendsToShowSpy).toHaveBeenCalled();
+  });
+
+  it('should return online status for a friend', () => {
+    userOnlineStatusServiceMock.usersOnlineStatus$.next([
+      { id: 1, onlineStatus: true },
+      { id: 2, onlineStatus: false }
+    ]);
+    const result = component.isFriendOnline(1);
+    expect(result).toBeTrue();
   });
 });

--- a/src/app/main/component/user/components/profile/users-friends/users-friends.component.ts
+++ b/src/app/main/component/user/components/profile/users-friends/users-friends.component.ts
@@ -6,6 +6,7 @@ import { debounceTime, takeUntil } from 'rxjs/operators';
 import { Router } from '@angular/router';
 import { FriendArrayModel, FriendModel } from '@global-user/models/friend.model';
 import { calendarImage } from '@shared/components/calendar-base/calendar-image';
+import { UserOnlineStatusService } from '@global-user/services/user-online-status.service';
 
 @Component({
   selector: 'app-users-friends',
@@ -32,7 +33,8 @@ export class UsersFriendsComponent implements OnInit, OnDestroy {
     private userFriendsService: UserFriendsService,
     private localStorageService: LocalStorageService,
     private router: Router,
-    private renderer: Renderer2
+    private renderer: Renderer2,
+    private userOnlineStatusService: UserOnlineStatusService
   ) {}
 
   ngOnInit() {
@@ -52,6 +54,9 @@ export class UsersFriendsComponent implements OnInit, OnDestroy {
         next: (item: FriendArrayModel) => {
           this.totalPages = item.totalPages;
           this.usersFriends = item.page;
+          const friendIds = this.usersFriends.map((friend) => friend.id);
+          this.userOnlineStatusService.addUsersId('usersFriends', friendIds);
+
           this.amountOfFriends = item.totalElements;
           this.updateArrowsVisibility();
         },
@@ -110,6 +115,10 @@ export class UsersFriendsComponent implements OnInit, OnDestroy {
     const show = this.friendsToShow < this.amountOfFriends && window.innerWidth < 768 ? 'visible' : 'hidden';
     this.renderer.setStyle(this.nextArrow.nativeElement, 'visibility', show);
     this.renderer.setStyle(this.previousArrow.nativeElement, 'visibility', show);
+  }
+
+  isFriendOnline(friendId: number): boolean {
+    return this.userOnlineStatusService.checkIsOnline(friendId);
   }
 
   ngOnDestroy() {

--- a/src/app/main/component/user/components/profile/users-friends/users-friends.component.ts
+++ b/src/app/main/component/user/components/profile/users-friends/users-friends.component.ts
@@ -30,11 +30,11 @@ export class UsersFriendsComponent implements OnInit, OnDestroy {
   @ViewChild('previousArrow', { static: false }) previousArrow: ElementRef;
 
   constructor(
-    private userFriendsService: UserFriendsService,
-    private localStorageService: LocalStorageService,
-    private router: Router,
-    private renderer: Renderer2,
-    private userOnlineStatusService: UserOnlineStatusService
+    private readonly userFriendsService: UserFriendsService,
+    private readonly localStorageService: LocalStorageService,
+    private readonly router: Router,
+    private readonly renderer: Renderer2,
+    private readonly userOnlineStatusService: UserOnlineStatusService
   ) {}
 
   ngOnInit() {


### PR DESCRIPTION
[#6272](https://github.com/ita-social-projects/GreenCity/issues/6272)
**Result**
<img width="1766" alt="Знімок екрана 2025-01-17 о 14 15 56" src="https://github.com/user-attachments/assets/4c8abbda-8711-4e92-bc9a-ce09f108629f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added online status indicator for friends in user profile.
  - Implemented method to check a friend's online status.

- **Tests**
  - Added test case to verify online status functionality for friends.

These updates enhance the user experience by providing real-time online status information for friends in the user profile section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->