### PR TITLE
fixed username uppercase first letter in a header

### DIFF
--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -452,7 +452,6 @@ header {
       padding: 0;
       font-family: var(--tertiary-font);
       font-weight: 400;
-      text-transform: capitalize;
       max-width: 160px;
       white-space: nowrap;
       text-overflow: ellipsis;


### PR DESCRIPTION
The username is displayed exactly as entered in the upper right corner.
![image](https://github.com/user-attachments/assets/e4146481-35b6-44e8-bf54-2e97835e0827)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated header styling to remove automatic capitalization of user names, preserving the original text format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->