### PR TITLE
Bugfix/8868 Incorrect phone placeholder fix in employee edit page

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-edit-form/ubs-admin-employee-edit-form.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-edit-form/ubs-admin-employee-edit-form.component.html
@@ -26,7 +26,15 @@
       <div class="private-section">
         <div class="form-group odd">
           <label for="phoneNumber" class="group-title">{{ 'ubs-employee.phone-number' | translate }}</label>
-          <input id="phoneNumber" formControlName="phoneNumber" placeholder="+380" [imask]="{ mask: phoneMask }" [unmask]="true" />
+          <input
+            id="phoneNumber"
+            formControlName="phoneNumber"
+            placeholder="+380"
+            [imask]="phoneMask"
+            [unmask]="true"
+            (focus)="onPhoneFocus()"
+            (blur)="onPhoneBlur()"
+          />
           <div class="validation" *ngIf="phoneNumber.invalid && phoneNumber.touched">
             <app-ubs-input-error
               [formElement]="phoneNumber"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-edit-form/ubs-admin-employee-edit-form.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-edit-form/ubs-admin-employee-edit-form.component.spec.ts
@@ -286,4 +286,19 @@ describe('UbsAdminEmployeeEditFormComponent', () => {
       });
     });
   });
+
+  it('should add +380 to the value of recipientPhone', () => {
+    component.phoneNumber.setValue('');
+    component.onPhoneFocus();
+
+    expect(component.phoneNumber.value).toBe('+380');
+  });
+
+  it('should clear the value of recipientPhone', () => {
+    component.phoneNumber.setValue('+380');
+    component.onPhoneBlur();
+
+    expect(component.phoneNumber.value).toBe('');
+    expect(component.phoneNumber.untouched).toBe(true);
+  });
 });

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-edit-form/ubs-admin-employee-edit-form.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-edit-form/ubs-admin-employee-edit-form.component.ts
@@ -16,7 +16,7 @@ import { AddEmployee, UpdateEmployee } from 'src/app/store/actions/employee.acti
 import { skip, takeUntil } from 'rxjs/operators';
 import { ShowImgsPopUpComponent } from '@ubs/shared/components/show-imgs-pop-up/show-imgs-pop-up.component';
 import { Subject } from 'rxjs';
-import { Masks, Patterns } from 'src/assets/patterns/patterns';
+import { Masks, Patterns, phonePrefix } from 'src/assets/patterns/patterns';
 import { PhoneNumberValidator } from '@ubs/shared/validators/phone-validator/phone.validator';
 import { TariffsService } from 'src/app/ubs/ubs-admin/services/tariffs.service';
 import { LanguageService } from 'src/app/shared/i18n/language.service';
@@ -39,6 +39,7 @@ export class UbsAdminEmployeeEditFormComponent implements OnInit, OnDestroy {
   tariffs: TariffForEmployee[] = [];
   employeeDataToSend: EmployeeDataToSend;
   phoneMask = Masks.phoneMask;
+  phonePrefix: string = phonePrefix;
   private maxImageSize = 10485760;
   private destroyed$: Subject<void> = new Subject<void>();
   isWarning = false;
@@ -376,5 +377,18 @@ export class UbsAdminEmployeeEditFormComponent implements OnInit, OnDestroy {
         !this.isInitialPositionsChanged &&
         !this.isInitialTariffsChanged)
     );
+  }
+
+  onPhoneFocus(): void {
+    if (!this.phoneNumber.value) {
+      this.phoneNumber.setValue(this.phonePrefix);
+    }
+  }
+
+  onPhoneBlur(): void {
+    if (this.phoneNumber.value === this.phonePrefix) {
+      this.phoneNumber.setValue('');
+      this.phoneNumber.markAsUntouched();
+    }
   }
 }


### PR DESCRIPTION
[#8868](https://github.com/ita-social-projects/GreenCity/issues/8868)

There was an issue that instead of "+380" only "+38" appeared in phone number input.

### Result:


https://github.com/user-attachments/assets/16c6355b-f36e-43a4-a872-d4899e863dac



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved phone number input in the employee edit form: the field now automatically adds the country code when focused and removes it if left empty on blur.

* **Bug Fixes**
  * Enhanced handling of phone number input to prevent accidental submission of incomplete numbers.

* **Tests**
  * Added unit tests to verify the new phone number input behavior on focus and blur events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->