### PR TITLE
Bugfix/8674 Footer wasn't fixed at the bottom

### DIFF
--- a/src/app/ubs/shared/components/ubs-base-sidebar/ubs-base-sidebar.component.scss
+++ b/src/app/ubs/shared/components/ubs-base-sidebar/ubs-base-sidebar.component.scss
@@ -1,6 +1,7 @@
 .main {
   position: relative;
   display: grid;
+  min-height: 80vh;
 
   .active {
     background-color: var(--ubs-secondary-grey);


### PR DESCRIPTION
[#8674](https://github.com/ita-social-projects/GreenCity/issues/8674)
There was an issue where footer was not fixed at the bottom.

**Result:**
![image](https://github.com/user-attachments/assets/6dbaba21-213a-4228-b3ba-43c653bcff9c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the main container to maintain a minimum height of 80% of the viewport, improving layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->