### PR TITLE
added filtration for region prediction

### DIFF
--- a/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.spec.ts
+++ b/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.spec.ts
@@ -20,7 +20,7 @@ class MockLanguageService {
   }
 }
 
-describe('InputGoogleAutocompleteComponent', () => {
+fdescribe('InputGoogleAutocompleteComponent', () => {
   let component: InputGoogleAutocompleteComponent;
   let fixture: ComponentFixture<InputGoogleAutocompleteComponent>;
   const previousGoogle = (window as any).google;
@@ -137,5 +137,25 @@ describe('InputGoogleAutocompleteComponent', () => {
     const event = new KeyboardEvent('keyup');
     input.dispatchEvent(event);
     expect(component.keyupEmitter.emit).toHaveBeenCalledWith('test value');
+  });
+  fit('should correctly validate region predictions', () => {
+    const validPredictionsMock = [
+      'Київська область, Україна',
+      'Kyiv Oblast, Ukraine',
+      'місто Київ, Україна',
+      'city Kyiv, Ukraine',
+      'Крим, Україна',
+      'Crimea, Ukraine'
+    ];
+
+    const invalidPredictionsMock = ['Кхарківська, Україна', 'Керсонска, Україна', 'Khersonska, Ukraine'];
+
+    validPredictionsMock.forEach((prediction) => {
+      expect(component.regionValidation(prediction)).toBeTrue();
+    });
+
+    invalidPredictionsMock.forEach((prediction) => {
+      expect(component.regionValidation(prediction)).toBeFalse();
+    });
   });
 });

--- a/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.spec.ts
+++ b/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.spec.ts
@@ -238,7 +238,7 @@ describe('InputGoogleAutocompleteComponent', () => {
         { description: 'Place 1, Russia', place_id: '1' } as google.maps.places.AutocompletePrediction,
         { description: 'Place 2, Россия', place_id: '2' } as google.maps.places.AutocompletePrediction,
         { description: 'Place 3, Росія', place_id: '3' } as google.maps.places.AutocompletePrediction,
-        { description: 'Place', place_id: '4' } as google.maps.places.AutocompletePrediction
+        { description: 'Kyiv oblast', place_id: '4' } as google.maps.places.AutocompletePrediction
       ];
       component.predictionList = customPredictionList;
       callback(customPredictionList, (window as any).google.maps.places.PlacesServiceStatus.OK);
@@ -249,7 +249,7 @@ describe('InputGoogleAutocompleteComponent', () => {
     tick(400);
 
     expect(component.predictionList.length).toBe(1);
-    expect(component.predictionList[0].description).toBe('Place');
+    expect(component.predictionList[0].description).toBe('Kyiv oblast');
     expect(component.predictionList[0].place_id).toBe('4');
     expect(mockAutocompleteServiceInstance.getPlacePredictions).toHaveBeenCalled();
   }));
@@ -259,9 +259,9 @@ describe('InputGoogleAutocompleteComponent', () => {
     mockAutocompleteServiceInstance.getPlacePredictions.calls.reset();
     mockAutocompleteServiceInstance.getPlacePredictions.and.callFake((request, callback) => {
       const customPredictionList = [
-        { description: 'вул. Центральна', place_id: '1' } as google.maps.places.AutocompletePrediction,
-        { description: 'вулиця Центральна', place_id: '2' } as google.maps.places.AutocompletePrediction,
-        { description: 'Проспект Свободи', place_id: '3' } as google.maps.places.AutocompletePrediction
+        { description: 'Полтавська область, місто Солонці, вул. Центральна', place_id: '1' } as google.maps.places.AutocompletePrediction,
+        { description: 'Полтавська область, місто Солонці, вулиця Центральна', place_id: '2' } as google.maps.places.AutocompletePrediction,
+        { description: 'Полтавська область, місто Кременчук, Проспект Свободи', place_id: '3' } as google.maps.places.AutocompletePrediction
       ];
       callback(customPredictionList, (window as any).google.maps.places.PlacesServiceStatus.OK);
       return Promise.resolve({ predictions: customPredictionList, status: (window as any).google.maps.places.PlacesServiceStatus.OK });
@@ -272,8 +272,8 @@ describe('InputGoogleAutocompleteComponent', () => {
     tick(400);
 
     expect(component.predictionList.length).toBe(2);
-    expect(component.predictionList[0].description).toBe('вулиця Центральна');
-    expect(component.predictionList[1].description).toBe('Проспект Свободи');
+    expect(component.predictionList[0].description).toBe('Полтавська область, місто Солонці, вулиця Центральна');
+    expect(component.predictionList[1].description).toBe('Полтавська область, місто Кременчук, Проспект Свободи');
     expect(mockAutocompleteServiceInstance.getPlacePredictions).toHaveBeenCalled();
   }));
 
@@ -457,9 +457,9 @@ describe('InputGoogleAutocompleteComponent', () => {
     mockAutocompleteServiceInstance.getPlacePredictions.calls.reset();
     mockAutocompleteServiceInstance.getPlacePredictions.and.callFake((request, callback) => {
       const customPredictionList = [
-        { description: 'Street Central', place_id: '1' } as google.maps.places.AutocompletePrediction,
-        { description: 'Street Central', place_id: '2' } as google.maps.places.AutocompletePrediction,
-        { description: 'Liberty Avenue', place_id: '3' } as google.maps.places.AutocompletePrediction
+        { description: 'Kyiv oblast', place_id: '1' } as google.maps.places.AutocompletePrediction,
+        { description: 'Lviv oblast', place_id: '2' } as google.maps.places.AutocompletePrediction,
+        { description: 'Poltava oblast', place_id: '3' } as google.maps.places.AutocompletePrediction
       ];
       callback(customPredictionList, (window as any).google.maps.places.PlacesServiceStatus.OK);
       return Promise.resolve({ predictions: customPredictionList, status: (window as any).google.maps.places.PlacesServiceStatus.OK });
@@ -470,9 +470,9 @@ describe('InputGoogleAutocompleteComponent', () => {
     tick(400);
 
     expect(component.predictionList.length).toBe(3);
-    expect(component.predictionList[0].description).toBe('Street Central');
-    expect(component.predictionList[1].description).toBe('Street Central');
-    expect(component.predictionList[2].description).toBe('Liberty Avenue');
+    expect(component.predictionList[0].description).toBe('Kyiv oblast');
+    expect(component.predictionList[1].description).toBe('Lviv oblast');
+    expect(component.predictionList[2].description).toBe('Poltava oblast');
     expect(mockAutocompleteServiceInstance.getPlacePredictions).toHaveBeenCalled();
   }));
   

--- a/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.spec.ts
+++ b/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.spec.ts
@@ -20,7 +20,7 @@ class MockLanguageService {
   }
 }
 
-fdescribe('InputGoogleAutocompleteComponent', () => {
+describe('InputGoogleAutocompleteComponent', () => {
   let component: InputGoogleAutocompleteComponent;
   let fixture: ComponentFixture<InputGoogleAutocompleteComponent>;
   const previousGoogle = (window as any).google;
@@ -138,7 +138,7 @@ fdescribe('InputGoogleAutocompleteComponent', () => {
     input.dispatchEvent(event);
     expect(component.keyupEmitter.emit).toHaveBeenCalledWith('test value');
   });
-  fit('should correctly validate region predictions', () => {
+  it('should correctly validate region predictions', () => {
     const validPredictionsMock = [
       'Київська область, Україна',
       'Kyiv Oblast, Ukraine',

--- a/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.ts
+++ b/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.ts
@@ -163,14 +163,22 @@ export class InputGoogleAutocompleteComponent implements OnInit, OnDestroy, Cont
     const regex = new RegExp(Patterns.countriesRestriction);
 
     const filteredPredictions = predictions.filter((prediction) => {
+      const regionIsCorrect = this.regionValidation(prediction.description);
       const description = prediction.description || '';
       const isValidText = Patterns.ukrainianText.test(description) || Patterns.englishText.test(description);
 
-      return isValidText && !regex.test(description);
+      return regionIsCorrect && isValidText && !regex.test(description);
     });
 
     this.predictionList =
       this.languageService.getCurrentLanguage() === 'en' ? filteredPredictions : this.filterDuplicates(filteredPredictions);
+  }
+
+  regionValidation(prediction: string) {
+    if (prediction.includes('Крим') || prediction.includes('Crimea') || prediction.includes('Kyiv') || prediction.includes('Київ')) {
+      return true;
+    }
+    return prediction.toLowerCase().includes('oblast') || prediction.toLowerCase().includes('область');
   }
 
   onPredictionSelected(prediction: GooglePrediction): void {

--- a/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.ts
+++ b/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.ts
@@ -32,6 +32,7 @@ export class InputGoogleAutocompleteComponent implements OnInit, OnDestroy, Cont
   @Output() predictionSelected = new EventEmitter<GooglePrediction | null>();
   @Output() keyupEmitter = new EventEmitter<string>();
 
+  validationLocations = ['Крим', 'Crimea', 'Київ', 'Kyiv'];
   disabled = false;
   touched = false;
   isCitySelected = false;
@@ -175,7 +176,7 @@ export class InputGoogleAutocompleteComponent implements OnInit, OnDestroy, Cont
   }
 
   regionValidation(prediction: string) {
-    if (prediction.includes('Крим') || prediction.includes('Crimea') || prediction.includes('Kyiv') || prediction.includes('Київ')) {
+    if (this.validationLocations.some((location) => prediction.includes(location))) {
       return true;
     }
     return prediction.toLowerCase().includes('oblast') || prediction.toLowerCase().includes('область');


### PR DESCRIPTION
added filtration for the region suggestions to show only valid predictions

<img width="993" height="867" alt="image" src="https://github.com/user-attachments/assets/0c901b0c-8802-4c45-8526-4bb32a57655a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved prediction filtering in the autocomplete input by introducing region-specific validation. Only predictions related to Kyiv, Crimea, or containing "oblast" are now considered valid.  
* **Tests**
  * Added focused tests to verify correct validation of region predictions in the autocomplete input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->