### PR TITLE
[Bugfix] #7980 disable when clicking 'Accept' button for the second time on the same invitation in notifications

### DIFF
--- a/src/app/main/component/user/components/profile/user-notifications/user-notifications.component.html
+++ b/src/app/main/component/user/components/profile/user-notifications/user-notifications.component.html
@@ -110,10 +110,10 @@
           (keydown)="navigate($event)"
         ></p>
         <div class="friend-action-button" *ngIf="isHabitInvitation(notification) || isFriendRequest(notification)">
-          <button (click)="declineRequest(notification)" class="decline-request">
+          <button (click)="declineRequest(notification)" class="decline-request" [disabled]="!isPending(notification)">
             <span class="material-icons">close</span><span>{{ 'profile.friends.request-decline' | translate }}</span>
           </button>
-          <button (click)="acceptRequest(notification)" class="accept-request">
+          <button (click)="acceptRequest(notification)" class="accept-request" [disabled]="!isPending(notification)">
             <span class="material-icons">done</span><span>{{ 'profile.friends.request-accept' | translate }}</span>
           </button>
         </div>

--- a/src/app/main/component/user/components/profile/user-notifications/user-notifications.component.ts
+++ b/src/app/main/component/user/components/profile/user-notifications/user-notifications.component.ts
@@ -10,7 +10,8 @@ import {
   FilterCriteria,
   filterCriteriaOptions,
   notificationCriteriaOptions,
-  projects
+  projects,
+  NotificationStatus
 } from '@global-user/models/notification.model';
 import { UserFriendsService } from '@global-user/services/user-friends.service';
 import { UserNotificationService } from '@global-user/services/user-notification.service';
@@ -272,6 +273,10 @@ export class UserNotificationsComponent implements OnInit, OnDestroy {
     return notification.notificationType === this.notificationHabitInvitation;
   }
 
+  isPending(notification: NotificationModel): boolean {
+    return notification.status === NotificationStatus.PENDING;
+  }
+
   acceptRequest(notification: NotificationModel): void {
     if (this.isFriendRequest(notification)) {
       this.handleFriendRequest(notification, 'accept');
@@ -299,6 +304,7 @@ export class UserNotificationsComponent implements OnInit, OnDestroy {
         },
         complete: () => {
           this.matSnackBar.openSnackBar(isAccepted ? 'friendRequestAccepted' : 'friendInValidRequest');
+          this.reloadNotifications();
         }
       });
     } else {
@@ -308,6 +314,7 @@ export class UserNotificationsComponent implements OnInit, OnDestroy {
         },
         complete: () => {
           this.matSnackBar.openSnackBar(isAccepted ? 'friendRequestDeclined' : 'friendInValidRequest');
+          this.reloadNotifications();
         }
       });
     }
@@ -323,6 +330,7 @@ export class UserNotificationsComponent implements OnInit, OnDestroy {
         },
         complete: () => {
           this.matSnackBar.openSnackBar(isAccepted ? 'habitAcceptRequest' : 'habitAcceptInValidRequest');
+          this.reloadNotifications();
         }
       });
     } else {
@@ -332,6 +340,7 @@ export class UserNotificationsComponent implements OnInit, OnDestroy {
         },
         complete: () => {
           this.matSnackBar.openSnackBar(isAccepted ? 'habitDeclineRequest' : 'habitDeclineInValidRequest');
+          this.reloadNotifications();
         }
       });
     }

--- a/src/app/main/component/user/models/notification.model.ts
+++ b/src/app/main/component/user/models/notification.model.ts
@@ -24,6 +24,7 @@ export interface NotificationModel {
   time: any;
   titleText: string;
   viewed: boolean;
+  status?: NotificationStatus;
 }
 
 export enum FilterCriteria {
@@ -109,3 +110,10 @@ export const projects: NotificationFilter[] = [
   { name: 'GREENCITY', nameEn: 'GreenCity', isSelected: false },
   { name: 'PICKUP', nameEn: 'Pick up', isSelected: false }
 ];
+
+export enum NotificationStatus {
+  PENDING = 'PENDING',
+  ACCEPTED = 'ACCEPTED',
+  REJECTED = 'REJECTED',
+  CANCELED = 'CANCELED'
+}


### PR DESCRIPTION
[#7980](https://github.com/ita-social-projects/GreenCity/issues/7980)
implemented accroding to updated backend dto - "status" 

This update enhances the user notification functionality. It introduces a new NotificationStatus enum and an optional status property in the notification model. In the user notifications component, the UI now conditionally disables friend request buttons based on a pending status check. The component logic is updated to include an isPending method and to reload notifications after handling friend requests or habit invitations.


![accept invite error 2](https://github.com/user-attachments/assets/ecb27dc8-2b27-43db-94fe-fd1c90d2cc49)