### PR TITLE
[Bugfix] #8223 remove uah from each row

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.ts
@@ -439,16 +439,12 @@ export class UbsAdminTableComponent implements OnInit, OnDestroy {
   }
 
   formatTableData() {
-    const currency = {
-      ua: 'грн',
-      en: 'UAH'
-    };
     this.dataSource = new MatTableDataSource(
       this.tableData.map((row) => {
         const newRow = structuredClone(row);
         const priceKeys = [TableKeys.amountDue, TableKeys.totalOrderSum, TableKeys.generalDiscount, TableKeys.totalPayment];
         for (const key of priceKeys) {
-          newRow[key] = parseFloat(newRow[key]).toFixed(2) + ' ' + currency[this.currentLang];
+          newRow[key] = parseFloat(newRow[key]).toFixed(2);
         }
         const arr = newRow.orderCertificateCode?.split(', ');
         if (arr && arr.length > 0) {


### PR DESCRIPTION
[#8223](https://github.com/ita-social-projects/GreenCity/issues/8223)

Units of measurement should be moved to the column header to avoid duplication in each row. (remove UAH in each row)
the name of the column will be changed by backend
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the administration table to display price values as two-decimal numbers without appended currency symbols. This change provides a cleaner numerical presentation, ensuring clarity in the monetary figures shown while maintaining precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->