### PR TITLE
bugfix/8463 Save button was always active without making any changes

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.html
@@ -107,7 +107,7 @@
         <div class="order-limit-textarea">
           <h6>{{ 'ubs-tariffs.info_about_order_limits' | translate }}</h6>
           <textarea
-            (ngModelChange)="unClickSaveBTN($event)"
+            (input)="unClickSaveBTN($event)"
             maxlength="255"
             formControlName="limitDescription"
             placeholder="{{ 'ubs-tariffs.placeholder_order_limits_info' | translate }}"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.ts
@@ -34,7 +34,7 @@ export class UbsAdminTariffsPricingPageComponent implements OnInit, OnDestroy {
   isLoading = true;
   amount;
   currentCourierId: number;
-  saveBTNClicked: boolean;
+  saveBTNClicked = true;
   areAllCheckBoxEmpty: boolean;
   limitStatus: limitStatus = null;
   description;


### PR DESCRIPTION
[#8463](https://github.com/ita-social-projects/GreenCity/issues/8463)
There was an issue of consistently active save button, even though user did not do any changes.
It was fixed by changing variable of save btn state and changing "ngModelChange" into "input" because using it was outdated, which caused this issue.

**Result:**

https://github.com/user-attachments/assets/377f8a56-f842-4b97-a371-0719aafe8f56





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved responsiveness of the save button for order limits description by updating when changes are detected during user input.
  - Adjusted the initial state of the save button to ensure consistent behavior when the page loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->