### PR TITLE
UBS admin/ Fixbug/#8395 Fix "Місто" field not displaying selected values in tariff card creation

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -319,7 +319,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
 
   onSelectCity(event: MatAutocompleteSelectedEvent, trigger?: MatAutocompleteTrigger): void {
     const panel = document.querySelector('.mat-autocomplete-panel');
-    this.scrollPosition = panel.scrollTop;
+    this.scrollPosition = panel ? panel.scrollTop : 0;
 
     if (event.option.value === 'all') {
       this.toggleSelectAllCity();

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -313,8 +313,12 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
   }
 
   onOpenDropdown(): void {
-    const panel = document.querySelector('.mat-autocomplete-panel');
-    panel.scrollTop = this.scrollPosition;
+    requestAnimationFrame(() => {
+      const panel = document.querySelector('.mat-autocomplete-panel');
+      if (panel) {
+        panel.scrollTop = this.scrollPosition || 0;
+      }
+    });
   }
 
   onSelectCity(event: MatAutocompleteSelectedEvent, trigger?: MatAutocompleteTrigger): void {


### PR DESCRIPTION
Added a null check before accessing scrollTop to avoid runtime errors in onSelectCity.
Used requestAnimationFrame in onOpenDropdown to ensure the DOM element is available before accessing scrollTop (needed because of an error).
Correctly updated and used scrollPosition in onOpenDropdown with fallback (|| 0)
Checked activity of button "Створити".

Before fix:
![image](https://github.com/user-attachments/assets/933d2cde-5d03-4777-bb1e-d83fa8d23379)

After:
![Screenshot_2](https://github.com/user-attachments/assets/5e5ca61e-7ec3-436c-93f4-e0fc4bc57ad8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability of dropdown and city selection features to prevent errors when elements are not present, ensuring a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->