### PR TITLE
fixed display of the order comment and delivery according to the mockup

### DIFF
--- a/src/app/ubs/ubs-user/components/ubs-user-order-details/ubs-user-order-details.component.scss
+++ b/src/app/ubs/ubs-user/components/ubs-user-order-details/ubs-user-order-details.component.scss
@@ -14,6 +14,10 @@
     font-family: var(--primary-font);
     grid-column: 1 / -1;
   }
+
+  .recipient {
+    grid-column: 1 / -1;
+  }
 }
 
 .table_of_details {


### PR DESCRIPTION
[#8576](https://github.com/ita-social-projects/GreenCity/issues/8576)
aligned to the left order comment and additional information 
<img width="1717" height="700" alt="image" src="https://github.com/user-attachments/assets/3707fac9-e9b2-4cfc-a97a-6e0888c44013" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout of the recipient section in order details, ensuring it spans the full width of its container for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->