### PR TITLE
fixed username uppercase first letter in a header

### DIFF
--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -452,7 +452,6 @@ header {
       padding: 0;
       font-family: var(--tertiary-font);
       font-weight: 400;
-      text-transform: capitalize;
       max-width: 160px;
       white-space: nowrap;
       text-overflow: ellipsis;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated user name display in the header to no longer automatically capitalize the first letter of each word. User names will now appear as originally entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->