### PR TITLE
[fix] footer appears above sidebar

### DIFF
--- a/src/app/ubs/shared/components/ubs-base-sidebar/ubs-base-sidebar.component.scss
+++ b/src/app/ubs/shared/components/ubs-base-sidebar/ubs-base-sidebar.component.scss
@@ -10,6 +10,7 @@
     .sidebar-container {
       margin: 0 25px;
       width: calc(100% - 50px);
+      z-index: 1;
     }
 
     .sidebar-slider {

--- a/src/app/ubs/shared/components/ubs-footer/ubs-footer.component.scss
+++ b/src/app/ubs/shared/components/ubs-footer/ubs-footer.component.scss
@@ -9,6 +9,7 @@
   flex-direction: column;
   gap: 32px;
   align-items: center;
+  z-index: 3;
 
   &__menu {
     width: 100%;

--- a/src/app/ubs/ubs-user/ubs-user.component.scss
+++ b/src/app/ubs/ubs-user/ubs-user.component.scss
@@ -4,6 +4,7 @@
 
 .footer {
   display: flex;
+  z-index: 3;
 }
 
 @media (max-width: 480px) {

--- a/src/app/ubs/ubs/ubs-order.component.scss
+++ b/src/app/ubs/ubs/ubs-order.component.scss
@@ -4,3 +4,7 @@
   min-height: 100%;
   flex: 1 1 auto;
 }
+
+app-ubs-footer {
+  z-index: 3;
+}


### PR DESCRIPTION

**Description:**  
This pull request fixes an issue where the sidebar was overlapping the footer. Styles were adjusted to ensure both elements are correctly positioned within the layout.

**Changes include:**
- Updated `sidebar` and `footer` CSS to prevent overlap

**How to test:**
1. Open a page containing both the sidebar and footer
2. Scroll down and confirm that the footer is not covered by the sidebar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted layering for sidebar and footer elements to enhance visual stacking order.
  - Updated styling ensures that footers consistently appear above other page elements, improving overall display hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->