### PR TITLE
[Fix] sidebar overlapping footer on PROD

### DIFF
--- a/src/app/ubs/shared/components/ubs-base-sidebar/ubs-base-sidebar.component.scss
+++ b/src/app/ubs/shared/components/ubs-base-sidebar/ubs-base-sidebar.component.scss
@@ -10,6 +10,7 @@
     .sidebar-container {
       margin: 0 25px;
       width: calc(100% - 50px);
+      z-index: 1;
     }
 
     .sidebar-slider {

--- a/src/app/ubs/shared/components/ubs-footer/ubs-footer.component.scss
+++ b/src/app/ubs/shared/components/ubs-footer/ubs-footer.component.scss
@@ -9,6 +9,7 @@
   flex-direction: column;
   gap: 32px;
   align-items: center;
+  z-index: 3;
 
   &__menu {
     width: 100%;

--- a/src/app/ubs/ubs-user/ubs-user.component.html
+++ b/src/app/ubs/ubs-user/ubs-user.component.html
@@ -1,3 +1,3 @@
 <app-header></app-header>
 <app-ubs-user-sidebar></app-ubs-user-sidebar>
-<app-ubs-footer class="footer"></app-ubs-footer>
+<!--<app-ubs-footer class="footer"></app-ubs-footer>-->

--- a/src/app/ubs/ubs-user/ubs-user.component.html
+++ b/src/app/ubs/ubs-user/ubs-user.component.html
@@ -1,3 +1,2 @@
 <app-header></app-header>
 <app-ubs-user-sidebar></app-ubs-user-sidebar>
-<!--<app-ubs-footer class="footer"></app-ubs-footer>-->

--- a/src/app/ubs/ubs/ubs-order.component.scss
+++ b/src/app/ubs/ubs/ubs-order.component.scss
@@ -4,3 +4,7 @@
   min-height: 100%;
   flex: 1 1 auto;
 }
+
+app-ubs-footer {
+  z-index: 3;
+}


### PR DESCRIPTION
Description:
This pull request fixes an issue where the sidebar was overlapping the footer on PROD. Styles were adjusted to ensure both elements are correctly positioned within the layout.

Changes include:

Updated sidebar and footer CSS to prevent overlap
How to test:

Open a page containing both the sidebar and footer
Scroll down and confirm that the footer is not covered by the sidebar
Summary by CodeRabbit
Style
Adjusted layering for sidebar and footer elements to enhance visual stacking order.
Updated styling ensures that footers consistently appear above other page elements, improving overall display hierarchy.
