### PR TITLE
bugfix/5973-the mandatory filling in the receiving station field message is not displayed when only the location and the courier tags are selected creating a new pricing card

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-card-pop-up/ubs-admin-tariffs-card-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-card-pop-up/ubs-admin-tariffs-card-pop-up.component.ts
@@ -223,6 +223,7 @@ export class UbsAdminTariffsCardPopUpComponent implements OnInit, OnDestroy {
 
         if (this.isEdit || this.provideValues) {
           this.setSelectedStation();
+          this.checkIfAlreadyExists();
         }
 
         const stationsName = this.stations.map((it) => it.name);
@@ -252,6 +253,7 @@ export class UbsAdminTariffsCardPopUpComponent implements OnInit, OnDestroy {
 
         if (this.isEdit || (this.provideValues && this.regionEnglishName)) {
           this.setSelectedCities();
+          this.checkIfAlreadyExists();
         }
       }
     });
@@ -525,12 +527,13 @@ export class UbsAdminTariffsCardPopUpComponent implements OnInit, OnDestroy {
 
       this.currentCourierNameTranslated = this.languageService.getLangValue(courierEnglishName, courierUkrainianName);
       this.currentRegionTranslated = this.languageService.getLangValue(regionEnglishName, regionUkrainianName);
+      this.checkIfAlreadyExists();
     }
   }
 
   checkIfAlreadyExists() {
     this.isCreationAllowed = false;
-    if (this.courierId && this.selectedStation && (this.regionId || this.isEdit) && this.selectedCities.length > 0) {
+    if (this.courierId && this.selectedStation.length && (this.regionId || this.isEdit) && this.selectedCities.length > 0) {
       this.createCardDto();
       this.tariffsService
         .checkIfCardExist(this.createCardObj)

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
@@ -358,6 +358,8 @@ describe('UbsUserProfilePageComponent', () => {
       const deleteButton = fixture.debugElement.query(By.css('.submit-btns .ubs-primary-global-button')).nativeElement;
       deleteButton.click();
       expect(spy).toHaveBeenCalled();
+    } else {
+      expect(component.isSubmitBtnDisabled()).toBeTrue();
     }
     tick(500);
   }));


### PR DESCRIPTION
the bug
<img width="883" height="243" alt="image" src="https://github.com/user-attachments/assets/91861a6e-0856-47e2-b222-554969f1bc70" />

Fixed if already exists, check not to send request to the server if not every variable in the card DTO is filled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI feedback by ensuring existence checks for tariff cards are performed more consistently whenever relevant form data changes, preventing attempts to create duplicate cards.

* **Tests**
  * Enhanced test coverage for the user profile page by verifying that the submit button is disabled when the form is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->