### PR TITLE
Bugfix/8718 google script rare new error

### DIFF
--- a/src/app/greencity/modules/events/components/event-editor/components/create-event-dates/place-online/place-online.component.spec.ts
+++ b/src/app/greencity/modules/events/components/event-editor/components/create-event-dates/place-online/place-online.component.spec.ts
@@ -451,10 +451,9 @@ describe('PlaceOnlineComponent', () => {
     expect(component.map.center).toEqual(latLng);
   });
 
-  it('should update map with default coords if lat/lng are missing', () => {
+  it('should not update map if lat/lng are missing', () => {
     const latLng = { lat: null, lng: 0 };
     component['updateMap'](latLng as any);
-    expect(component.mapMarkerCoords).toEqual({ lat: 0, lng: 0 });
     expect(component.map.panTo).not.toHaveBeenCalled();
     expect(component.map.center).toEqual({ lat: 0, lng: 0 });
   });

--- a/src/app/greencity/modules/events/components/event-editor/components/create-event-dates/place-online/place-online.component.ts
+++ b/src/app/greencity/modules/events/components/event-editor/components/create-event-dates/place-online/place-online.component.ts
@@ -327,9 +327,6 @@ export class PlaceOnlineComponent implements OnInit, OnDestroy {
       this.mapMarkerCoords = latLngLiteral;
       this.map.panTo(latLngLiteral);
       this.map.center = latLngLiteral;
-    } else {
-      this.mapMarkerCoords = { lat: 0, lng: 0 };
-      this.map.center = { lat: 0, lng: 0 };
     }
   }
 

--- a/src/app/greencity/modules/user/components/profile/profile-widget/profile-progress/profile-progress.component.scss
+++ b/src/app/greencity/modules/user/components/profile/profile-widget/profile-progress/profile-progress.component.scss
@@ -66,7 +66,7 @@ p {
     height: 189px;
     grid-template-rows: repeat(2, 1fr);
     grid-template-columns: repeat(2, 1fr);
-    gap: 16px 16px;
+    gap: 16px;
     border-top: 1px solid var(--light-green-grey-color);
 
     .chain {
@@ -90,7 +90,7 @@ p {
 @include responsiveMobileFirst(2xl) {
   .stat {
     width: 220px;
-    gap: 15px 15px;
+    gap: 15px;
   }
 }
 

--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -146,15 +146,17 @@
               aria-label="language switcher"
               role="menu"
               tabindex="-1"
-              [attr.aria-expanded]="langDropdownVisible ? 'true' : 'false'"
+              [attr.aria-expanded]="langDropdownVisible && canChangeLang ? 'true' : 'false'"
+              [attr.aria-disabled]="!canChangeLang"
               [ngClass]="{
                 'add-shadow': langDropdownVisible,
                 'header_lang-switcher-wrp header_navigation-menu-right-lang': true,
-                'ubs-lang-switcher': isUBS
+                'ubs-lang-switcher': isUBS,
+                'disabled-lang-switcher': !canChangeLang
               }"
-              (click)="langDropdownVisible = !langDropdownVisible"
-              (keydown.enter)="toggleLangDropdown($event)"
-              (keydown.space)="toggleLangDropdown($event)"
+              (click)="canChangeLang && (langDropdownVisible = !langDropdownVisible)"
+              (keydown.enter)="canChangeLang && toggleLangDropdown($event)"
+              (keydown.space)="canChangeLang && toggleLangDropdown($event)"
               (clickOutSide)="autoCloseLangDropDown($event)"
             >
               <li role="option" aria-label="english" class="lang-option" tabindex="0">

--- a/src/app/shared/components/header/header.component.spec.ts
+++ b/src/app/shared/components/header/header.component.spec.ts
@@ -7,17 +7,22 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HeaderComponent } from './header.component';
-import { BehaviorSubject, of, Subject } from 'rxjs';
+import { BehaviorSubject, filter, of, Subject } from 'rxjs';
 import { JwtService } from 'src/app/shared/services/jwt/jwt.service';
 import { UserService } from 'src/app/shared/services/user/user.service';
 import { HabitStatisticService } from 'src/app/shared/services/habit-statistic/habit-statistic.service';
 import { UserOwnAuthService } from 'src/app/shared/services/auth/user-own-auth.service';
 import { SearchService } from 'src/app/shared/services/search/search.service';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { Router } from '@angular/router';
+import { MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { Router, NavigationStart } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 import { SocketService } from 'src/app/shared/services/socket/socket.service';
+import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component';
+import { UserNotificationsPopUpComponent } from 'src/app/greencity/modules/user/components/profile/user-notifications/user-notifications-pop-up/user-notifications-pop-up.component';
+import { CommonService } from 'src/app/chat/service/common/common.service';
+import { GoogleScript } from '@assets/google-script/google-script';
+import { OrderService } from 'src/app/ubs/ubs/services/order.service';
 
 class MatDialogMock {
   afterAllClosed = of(true);
@@ -43,7 +48,7 @@ describe('HeaderComponent', () => {
 
   const mockData = ['SEE_BIG_ORDER_TABLE', 'SEE_CLIENTS_PAGE', 'SEE_CERTIFICATES', 'SEE_EMPLOYEES_PAGE', 'SEE_TARIFFS'];
   const storeMock = jasmine.createSpyObj('Store', ['select', 'dispatch']);
-  storeMock.select.and.returnValue(of({ emplpyees: { employeesPermissions: mockData } }));
+  storeMock.select.and.returnValue(of({ employees: { employeesPermissions: mockData } }));
   const fakeJwtService = jasmine.createSpyObj('JwtService', ['getEmailFromAccessToken']);
 
   const localStorageServiceMock: LocalStorageService = jasmine.createSpyObj('LocalStorageService', ['userIdBehaviourSubject']);
@@ -95,6 +100,12 @@ describe('HeaderComponent', () => {
   socketServiceMock.onMessage = () => of();
   socketServiceMock.initiateConnection = () => {};
 
+  const commonChatServiceMock: CommonService = jasmine.createSpyObj('CommonService', [], { isChatVisible$: new BehaviorSubject(false) });
+
+  const googleScriptMock: GoogleScript = jasmine.createSpyObj('GoogleScript', [], { mapReady: of(true) });
+
+  const orderServiceMock: OrderService = jasmine.createSpyObj('OrderService', ['cancelUBSwithoutSaving']);
+
   let dialog: MatDialog;
   let router: Router;
 
@@ -120,7 +131,10 @@ describe('HeaderComponent', () => {
         { provide: LanguageService, useValue: languageServiceMock },
         { provide: SearchService, useValue: searchServiceMock },
         { provide: UserOwnAuthService, useValue: userOwnAuthServiceMock },
-        { provide: SocketService, useValue: socketServiceMock }
+        { provide: SocketService, useValue: socketServiceMock },
+        { provide: CommonService, useValue: commonChatServiceMock },
+        { provide: GoogleScript, useValue: googleScriptMock },
+        { provide: OrderService, useValue: orderServiceMock }
       ]
     }).compileComponents();
   }));
@@ -130,17 +144,16 @@ describe('HeaderComponent', () => {
     component = fixture.componentInstance;
     fakeJwtService.userRole$ = of('ROLE_UBS_EMPLOYEE');
 
-    // init states
     component.dropdownVisible = false;
     component.langDropdownVisible = false;
     component.toggleBurgerMenu = false;
     (component as any).userId = 1;
     dialog = TestBed.inject(MatDialog);
     router = TestBed.inject(Router);
-    spyOn(router, 'navigate');
+    spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
     spyOn(router, 'navigateByUrl').and.returnValue(Promise.resolve(true));
-    spyOn(router.url, 'includes');
-    spyOn(router.events, 'pipe').and.returnValue(of(true));
+    spyOnProperty(router, 'url', 'get').and.returnValue('/greenCity');
+    spyOn(router.events, 'pipe').and.returnValue(of(new NavigationStart(1, '/some-route')));
     userOwnAuthServiceMock.isLoginUserSubject = new BehaviorSubject(true);
     fixture.detectChanges();
   });
@@ -156,7 +169,7 @@ describe('HeaderComponent', () => {
       expect(component.dropdownVisible).toBeTruthy();
     });
 
-    it('should toogle burger menu state', () => {
+    it('should toggle burger menu state', () => {
       component.onToggleBurgerMenu();
       expect(component.toggleBurgerMenu).toBeTruthy();
     });
@@ -177,6 +190,110 @@ describe('HeaderComponent', () => {
       tick();
       expect(spy1).toHaveBeenCalled();
     }));
+
+    it('should focus element after auth modal closes', fakeAsync(() => {
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: () => of(true)
+      } as MatDialogRef<AuthModalComponent>);
+      const focusSpy = spyOn(component, 'focusDone');
+      component.openAuthModalWindow('sign-in');
+      tick();
+      expect(focusSpy).toHaveBeenCalled();
+    }));
+
+    it('should call openAboutServicePopUp on onPressEnterAboutService', () => {
+      const spy = spyOn(component, 'openAboutServicePopUp');
+      const event = { preventDefault: () => {} } as Event;
+      component.onPressEnterAboutService(event);
+      expect(spy).toHaveBeenCalledWith(event);
+    });
+
+    it('should navigate to notifications page when openNotificationsDialog is called', () => {
+      component['userId'] = 123;
+      component.openNotificationsDialog();
+      expect(router.navigate).toHaveBeenCalledWith(['greenCity/profile', 123, 'notifications']);
+    });
+
+    it('should open UserNotificationsPopUpComponent when openNotificationPopUp is called', () => {
+      const spy = spyOn(dialog, 'open').and.returnValue({
+        afterClosed: () => of(null)
+      } as MatDialogRef<UserNotificationsPopUpComponent>);
+      component.openNotificationPopUp();
+      expect(spy).toHaveBeenCalledWith(UserNotificationsPopUpComponent, jasmine.any(Object));
+    });
+
+    it('should navigate to all notifications if openAll is true', fakeAsync(() => {
+      spyOn(dialog, 'open').and.returnValue({
+        afterClosed: () => of({ openAll: true })
+      } as MatDialogRef<UserNotificationsPopUpComponent>);
+      component['userId'] = 123;
+      component.openNotificationPopUp();
+      tick();
+      expect(router.navigate).toHaveBeenCalledWith(['greenCity/profile', 123, 'notifications']);
+    }));
+
+    it('should signOut correctly when isUBS is true', fakeAsync(() => {
+      component.isUBS = true;
+      component.signOut();
+      tick();
+      expect(router.navigateByUrl).toHaveBeenCalledWith('/ubs');
+    }));
+
+    it('should toggle langDropdownVisible on toggleLangDropdown', () => {
+      const event = { preventDefault: () => {} } as Event;
+      component.langDropdownVisible = false;
+      component.toggleLangDropdown(event);
+      expect(component.langDropdownVisible).toBeTrue();
+      component.toggleLangDropdown(event);
+      expect(component.langDropdownVisible).toBeFalse();
+    });
+
+    it('should change current language onKeydownLangOption with Enter key', () => {
+      const changeLangSpy = spyOn(component, 'changeCurrentLanguage');
+      const event = new KeyboardEvent('keydown', { key: 'Enter' });
+      const mockArrayLang = [{ lang: 'EN' }, { lang: 'UA' }];
+      component.arrayLang = mockArrayLang as any;
+      component.onKeydownLangOption(event, 1);
+      expect(changeLangSpy).toHaveBeenCalledWith('UA', 1);
+    });
+
+    it('should change current language onKeydownLangOption with Space key', () => {
+      const changeLangSpy = spyOn(component, 'changeCurrentLanguage');
+      const event = new KeyboardEvent('keydown', { key: ' ' });
+      const mockArrayLang = [{ lang: 'EN' }, { lang: 'UA' }];
+      component.arrayLang = mockArrayLang as any;
+      component.onKeydownLangOption(event, 1);
+      expect(changeLangSpy).toHaveBeenCalledWith('UA', 1);
+    });
+
+    it('should prevent default event onKeydownLangOption', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Enter' });
+      const preventDefaultSpy = spyOn(event, 'preventDefault');
+      component.arrayLang = [{ lang: 'EN' }] as any;
+      component.onKeydownLangOption(event, 0);
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+
+    it('should stop propagation onKeydownLangOption', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Enter' });
+      const stopPropagationSpy = spyOn(event, 'stopPropagation');
+      component.arrayLang = [{ lang: 'EN' }] as any;
+      component.onKeydownLangOption(event, 0);
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
+
+    it('should add modal-open class to body when burger menu is open', () => {
+      component.toggleBurgerMenu = false;
+      component.onToggleBurgerMenu();
+      expect(document.body.classList).toContain('modal-open');
+    });
+
+    it('should remove modal-open class from body when burger menu is closed', () => {
+      document.body.classList.add('modal-open');
+      component.toggleBurgerMenu = true;
+      component.onToggleBurgerMenu();
+      expect(document.body.classList).not.toContain('modal-open');
+    });
   });
 
   describe('getHeaderClass', () => {
@@ -202,6 +319,180 @@ describe('HeaderComponent', () => {
       const headerClass = component.getHeaderClass();
 
       expect(headerClass).toEqual('header_navigation-menu');
+    });
+  });
+
+  describe('Lifecycle hooks', () => {
+    it('should call setUbsRegistration on localStorageService on ngOnInit', () => {
+      const spy = spyOn(localStorageServiceMock, 'setUbsRegistration');
+      component.ngOnInit();
+      expect(spy).toHaveBeenCalledWith(component.isUBS);
+    });
+
+    it('should subscribe to searchSubject and allSearchSubject on ngOnInit', () => {
+      const searchSpy = spyOn(searchServiceMock.searchSubject, 'subscribe').and.callThrough();
+      const allSearchSpy = spyOn(searchServiceMock.allSearchSubject, 'subscribe').and.callThrough();
+      component.ngOnInit();
+      expect(searchSpy).toHaveBeenCalled();
+      expect(allSearchSpy).toHaveBeenCalled();
+    });
+
+    it('should update name when firstNameBehaviourSubject emits', fakeAsync(() => {
+      const testName = 'TestUser';
+      localStorageServiceMock.firstNameBehaviourSubject.next(testName);
+      fixture.detectChanges();
+      expect(component.name).toEqual(testName);
+    }));
+
+    it('should set isLoggedIn to true if userId is not null', fakeAsync(() => {
+      localStorageServiceMock.userIdBehaviourSubject.next(123);
+      fixture.detectChanges();
+      expect(component.isLoggedIn).toBeTrue();
+    }));
+
+    it('should call initLanguage on ngOnInit', () => {
+      const spy = spyOn(component as any, 'initLanguage');
+      component.ngOnInit();
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should call subToGoogleScript on ngOnInit', () => {
+      const spy = spyOn(component as any, 'subToGoogleScript');
+      component.ngOnInit();
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should set managementLink when accessTokenBehaviourSubject emits', fakeAsync(() => {
+      const testToken = 'testToken123';
+      localStorageServiceMock.accessTokenBehaviourSubject.next(testToken);
+      fixture.detectChanges();
+      expect(component.managementLink).toContain(testToken);
+    }));
+
+    it('should unsubscribe on ngOnDestroy', () => {
+      const spy = spyOn(component['destroySub'], 'next');
+      const spyComplete = spyOn(component['destroySub'], 'unsubscribe');
+      component.ngOnDestroy();
+      expect(spy).toHaveBeenCalledWith(true);
+      expect(spyComplete).toHaveBeenCalled();
+    });
+  });
+
+  describe('Language methods', () => {
+    it('should initialize language to UA if no language is set', () => {
+      spyOn(languageServiceMock, 'getCurrentLanguage').and.returnValue(null);
+      spyOn(languageServiceMock, 'changeCurrentLanguage');
+      component['initLanguage']();
+      expect(component.currentLanguage).toEqual(Language.UA);
+      expect(languageServiceMock.changeCurrentLanguage).toHaveBeenCalledWith(Language.UA);
+    });
+  });
+
+  describe('Search methods', () => {
+    it('should set isSearchClicked based on signal', () => {
+      component['openSearchSubscription'](true);
+      expect(component.isSearchClicked).toBeTrue();
+      component['openSearchSubscription'](false);
+      expect(component.isSearchClicked).toBeFalse();
+    });
+
+    it('should set isAllSearchOpen based on signal', () => {
+      component['openAllSearchSubscription'](true);
+      expect(component.isAllSearchOpen).toBeTrue();
+      component['openAllSearchSubscription'](false);
+      expect(component.isAllSearchOpen).toBeFalse();
+    });
+  });
+
+  describe('User and Role related methods', () => {
+    it('should return correct user ID', () => {
+      (component as any).userId = 456;
+      expect(component.getUserId()).toEqual(456);
+      (component as any).userId = null;
+      expect(component.getUserId()).toEqual('not_signed_in');
+    });
+
+    it('should set isGreenCityAdmin to true if userRole is ROLE_ADMIN', fakeAsync(() => {
+      jwtServiceMock.userRole$.next('ROLE_ADMIN');
+      component.ngOnInit();
+      tick();
+      expect(component.isGreenCityAdmin).toBeTrue();
+    }));
+
+    it('should set isGreenCityAdmin to false if userRole is not ROLE_ADMIN', fakeAsync(() => {
+      jwtServiceMock.userRole$.next('ROLE_USER');
+      component.ngOnInit();
+      tick();
+      expect(component.isGreenCityAdmin).toBeFalse();
+    }));
+  });
+
+  describe('Socket and Notifications', () => {
+    it('should display "99+" if newMessagesCount is greater than 99', () => {
+      component.newMessagesCount = 100;
+      expect(component.displayMessagesCount()).toEqual('99+');
+    });
+
+    it('should display newMessagesCount as string if less than or equal to 99', () => {
+      component.newMessagesCount = 50;
+      expect(component.displayMessagesCount()).toEqual('50');
+    });
+  });
+
+  describe('Navigation and Routes', () => {
+    it('should return correct router link for UBS admin', () => {
+      component.isUBS = true;
+      component.isAdmin = true;
+      expect(component.getRouterLink()).toEqual('/ubs/admin/orders');
+    });
+
+    it('should return correct router link for UBS non-admin', () => {
+      component.isUBS = true;
+      component.isAdmin = false;
+      expect(component.getRouterLink()).toEqual('/ubs');
+    });
+
+    it('should return correct router link for GreenCity', () => {
+      component.isUBS = false;
+      expect(component.getRouterLink()).toEqual('/greenCity');
+    });
+
+    it('should navigate to saved news when navigateToSaved is called', () => {
+      component.navigateToSaved();
+      expect(router.navigate).toHaveBeenCalledWith(['/greenCity/news'], { queryParams: { isBookmark: true } });
+    });
+  });
+
+  describe('Header UI and state management', () => {
+    it('should set selectedIndex and navLinks and headerImageList and imageLogo on toggleHeader', () => {
+      spyOn(component['headerService'], 'getSelectedIndex').and.returnValue(5);
+      component.toggleHeader();
+      expect(component.selectedIndex).toEqual(5);
+      expect(component.headerImageList).toBeDefined();
+      expect(component.imageLogo).toBeDefined();
+    });
+
+    it('should set ariaStatus to expanded when dropdownVisible is true', () => {
+      component.dropdownVisible = false;
+      component.toggleDropdown();
+      expect(component.ariaStatus).toEqual('profile options expanded');
+    });
+
+    it('should set ariaStatus to collapsed when dropdownVisible is false', () => {
+      component.dropdownVisible = true;
+      component.toggleDropdown();
+      expect(component.ariaStatus).toEqual('profile options collapsed');
+    });
+
+    it('should set dropdownVisible to false and ariaStatus to collapsed on autoCloseUserDropDown', () => {
+      component.autoCloseUserDropDown(false);
+      expect(component.dropdownVisible).toBeFalse();
+      expect(component.ariaStatus).toEqual('profile options collapsed');
+    });
+
+    it('should set langDropdownVisible to false on autoCloseLangDropDown', () => {
+      component.autoCloseLangDropDown(false);
+      expect(component.langDropdownVisible).toBeFalse();
     });
   });
 });

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -26,6 +26,7 @@ import { ResetFriends } from 'src/app/store/actions/friends.actions';
 import { SocketService } from 'src/app/shared/services/socket/socket.service';
 import { SignOutAction } from 'src/app/store/actions/auth.actions';
 import { CommonService } from 'src/app/chat/service/common/common.service';
