### PR TITLE
[Tech] #8171 In UBS Order we have two headers rendered

### DIFF
--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -5,7 +5,7 @@
       {{ 'accessibility.skip-to-the-main-content' | translate }}
     </a>
   </div>
-  <app-header *ngIf="!isUnsubscribe"></app-header>
+  <app-header *ngIf="!isUnsubscribe && !isUBS"></app-header>
   <app-search-popup></app-search-popup>
   <div class="main-content app-container">
     <div #focusLast tabindex="-1" aria-label="Tab To Main"></div>


### PR DESCRIPTION
[#8171](https://github.com/ita-social-projects/GreenCity/issues/8171)
We have the header rendered in the ubs order, as well as in the main app, added the !isUBS so it would render one time as expected
## Before
_When we check document.querySelectorAll('.ubs-header-sing-in-img') in UBS Order_

<img width="539" alt="Image" src="https://github.com/user-attachments/assets/680911b6-13dc-4de8-aaa7-5c87f5ec730a" />

There are two images, which is dublication
**Two headers are being rendered** 

## After 
<img width="606" alt="Знімок екрана 2025-02-24 о 10 14 38" src="https://github.com/user-attachments/assets/87486122-8a58-43ae-8130-510b832f01a1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the header’s visibility so it now appears only when neither the unsubscribe state nor an additional condition is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->