### PR TITLE
Bug/7872 when ordering 0 pakages certificate should not be active

### DIFF
--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.spec.ts
@@ -7,6 +7,7 @@ import { UbsOrderCertificateComponent } from './ubs-order-certificate.component'
 import { OrderService } from '../../../services/order.service';
 import { GetUserBonuses } from 'src/app/store/actions/ubs-user.actions';
 import { TranslateModule } from '@ngx-translate/core';
+import { CCertificate } from '@ubs/ubs/models/ubs.model';
 
 const orderServiceMock = {
   processCertificate: jasmine.createSpy('processCertificate')
@@ -139,9 +140,13 @@ describe('UbsOrderCertificateComponent (Partial Tests)', () => {
   describe('clearCertificates()', () => {
     it('should clear all certificates', () => {
       component.initForm();
+
       component.addNewCertificate();
       component.formArrayCertificates.at(0).setValue('TESTCODE1');
       component.formArrayCertificates.at(1).setValue('TESTCODE2');
+
+      const certificateMock = { points: 100, code: '1234-5678' } as CCertificate;
+      component.certificates.push(certificateMock);
       component.certificateSum = 1000;
 
       const spyOnDelete = spyOn(component, 'deleteCertificate').and.callThrough();
@@ -150,6 +155,7 @@ describe('UbsOrderCertificateComponent (Partial Tests)', () => {
 
       expect(spyOnDelete).toHaveBeenCalled();
       expect(component.formArrayCertificates.length).toBe(1);
+      expect(component.certificates.length).toBe(0);
     });
   });
 });

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.spec.ts
@@ -138,14 +138,20 @@ describe('UbsOrderCertificateComponent (Partial Tests)', () => {
   });
 
   describe('clearCertificates()', () => {
-    it('should clear all certificates', () => {
+    it('should clear all certificates when certificateSum > 0', () => {
       component.initForm();
 
       component.addNewCertificate();
       component.formArrayCertificates.at(0).setValue('TESTCODE1');
       component.formArrayCertificates.at(1).setValue('TESTCODE2');
 
-      const certificateMock = { points: 100, code: '1234-5678' } as CCertificate;
+      const certificateMock = CCertificate.ofResponse({
+        code: '1234-5678',
+        points: 1000,
+        certificateStatus: 'ACTIVE',
+        dateOfUse: null,
+        expirationDate: '2023-12-31'
+      });
       component.certificates.push(certificateMock);
       component.certificateSum = 1000;
 
@@ -156,6 +162,18 @@ describe('UbsOrderCertificateComponent (Partial Tests)', () => {
       expect(spyOnDelete).toHaveBeenCalled();
       expect(component.formArrayCertificates.length).toBe(1);
       expect(component.certificates.length).toBe(0);
+      expect(component.formArrayCertificates.at(0).value).toBe('1234-5678');
+    });
+
+    it('should not clear certificates when certificateSum is 0', () => {
+      component.initForm();
+      component.addNewCertificate();
+      component.certificateSum = 0;
+
+      const spyOnDelete = spyOn(component, 'deleteCertificate').and.callThrough();
+
+      component.clearCertificates();
+      expect(spyOnDelete).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.spec.ts
@@ -135,4 +135,21 @@ describe('UbsOrderCertificateComponent (Partial Tests)', () => {
       expect(bonusControl.value).toBeFalse();
     });
   });
+
+  describe('clearCertificates()', () => {
+    it('should clear all certificates', () => {
+      component.initForm();
+      component.addNewCertificate();
+      component.formArrayCertificates.at(0).setValue('TESTCODE1');
+      component.formArrayCertificates.at(1).setValue('TESTCODE2');
+      component.certificateSum = 1000;
+
+      const spyOnDelete = spyOn(component, 'deleteCertificate').and.callThrough();
+
+      component.clearCertificates();
+
+      expect(spyOnDelete).toHaveBeenCalled();
+      expect(component.formArrayCertificates.length).toBe(1);
+    });
+  });
 });

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -84,6 +84,7 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
 
     this.store.pipe(select(isFirstFormValidSelector), takeUntil(this.$destroy)).subscribe((isValid) => {
       this.isFirstFormValid = isValid;
+      !isValid && this.clearCertificates();
     });
   }
 
@@ -116,6 +117,14 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
     this.formArrayCertificates.removeAt(index);
     if (this.formArrayCertificates.length === 0) {
       this.addNewCertificate();
+    }
+  }
+
+  clearCertificates(): void {
+    if (this.formArrayCertificates.length >= 0 && this.certificateSum > 0) {
+      for (let i = 0; i < this.formArrayCertificates.length; i++) {
+        this.deleteCertificate(i);
+      }
     }
   }
 

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -122,11 +122,11 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
 
   clearCertificates(): void {
     if (this.formArrayCertificates.length >= 0 && this.certificateSum > 0) {
-      const lastEnteredCertificate = this.certificates[0].code;
+      const lastEnteredCertificate = this.certificates[0]?.code;
       for (let i = 0; i < this.formArrayCertificates.length; i++) {
         this.deleteCertificate(i);
       }
-      this.formArrayCertificates.at(0).setValue(lastEnteredCertificate);
+      lastEnteredCertificate && this.formArrayCertificates.at(0).setValue(lastEnteredCertificate);
     }
   }
 

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -121,7 +121,7 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
   }
 
   clearCertificates(): void {
-    if (this.formArrayCertificates.length >= 0 && this.certificateSum > 0) {
+    if (this.formArrayCertificates.length > 0 && this.certificateSum > 0) {
       const lastEnteredCertificate = this.certificates[0]?.code;
       for (let i = this.formArrayCertificates.length; i >= 0; i--) {
         this.deleteCertificate(i);

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -123,10 +123,11 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
   clearCertificates(): void {
     if (this.formArrayCertificates.length >= 0 && this.certificateSum > 0) {
       const lastEnteredCertificate = this.certificates[0]?.code;
-      for (let i = 0; i < this.formArrayCertificates.length; i++) {
+      for (let i = this.formArrayCertificates.length; i >= 0; i--) {
         this.deleteCertificate(i);
       }
       lastEnteredCertificate && this.formArrayCertificates.at(0).setValue(lastEnteredCertificate);
+      this.certificates = [];
     }
   }
 

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -122,9 +122,11 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
 
   clearCertificates(): void {
     if (this.formArrayCertificates.length >= 0 && this.certificateSum > 0) {
+      const lastEnteredCertificate = this.certificates[0].code;
       for (let i = 0; i < this.formArrayCertificates.length; i++) {
         this.deleteCertificate(i);
       }
+      this.formArrayCertificates.at(0).setValue(lastEnteredCertificate);
     }
   }
 


### PR DESCRIPTION
There was an issue that you certificate was still active when there was 0 packages.
I've changed that by adding a new function that clears whole array of redeemed certificated for the current order and wrote tests for this function.


https://github.com/user-attachments/assets/5ed67736-0ec5-4bf8-9e16-cb718124ebbd


/summarize


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic clearing of certificates in order details when the form becomes invalid or upon user action.

- **Tests**
  - Added tests to verify certificate clearing behavior and state reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->