### PR TITLE
Bugfix/8899 Tot existing endpoint notifications fixed

### DIFF
--- a/src/app/ubs/ubs-user/services/user-messages.service.spec.ts
+++ b/src/app/ubs/ubs-user/services/user-messages.service.spec.ts
@@ -51,7 +51,7 @@ describe('UserMessagesService', () => {
     service.getCountUnreadNotification().subscribe((data) => {
       expect(data).toBeGreaterThanOrEqual(0);
     });
-    const req = httpMock.expectOne(`${mainUbsLink}/notifications/quantityUnreadenNotifications`);
+    const req = httpMock.expectOne(`${mainUbsLink}/notifications/quantityUnreadNotifications`);
     expect(req.request.method).toBe('GET');
   });
 

--- a/src/app/ubs/ubs-user/services/user-messages.service.ts
+++ b/src/app/ubs/ubs-user/services/user-messages.service.ts
@@ -20,7 +20,7 @@ export class UserMessagesService implements OnDestroy {
   }
 
   getCountUnreadNotification(): Observable<number> {
-    return this.http.get<number>(`${this.url}/notifications/quantityUnreadenNotifications`);
+    return this.http.get<number>(`${this.url}/notifications/quantityUnreadNotifications`);
   }
 
   markNotificationAsRead(id: number): Observable<void> {


### PR DESCRIPTION
[#8899](https://github.com/ita-social-projects/GreenCity/issues/8899)

There was an issue that requests were sent to wrong endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the notifications endpoint to ensure accurate retrieval of unread notification counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->