### PR TITLE
Bugfix/8642 Amount is converted to xx.xx

### DIFF
--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.html
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.html
@@ -47,13 +47,13 @@
           <div class="mobile_list">
             <div class="mobile mobile_list-paymentAmount">{{ 'user-orders.payment-amount' | translate }}</div>
             <mat-panel-description class="order_list-paymentAmount table-data">
-              {{ order.orderFullPrice | localizedCurrency }}
+              {{ order.orderFullPrice | localizedCurrency: true }}
             </mat-panel-description>
           </div>
           <div class="mobile_list">
             <div class="mobile mobile_list-amountDue">{{ 'user-orders.amount-due' | translate }}</div>
             <mat-panel-description *ngIf="!isOrderDoneOrCancel(order)" class="order_list-paymentAmountDue table-data">
-              {{ order.amountBeforePayment | localizedCurrency }}
+              {{ order.amountBeforePayment | localizedCurrency: true }}
             </mat-panel-description>
           </div>
         </div>


### PR DESCRIPTION
[#8642](https://github.com/ita-social-projects/GreenCity/issues/8642)
There was an issue that amount was disaplyed as XXX, when it was required to be XXX.XX. It was fixed by passing prop true into pipe

**Result:**
![Знімок екрана 2025-06-16 175617](https://github.com/user-attachments/assets/8bee871b-c602-471e-b132-5bb27e09fe30)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated currency formatting in the order list to enhance localization or display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->