### PR TITLE
added space between the word address and a number on the user editing…

### DIFF
--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.scss
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.scss
@@ -72,6 +72,7 @@ $inputwidth: 260px;
     display: flex;
     align-items: center;
     margin: 28px 0 14px;
+    gap: 4px;
 
     .address-header__title {
       font-size: 20px;


### PR DESCRIPTION
There is space between the word Address and a number on the User data editing page.
![image](https://github.com/user-attachments/assets/1701ee31-03c9-45ee-b2c4-ed67b96153cd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved spacing between items in the address header for a more polished appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->