### PR TITLE
fix/8404-corrected-filtering-in-tariffs

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -336,7 +336,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
     }
     this.getExistingCard(this.filterData);
     this.setCountOfCheckedCity();
-    this.city.setValue('');
+    this.city.setValue(this.translate.instant('ubs-tariffs.states.all'));
     this.checkisCardExist();
     if (trigger) {
       requestAnimationFrame(() => {
@@ -402,7 +402,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
       Object.assign(this.filterData, { receivingStation: receivingStationId });
     }
     this.getExistingCard(this.filterData);
-    this.station.setValue('');
+    this.station.setValue(this.translate.instant('ubs-tariffs.states.all'));
     this.setStationPlaceholder();
     if (trigger) {
       requestAnimationFrame(() => {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -571,8 +571,13 @@ body {
 
 .mat-mdc-select-min-line {
   font-family: Lato, sans-serif;
-  font-size: 14px;
-  padding-left: 2px;
+  font-size: 16px;
+  line-height: 24px;
+  padding-left: 15px;
+  color: rgb(29, 40, 48);
+  display: inline-block;
+  box-sizing: border-box;
+  height: 36px;
 }
 
 .cursor-waite * {
@@ -580,9 +585,19 @@ body {
 }
 
 .mat-mdc-select-placeholder {
+  margin-top: 2px !important;
   font-family: Lato, sans-serif !important;
   font-size: 14px !important;
   font-weight: 400 !important;
-  letter-spacing: normal !important;
-  color: rgba(120 120 120 / 43%) !important;
+  line-height: 24px !important;
+  padding-left: 15px !important;
+  color: #cacfd3 !important;
+  display: inline-block !important;
+  box-sizing: border-box !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  opacity: 1 !important;
+  transform: none !important;
+  letter-spacing: -0.1px !important;
 }


### PR DESCRIPTION
Fixed filtering in drop-down lists and multi-select lists in when choosing Все
Fixed styles in Кур'єр and Стан field to match the mockup
When selecting "Все" in the "Область" field, it should be displayed "Все" in the field
When selecting "Все" in the "Місто" field, it should be displayed "Все" in the field
When selecting "Все" in the "Кур'єр" field, it should be displayed "Все" in the field
When selecting "Все" in the "Станція приймання" field, it should be displayed "Все" in the field
When selecting "Все" in the "Стан" field, it should be displayed "Все" in the field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved the behavior of city and station selection by displaying a localized "all" option instead of leaving fields empty after selection.
  - Refined the appearance of select input elements and placeholders with updated font size, spacing, colors, and better text overflow handling for a more polished user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->