### PR TITLE
[Bugfix] #8348 replace dropdown with static display of selected status

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.html
@@ -36,24 +36,10 @@
           <div class="col-12">
             <div class="form-row">
               <div class="form-group col-sm-10 col-md-7">
-                <label for="payment" class="form__label">
+                <label class="form__label">
                   {{ 'order-edit.status.payment-label' | translate }}
                 </label>
-                <select
-                  id="payment"
-                  class="form-control payment"
-                  formControlName="paymentStatus"
-                  [disabled]="true"
-                  *ngIf="availablePaymentOrderStatuses?.length"
-                >
-                  <option
-                    *ngFor="let status of availablePaymentOrderStatuses"
-                    [selected]="status?.key === generalInfo.orderPaymentStatus"
-                    [value]="status?.key"
-                    [disabled]="true"
-                    [appLangValue]="{ ua: status?.uk, en: status?.en }"
-                  ></option>
-                </select>
+                <div class="form-control readonly payment" *ngIf="currentPaymentStatus" [appLangValue]="currentPaymentStatus"></div>
               </div>
             </div>
           </div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.scss
@@ -60,3 +60,10 @@ p {
 .readonly {
   pointer-events: none;
 }
+
+.payment {
+  background-color: var(--ubs-light-grey);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-status/ubs-admin-order-status.component.ts
@@ -44,6 +44,14 @@ export class UbsAdminOrderStatusComponent implements OnChanges, OnInit, OnDestro
     return this.generalOrderInfo.get('adminComment');
   }
 
+  get currentPaymentStatus(): { ua: string; en: string } | null {
+    if (!this.availablePaymentOrderStatuses?.length) {
+      return null;
+    }
+    const choosenStatus = this.availablePaymentOrderStatuses.find((st) => st.key === this.generalInfo.orderPaymentStatus);
+    return choosenStatus ? { ua: choosenStatus.uk, en: choosenStatus.en } : null;
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.additionalPayment) {
       this.generalInfo.orderPaymentStatus = changes.additionalPayment.currentValue;


### PR DESCRIPTION
[#8348](https://github.com/ita-social-projects/GreenCity/issues/8348)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Payment status is now displayed as read-only text instead of a dropdown, providing a clearer and simpler view.
- **Style**
  - Improved styling for the payment status display, including background color and text truncation with ellipsis for long statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->