### PR TITLE
Bugfix/8583 Ambiguous wording in payment pop-up

### DIFF
--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -69,7 +69,7 @@
       "already-used": "Certificate has already been used {{certDate}}",
       "expired": "Certificate is invalid. Certificate validity is up to {{certDate}}",
       "bonus": {
-        "need": "Do you want to take advantage of bonuses?",
+        "need": "Do you want to use bonuses?",
         "present": "On your bonus account:",
         "used": "Used",
         "left": "Left"


### PR DESCRIPTION
[#8583](https://github.com/ita-social-projects/GreenCity/issues/8583)
There was an ambiguous wording in payment pop-up.

**Result:**
<img width="619" height="629" alt="Знімок екрана 2025-07-15 155126" src="https://github.com/user-attachments/assets/5ebb653e-c5b6-43a0-a58f-18d1af9f5c5d" />
