### PR TITLE
fix grey ring around the date prior to 8 days

### DIFF
--- a/src/app/greencity/modules/user/components/profile/calendar/calendar.component.scss
+++ b/src/app/greencity/modules/user/components/profile/calendar/calendar.component.scss
@@ -207,6 +207,7 @@
 
 .unenrolled-past-day {
   background-color: transparent;
+  border: 1px solid var(--quaternary-light-grey);
   background-repeat: no-repeat;
   background-position: center;
   border-radius: 4px;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7f5c7c59-4ff1-45de-8abd-f738c621955e)
Days, when the user didn't mark a habit ‘as done’ prior to the 8-days tracking period, have a grey ring around the date (as 6th and 7th of May).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Added a visible border to elements with the "unenrolled-past-day" style in the calendar, improving their visual distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->