### PR TITLE
added correct info display on the order payment page

### DIFF
--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.ts
@@ -285,10 +285,7 @@ export class UBSOrderDetailsComponent extends FormBaseComponent implements OnIni
     const newBagsGroup = this.fb.group({}, { validators: courierLimitValidator(this.bags, validationConfig) });
 
     this.bags.forEach((bag: Bag) => {
-      newBagsGroup.addControl(
-        `quantity${bag.id}`,
-        new FormControl(String(this.getBagQuantity(bag.id) ?? 0), [Validators.min(0), Validators.max(999)])
-      );
+      newBagsGroup.addControl(`quantity${bag.id}`, new FormControl(String(bag.quantity ?? 0), [Validators.min(0), Validators.max(999)]));
     });
     this.orderDetailsForm.setControl('bags', newBagsGroup);
   }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/27a5c9f9-ff5a-4e83-bc20-377e3c6c30ee)
Order details are displayed now for unpaid saved orders.
[8492](https://github.com/ita-social-projects/GreenCity/issues/8492)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the initialization of bag quantity fields to more accurately reflect the raw bag data when viewing order details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->