### PR TITLE
Bugfix/8717 Redundant control displayed in calendar pop-up

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -460,6 +460,7 @@ body {
     background-size: 11px;
     width: 11px;
     height: 11px;
+    position: initial !important;
   }
 }
 


### PR DESCRIPTION
[#8717](https://github.com/ita-social-projects/GreenCity/issues/8717)
There was an issue that cross was behind the text

**Result:**
<img width="363" height="79" alt="Знімок екрана 2025-07-15 143946" src="https://github.com/user-attachments/assets/ecf796f4-6ad2-4cb9-b3af-dd48e436018b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the appearance of snack bar action buttons to improve the positioning of the focus indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->