### PR TITLE
Fixed names of sorting locations

### DIFF
--- a/src/app/greencity/modules/events/components/events-list/events-list.component.ts
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.ts
@@ -127,9 +127,10 @@ export class EventsListComponent implements OnInit, OnDestroy {
   }
 
   private initializeLocationData(): void {
-    this.eventService.getRelevantAddresses().subscribe((data: Addresses[]) => {
-      this.relevantLocationFiltersList = this.getUniqueLocations(data);
-    });
+    this.relevantLocationFiltersList = [
+      { type: 'location', nameEn: 'Online', nameUk: 'Онлайн' },
+      { type: 'location', nameEn: 'Offline', nameUk: 'Офлайн' }
+    ];
     this.cityForm = this.fb.group({
       city: ['', Validators.required]
     });


### PR DESCRIPTION
Fixed Location checkbox in GreenCity Events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the event location filters to show only "Online" and "Offline" options instead of dynamically loading addresses.
  * Previously selected cities from local storage will still appear in the location filters if available.
* **Tests**
  * Added a test to ensure address deletion updates the user profile and form correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->