### PR TITLE
Bugfix/8582 typo in activate btn word in payment window

### DIFF
--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -82,7 +82,7 @@
       "btn": {
         "pay": "Pay",
         "cancel": "Cancel",
-        "active": "Active"
+        "active": "Activate"
       }
     },
     "cancel-modal": {


### PR DESCRIPTION
[#8582](https://github.com/ita-social-projects/GreenCity/issues/8582)
There was an issue that instead of "Activate" user saw "Active" on button lable.

**Result:**
![image](https://github.com/user-attachments/assets/15c6657b-1dbb-4130-9c6f-cf84f92d2d14)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the English translation for the "Activate" button in the payment section of the client profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->