### PR TITLE
[Bugfix] #8206 Incorrect client's phone number display when client starts to place the order.

### DIFF
--- a/src/assets/patterns/patterns.ts
+++ b/src/assets/patterns/patterns.ts
@@ -54,5 +54,5 @@ export const Masks = {
   certificateMask: '0000-0000',
   ecoStoreMask: '00000000',
   servicesMask: '000',
-  phoneMask: '+{38\\0} (00) 000 00 00'
+  phoneMask: '{+380} (00) 000 00 00'
 };


### PR DESCRIPTION
[#8206](https://github.com/ita-social-projects/GreenCity/issues/8206)
**Before**
_edit profile_
<img width="522" alt="Знімок екрана 2025-03-05 о 11 03 27" src="https://github.com/user-attachments/assets/0f60106c-dffe-4238-9fb8-9633fdb1390f" />
_order_
<img width="568" alt="Знімок екрана 2025-03-05 о 11 04 31" src="https://github.com/user-attachments/assets/a926a5d1-20f0-4de9-98b4-35d9449b58f6" />

**Result**
_edit profile_
<img width="522" alt="Знімок екрана 2025-03-05 о 11 03 27" src="https://github.com/user-attachments/assets/0f60106c-dffe-4238-9fb8-9633fdb1390f" />
_order_
<img width="578" alt="Знімок екрана 2025-03-05 о 11 03 54" src="https://github.com/user-attachments/assets/05a700cf-8598-49a3-b545-48d260cf80e7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated phone number formatting to show the international dialing code using a standardized format. This change improves clarity in how phone numbers are displayed, ensuring consistency and a smoother experience when entering or viewing phone numbers. Users benefit from a more intuitive display that now aligns with international dialing standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->