+import { GoogleScript } from '@assets/google-script/google-script';
 
 @Component({
   selector: 'app-header',
@@ -64,6 +65,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
   selectedIndex: number = null;
   currentLanguage: string;
   imgAlt: string;
+  canChangeLang: boolean;
+
   private localeStorageService: LocalStorageService;
   private jwtService: JwtService;
   private router: Router;
@@ -82,7 +85,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
     injector: Injector,
     private store: Store,
     private socketService: SocketService,
-    private commonChatService: CommonService
+    private commonChatService: CommonService,
+    private readonly googleScript: GoogleScript
   ) {
     this.localeStorageService = injector.get(LocalStorageService);
     this.jwtService = injector.get(JwtService);
@@ -125,8 +129,16 @@ export class HeaderComponent implements OnInit, OnDestroy {
     this.updateArrayLang();
     this.initLanguage();
 
+    this.subToGoogleScript();
+
     this.localeStorageService.accessTokenBehaviourSubject.pipe(takeUntil(this.destroySub)).subscribe((token) => {
       this.managementLink = `${this.backEndLink}token?accessToken=${token}`;
+    });
+  }
+
+  private subToGoogleScript() {
+    this.googleScript.mapReady.pipe(takeUntil(this.destroySub)).subscribe((res: boolean) => {
+      this.canChangeLang = res;
     });
   }
 
@@ -419,6 +431,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   onKeydownLangOption(event: KeyboardEvent, index: number) {
+    event.stopPropagation();
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       this.changeCurrentLanguage(this.arrayLang[index].lang, index);

--- a/src/app/ubs/ubs-admin/components/shared/components/cron-picker/cron-picker.component.scss
+++ b/src/app/ubs/ubs-admin/components/shared/components/cron-picker/cron-picker.component.scss
@@ -25,7 +25,7 @@
       ::ng-deep .mat-button-toggle-group {
         display: grid;
         grid-template-columns: repeat(6, auto);
-        gap: 1px 1px;
+        gap: 1px;
         border: 0;
       }
     }
@@ -40,7 +40,7 @@
       ::ng-deep .mat-button-toggle-group {
         display: grid;
         grid-template-columns: repeat(8, auto);
-        gap: 1px 1px;
+        gap: 1px;
         border: 0;
       }
     }


### PR DESCRIPTION
[#8718](https://github.com/ita-social-projects/GreenCity/issues/8718)

New issue appeared, but it was extremely rare and few page reloads could be needed. The language can not be changed untill google script is loaded (approximately 0.5 second) only on pages where google script is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language switcher in the header now visually indicates and enforces when language selection is disabled, improving accessibility and user feedback.

* **Bug Fixes**
  * Map marker and center are no longer reset to default coordinates when invalid or missing location data is provided during event creation, preserving the previous map state.

* **Style**
  * Simplified grid and gap spacing in profile progress and cron picker components for more consistent and maintainable layouts.

* **Accessibility**
  * Improved ARIA attributes and keyboard handling for the language switcher dropdown, enhancing screen reader and keyboard navigation support.

* **Tests**
  * Expanded test coverage for the header component, including UI interactions, lifecycle hooks, and state management, ensuring higher reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->