### PR TITLE
optimization of the tariff's pricing page and rewriting it to use single id endpoint

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
@@ -175,7 +175,7 @@
   </div>
 </form>
 <table class="table-location">
-  <thead *ngIf="cards.length">
+  <thead *ngIf="cards.length || !this.showAllTariff">
     <tr>
       <th id="region">{{ 'ubs-tariffs.region' | translate }}</th>
       <th id="city">{{ 'ubs-tariffs.city' | translate }}</th>
@@ -274,7 +274,7 @@
     </tr>
   </tbody>
 </table>
-<div *ngIf="!isLoadingCards && !cards.length && !isCardExist" class="create-card-field">
+<div *ngIf="!isLoadingCards && !cards.length && !isCardExist && this.showAllTariff" class="create-card-field">
   <span>{{ 'ubs-tariffs.card-not-found' | translate }}</span>
   <button class="ubs-button" (click)="createTariffCard()">{{ 'ubs-tariffs-add-location-pop-up.create_button' | translate }}</button>
 </div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -135,24 +135,26 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
       this.setCard();
     });
     this.initForm();
-    this.getReceivingStation();
     this.region.valueChanges.pipe(takeUntil(this.destroy)).subscribe((value) => {
       this.checkRegionValue(value);
       this.selectedCities = [];
       this.setCountOfCheckedCity();
     });
     this.setStateValue();
-    this.getExistingCard(this.filterData);
-    this.languageService
-      .getCurrentLangObs()
-      .pipe(takeUntil(this.destroy))
-      .subscribe(() => {
-        this.getLocations();
-        this.translateSelectedCity();
-        this.setCountOfCheckedCity();
-        this.setStationPlaceholder();
-        this.getCouriers();
-      });
+    if (this.showAllTariff) {
+      this.getReceivingStation();
+      this.getExistingCard(this.filterData);
+      this.languageService
+        .getCurrentLangObs()
+        .pipe(takeUntil(this.destroy))
+        .subscribe(() => {
+          this.getLocations();
+          this.translateSelectedCity();
+          this.setCountOfCheckedCity();
+          this.setStationPlaceholder();
+          this.getCouriers();
+        });
+    }
     this.definitionUserAuthorities();
   }
 

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.spec.ts
@@ -213,7 +213,7 @@ describe('UbsAdminPricingPageComponent', () => {
     'setLimitDescription',
     'setLimitsBySumOrder',
     'setLimitsByAmountOfBags',
-    'getCardInfo',
+    'getTariffCardInfo',
     'setTariffLimits'
   ]);
   tariffsServiceMock.editInfo.and.returnValue(of([]));
@@ -223,7 +223,7 @@ describe('UbsAdminPricingPageComponent', () => {
   tariffsServiceMock.setLimitDescription.and.returnValue(of([fakeDescription]));
   tariffsServiceMock.setLimitsBySumOrder.and.returnValue(of([fakeSumInfo]));
   tariffsServiceMock.setLimitsByAmountOfBags.and.returnValue(of([fakeBagInfo]));
-  tariffsServiceMock.getCardInfo.and.returnValue(of([fakeCard]));
+  tariffsServiceMock.getTariffCardInfo.and.returnValue(of(fakeCard));
   tariffsServiceMock.setTariffLimits.and.returnValue(of());
 
   const matDialogMock = jasmine.createSpyObj('matDialogMock', ['open']);

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-pricing-page/ubs-admin-tariffs-pricing-page.component.ts
@@ -448,11 +448,11 @@ export class UbsAdminTariffsPricingPageComponent implements OnInit, OnDestroy {
   }
 
   getSelectedTariffCard(): void {
+    const tariffId = this.selectedCardId;
     this.tariffsService
-      .getCardInfo()
+      .getTariffCardInfo(tariffId)
       .pipe(takeUntil(this.destroy))
-      .subscribe((res: TariffCard[]) => {
-        const card = res.find((it) => it.cardId === this.selectedCardId);
+      .subscribe((card: TariffCard) => {
         this.selectedCard = {
           courierUk: card.courierDto.nameUk,
           courierEn: card.courierDto.nameEn,

--- a/src/app/ubs/ubs-admin/services/tariffs.service.ts
+++ b/src/app/ubs/ubs-admin/services/tariffs.service.ts
@@ -17,6 +17,10 @@ export class TariffsService {
     private langService: LanguageService
   ) {}
 
+  getTariffCardInfo(tariffId: number) {
+    return this.http.get(`${mainUbsLink}/ubs/superAdmin/tariff/${tariffId}`);
+  }
+
   getAllTariffsForService(tariffId: number) {
     return this.http.get(`${mainUbsLink}/ubs/superAdmin/${tariffId}/getTariffService`);
   }


### PR DESCRIPTION
[8531](https://github.com/ita-social-projects/GreenCity/issues/8531)

Modified the tariffs dashboard to load filter data only when that page is shown.
Rewrote the tariffs pricing page to use a single tariff endpoint by id to optimize loading of the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to fetch and display individual tariff card details based on their ID.

* **Improvements**
  * Updated visibility logic for the tariff cards table header and "create card" prompt to better reflect the current view and user actions.
  * Enhanced initialization behavior to load certain data only when viewing all tariffs, improving performance and relevance.

* **Bug Fixes**
  * Adjusted test mocks to align with updated service methods for more accurate testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->