### PR TITLE
bugfix/8594 Incorect date of used certificate is fixed

### DIFF
--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-order-payment-pop-up/ubs-user-order-payment-pop-up.component.html
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-order-payment-pop-up/ubs-user-order-payment-pop-up.component.html
@@ -98,7 +98,7 @@
       >
         {{
           'ubs-client-profile.payment.already-used'
-            | translate: { certDate: userCertificate.dateOfUse[userCertificate.dateOfUse.length - 1] }
+            | translate: { certDate: userCertificate.dateOfUse[userCertificate.dateOfUse.length - 1] || userCertificate.dateOfUse }
         }}
       </div>
       <div


### PR DESCRIPTION
[#8594](https://github.com/ita-social-projects/GreenCity/issues/8594)
There was an issue that, certificate date was showed icnorrectly as {{cerDate}} and now it shows correct date if it's allowed, if not shows nothing.

**Result:**
![Знімок екрана 2025-06-17 132742](https://github.com/user-attachments/assets/76efc608-032c-4768-a328-039ec0b2f75f)
![Знімок екрана 2025-06-17 132755](https://github.com/user-attachments/assets/ae1d24c0-59c3-4350-8a55-96f3ae71beed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved display of the certificate usage date in the "already used" message to ensure the correct date is always shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->