### PR TITLE
[Bugfix] #8232 dublication of footer in ubs user

### DIFF
--- a/src/app/ubs/ubs-user/ubs-user.component.html
+++ b/src/app/ubs/ubs-user/ubs-user.component.html
@@ -1,3 +1,2 @@
 <app-header></app-header>
 <app-ubs-user-sidebar></app-ubs-user-sidebar>
-<app-ubs-footer class="footer"></app-ubs-footer>


### PR DESCRIPTION
[#8232](https://github.com/ita-social-projects/GreenCity/issues/8232)

**before**

<img width="1791" alt="Image" src="https://github.com/user-attachments/assets/27ff27ad-a280-4528-af03-a78f8baec829" />
**result**

<img width="1792" alt="Image" src="https://github.com/user-attachments/assets/155c0bfd-2f72-4501-b617-2d7192197bca" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the footer section from the UBS user interface to streamline the layout and enhance the overall visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->