### PR TITLE
bugfix/8445 User Agreement page now can show an information

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-edit-user-agreement/ubs-admin-edit-user-agreement.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-edit-user-agreement/ubs-admin-edit-user-agreement.component.ts
@@ -69,7 +69,7 @@ export class UbsAdminEditUserAgreementComponent implements OnInit {
     };
 
     this.languages.forEach((lang) => {
-      userAgreement[`text${lang}`] = this.getUserAgreementControl(lang).value;
+      userAgreement[`text${lang === 'Ua' ? 'Uk' : lang}`] = this.getUserAgreementControl(lang).value;
     });
 
     this.confirmSave(userAgreement);
@@ -100,7 +100,7 @@ export class UbsAdminEditUserAgreementComponent implements OnInit {
 
         this.languages.forEach((lang) => {
           const control = this.getUserAgreementControl(lang);
-          control.setValue(userAgreement[`text${lang}`]);
+          control.setValue(userAgreement[`text${lang === 'Ua' ? 'Uk' : lang}`]);
           control.markAsPristine();
         });
 

--- a/src/app/ubs/ubs/components/ubs-user-agreement/ubs-user-agreement.component.scss
+++ b/src/app/ubs/ubs/components/ubs-user-agreement/ubs-user-agreement.component.scss
@@ -1,3 +1,14 @@
 .page {
-  margin-top: 50px;
+  margin: 50px 50px 0;
+  height: 80vh;
+
+  .page-content {
+    height: 100%;
+  }
+
+  .ql-editor {
+    height: 100%;
+    max-width: 100%;
+    margin: 0 auto;
+  }
 }


### PR DESCRIPTION
[#8445](https://github.com/ita-social-projects/GreenCity/issues/8445)
There was an issue that nothing was displayed on the "User Agreement" page.
It was beacause this page should be filled by admin account, but also that was impossible, due to bad naming and styles, now it's fixed.

**Result:**

https://github.com/user-attachments/assets/7789ad12-833f-42f7-9d3b-9e706a6a5250



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Ukrainian language code to ensure correct display and saving of user agreement text.

- **Style**
  - Updated page layout and content editor styles for better spacing, sizing, and centering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->