### PR TITLE
Bugfix/8604 Freezes after clicking edit eco news fixed

### DIFF
--- a/src/app/greencity/modules/eco-news/components/create-edit-news/create-edit-news-form-builder.ts
+++ b/src/app/greencity/modules/eco-news/components/create-edit-news/create-edit-news-form-builder.ts
@@ -27,7 +27,7 @@ export class CreateEditNewsFormBuilder {
       title: [data.title, [Validators.required, Validators.maxLength(170), this.noWhitespaceValidator]],
       source: [data.source],
       content: [data.text || data.content || data.content.html, contentValidator],
-      tags: this.fb.array(this.localStorageService.getCurrentLanguage() === 'ua' ? data.tagsUa : data.tags),
+      tags: this.fb.array(this.localStorageService.getCurrentLanguage() === 'ua' ? data.tagsUk : data.tagsEn),
       image: [data.imagePath]
     });
   }


### PR DESCRIPTION
[#8604](https://github.com/ita-social-projects/GreenCity/issues/8604)

There was an issue when user wanted to edit eco news, the whole website freezed and user was stuck.

**Result**

https://github.com/user-attachments/assets/6893e863-e61a-420d-a044-eba87f2b5384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of tag selection when editing news by correctly displaying tags according to the selected language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->