### PR TITLE
[Bugfix] #7769 Update image upload pop-up to match the design mock-up

### DIFF
--- a/src/app/main/component/shared/components/drag-and-drop/drag-and-drop.component.html
+++ b/src/app/main/component/shared/components/drag-and-drop/drag-and-drop.component.html
@@ -1,4 +1,3 @@
-<p class="warning" *ngIf="showTopMessage" [ngClass]="{ 'warning-color': isWarning }">{{ 'drag-and-drop.picture-tooltip' | translate }}</p>
 <div *ngIf="!file && !isWarning" class="dropzone" appDragAndDrop (files)="filesDropped($event)">
   <div class="text-wrapper">
     <div class="centered">
@@ -37,6 +36,7 @@
     </button>
   </div>
 </div>
+<p class="warning" *ngIf="showTopMessage" [ngClass]="{ 'warning-color': isWarning }">{{ 'drag-and-drop.picture-tooltip' | translate }}</p>
 
 <ng-template #elseBlock>
   <div class="dropzone warning-background" appDragAndDrop (files)="filesDropped($event)">

--- a/src/app/main/component/shared/components/drag-and-drop/drag-and-drop.component.scss
+++ b/src/app/main/component/shared/components/drag-and-drop/drag-and-drop.component.scss
@@ -31,7 +31,6 @@
   font-size: 18px;
   text-align: center;
   width: 250px;
-  font-family: var(--primary-font);
 
   span {
     color: var(--primary-green);

--- a/src/app/main/component/shared/components/edit-photo-pop-up/edit-photo-pop-up.component.html
+++ b/src/app/main/component/shared/components/edit-photo-pop-up/edit-photo-pop-up.component.html
@@ -32,8 +32,7 @@
       </div>
       <p *ngIf="!selectedFile" class="message" [ngClass]="{ warning: isWarning }">{{ 'user.edit-profile.picture-tooltip' | translate }}</p>
       <div *ngIf="!isWarning && selectedFile">
-        <p>{{ 'user.edit-profile.would-you-like' | translate }}</p>
-        <div class="buttons">
+        <div class="buttons buttons-with-spacing">
           <button type="button" class="tertiary-global-button m-btn" (click)="closeEditPhoto()">
             {{ 'user.edit-profile.btn.cancel' | translate }}
           </button>

--- a/src/app/main/component/shared/components/edit-photo-pop-up/edit-photo-pop-up.component.scss
+++ b/src/app/main/component/shared/components/edit-photo-pop-up/edit-photo-pop-up.component.scss
@@ -76,6 +76,7 @@
         font-family: var(--tertiary-font);
         letter-spacing: 0.1px;
       }
+
       &.buttons-with-spacing {
         margin-top: 40px;
       }

--- a/src/app/main/component/shared/components/edit-photo-pop-up/edit-photo-pop-up.component.scss
+++ b/src/app/main/component/shared/components/edit-photo-pop-up/edit-photo-pop-up.component.scss
@@ -76,6 +76,9 @@
         font-family: var(--tertiary-font);
         letter-spacing: 0.1px;
       }
+      &.buttons-with-spacing {
+        margin-top: 40px;
+      }
 
       .primary-global-button,
       .secondary-global-button {


### PR DESCRIPTION
[#7769](https://github.com/ita-social-projects/GreenCity/issues/7769)

This pull request addresses several UI adjustments for the image upload pop-up to ensure it aligns with the design mock-up:

- Corrected the placement of the text "Upload PNG or JPG only…" under the frame.
- Adjusted the spacing of the text "Image isn't uploaded. Drop your image here or browse." to match the mock-up.
- Changed the font of "Image isn't uploaded" from bold to regular.
- Updated text to "Image isn't uploaded."
- Removed the unnecessary element "Would you like to save changes?" from the pop-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Reintroduced a warning message in the drag-and-drop component.
  - Updated button functionality and styling in the edit photo pop-up component.
  - Removed prompt text from the edit photo pop-up interface.

- **Style Changes**
  - Removed explicit font family for the `.centered` class.
  - Added new `.buttons-with-spacing` class with top margin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->