### PR TITLE
Bugfix/8243 error when saving cancelled orders

### DIFF
--- a/src/app/ubs/shared/components/address-input/address-input.component.html
+++ b/src/app/ubs/shared/components/address-input/address-input.component.html
@@ -1,6 +1,6 @@
 <form *ngIf="addressForm" [formGroup]="addressForm" class="row adress">
   <div class="map-check">
-    <mat-checkbox [disabled]="!edit" (change)="onUseUserLocation($event.checked)">
+    <mat-checkbox [disabled]="!edit" (change)="edit && onUseUserLocation($event.checked)">
       {{ 'personal-info.pop-up-map-check' | translate }}</mat-checkbox
     >
   </div>

--- a/src/app/ubs/shared/components/address-input/address-input.component.html
+++ b/src/app/ubs/shared/components/address-input/address-input.component.html
@@ -1,6 +1,8 @@
 <form *ngIf="addressForm" [formGroup]="addressForm" class="row adress">
   <div class="map-check">
-    <mat-checkbox (change)="onUseUserLocation($event.checked)"> {{ 'personal-info.pop-up-map-check' | translate }}</mat-checkbox>
+    <mat-checkbox [disabled]="!edit" (change)="onUseUserLocation($event.checked)">
+      {{ 'personal-info.pop-up-map-check' | translate }}</mat-checkbox
+    >
   </div>
 
   <div class="col-md-6 col-sm-6 form-group">
@@ -25,6 +27,7 @@
       [autoCompRequest]="autocompleteCityRequest"
       (predictionSelected)="onCitySelected($event)"
       [isInvalid]="city.invalid && (city.touched || city.dirty)"
+      [disabled]="edit"
       ngDefaultControl
       (keyupEmitter)="keyup($event)"
     ></app-input-google-autocomplete>

--- a/src/app/ubs/shared/components/address-input/address-input.component.ts
+++ b/src/app/ubs/shared/components/address-input/address-input.component.ts
@@ -314,15 +314,17 @@ export class AddressInputComponent implements OnInit, AfterViewInit, OnDestroy, 
   }
 
   onUseUserLocation(isUseUserLocation: boolean) {
-    this.isShowMap = isUseUserLocation;
+    if (this.edit) {
+      this.isShowMap = isUseUserLocation;
 
-    if (isUseUserLocation) {
-      this.setCurrentLocation();
-    } else {
-      this.resetCity();
-      this.resetStreet();
-      this.resetDistricts();
-      this.resetHouseInfo();
+      if (isUseUserLocation) {
+        this.setCurrentLocation();
+      } else {
+        this.resetCity();
+        this.resetStreet();
+        this.resetDistricts();
+        this.resetHouseInfo();
+      }
     }
   }
 

--- a/src/app/ubs/shared/components/address-input/address-input.component.ts
+++ b/src/app/ubs/shared/components/address-input/address-input.component.ts
@@ -198,7 +198,7 @@ export class AddressInputComponent implements OnInit, AfterViewInit, OnDestroy, 
 
   private initializeFieldStates(): void {
     if (!this.edit) {
-      this.region.value ? this.city.enable() : this.city.disable();
+      this.region.value ? (this.isFromAdminPage ? this.city.disable() : this.city.enable()) : this.city.disable();
       this.street.disable();
       this.houseNumber.disable();
       this.houseCorpus.disable();
@@ -297,7 +297,7 @@ export class AddressInputComponent implements OnInit, AfterViewInit, OnDestroy, 
   }
 
   setInitialValues() {
-    this.edit
+    this.edit || this.isFromAdminPage
       ? this.addressData.initAddressData(this.address)
       : this.addressData.setRegionWithTranslation(this.locations.regionDto.nameUk, this.locations.regionDto.nameEn);
   }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-address-details/ubs-admin-address-details.component.html
@@ -8,7 +8,7 @@
     *ngIf="pageOpen"
     [formControl]="addressExportDetailsDto"
     [address]="address"
-    [edit]="true"
+    [edit]="!isEditableStatus$.value"
     [isFromAdminPage]="true"
     [isUneditableStatus]="isEditableStatus$ | async"
   ></app-address-input>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.html
@@ -90,12 +90,17 @@
           <button
             type="reset"
             class="cancel-button"
-            [disabled]="orderForm.pristine || !orderForm.valid || !isMinOrder"
+            [disabled]="orderForm.pristine || !orderForm.valid || !isMinOrder || orderForm.disabled"
             (click)="$event.preventDefault(); openCancelModal()"
           >
             {{ 'order-edit.btn.cancel' | translate }}
           </button>
-          <button [disabled]="!orderForm.dirty || !orderForm.valid || !isMinOrder" type="submit" class="save-button" (click)="onSubmit()">
+          <button
+            [disabled]="!orderForm.dirty || !orderForm.valid || orderForm.disabled || !isMinOrder"
+            type="submit"
+            class="save-button"
+            (click)="onSubmit()"
+          >
             {{ 'order-edit.btn.save' | translate }}
             <span class="inform-window" *ngIf="!orderForm.valid">
               {{ 'information-window.message' | translate }}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.spec.ts
@@ -210,6 +210,7 @@ describe('UbsAdminOrderComponent', () => {
   });
 
   it('onUpdatePaymentStatus should update additionalPayment and mark orderForm as dirty', () => {
+    component.generalInfo = OrderInfoMock.generalOrderInfo;
     const newPaymentStatus = 'paid';
     component.onUpdatePaymentStatus(newPaymentStatus);
     expect(component.additionalPayment).toEqual(newPaymentStatus);

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -352,7 +352,15 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
 
   onUpdatePaymentStatus(newPaymentStatus: string): void {
     this.additionalPayment = newPaymentStatus;
-    this.orderForm.disabled && this.orderForm.markAsDirty();
+    if (
+      !(
+        this.generalInfo.orderStatus === OrderStatus.CANCELED ||
+        this.generalInfo.orderStatus === OrderStatus.DONE ||
+        this.generalInfo.orderStatus === OrderStatus.BROUGHT_IT_HIMSELF
+      )
+    ) {
+      this.orderForm.markAsDirty();
+    }
   }
 
   onReturnMoneyOrBonusesChange(data: ReturnMoneyOrBonuses) {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -352,7 +352,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
 
   onUpdatePaymentStatus(newPaymentStatus: string): void {
     this.additionalPayment = newPaymentStatus;
-    this.orderForm.markAsDirty();
+    this.orderForm.disabled && this.orderForm.markAsDirty();
   }
 
   onReturnMoneyOrBonusesChange(data: ReturnMoneyOrBonuses) {


### PR DESCRIPTION
[#8243](https://github.com/ita-social-projects/GreenCity/issues/8243)
There was an issue where u could see possibility to change cancelled orders.

**Result:**

https://github.com/user-attachments/assets/6651c130-15f1-49d2-bfad-4b1ba3761d8f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - UI elements in the address input and admin order forms are now conditionally enabled or disabled based on edit mode and admin context, providing a more intuitive user experience.
- **Bug Fixes**
  - Cancel and save buttons in the admin order form are now correctly disabled when the form itself is disabled, preventing unintended actions.
- **Refactor**
  - Improved logic for initializing and controlling form fields and edit states to better reflect user permissions and context.
  - Updated payment status handling to avoid unnecessary form state changes for specific order statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->