### PR TITLE
Bugfix/#8101 Set up default reason correctly

### DIFF
--- a/src/app/ubs/ubs-admin/components/add-order-cancellation-reason/add-order-cancellation-reason.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/add-order-cancellation-reason/add-order-cancellation-reason.component.spec.ts
@@ -62,4 +62,8 @@ describe('AddOrderCancellationReasonComponent', () => {
     component.initForm();
     expect(spy).toHaveBeenCalled();
   });
+
+  it('should set the default reason', () => {
+    expect(component.cancellationReason).toEqual(component.defaultOption);
+  });
 });

--- a/src/app/ubs/ubs-admin/components/add-order-cancellation-reason/add-order-cancellation-reason.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/add-order-cancellation-reason/add-order-cancellation-reason.component.spec.ts
@@ -64,6 +64,6 @@ describe('AddOrderCancellationReasonComponent', () => {
   });
 
   it('should set the default reason', () => {
-    expect(component.cancellationReason).toEqual(component.defaultOption);
+    expect(component.cancellationReason).toEqual('DELIVERED_HIMSELF');
   });
 });

--- a/src/app/ubs/ubs-admin/components/add-order-cancellation-reason/add-order-cancellation-reason.component.ts
+++ b/src/app/ubs/ubs-admin/components/add-order-cancellation-reason/add-order-cancellation-reason.component.ts
@@ -49,7 +49,9 @@ export class AddOrderCancellationReasonComponent implements OnInit {
       this.adminName = firstName;
     });
 
-    this.cancellationReason = this.defaultOption;
+    if (!this.cancellationReason) {
+      this.cancellationReason = this.defaultOption;
+    }
   }
 
   initForm(): void {

--- a/src/app/ubs/ubs-admin/components/add-order-cancellation-reason/add-order-cancellation-reason.component.ts
+++ b/src/app/ubs/ubs-admin/components/add-order-cancellation-reason/add-order-cancellation-reason.component.ts
@@ -20,6 +20,7 @@ export class AddOrderCancellationReasonComponent implements OnInit {
   commentForm: FormGroup;
   cancellationReason: string;
   cancellationComment: string;
+  defaultOption = CancellationReason.DELIVERED_HIMSELF;
   orderID: number;
   isHistory: boolean;
   adminName;
@@ -47,6 +48,8 @@ export class AddOrderCancellationReasonComponent implements OnInit {
     this.localeStorageService.firstNameBehaviourSubject.pipe(takeUntil(this.destroySub)).subscribe((firstName) => {
       this.adminName = firstName;
     });
+
+    this.cancellationReason = this.defaultOption;
   }
 
   initForm(): void {


### PR DESCRIPTION
[#8101](https://github.com/ita-social-projects/GreenCity/issues/8101)

There was an issue that no option was selected, but brouth by himself had to be chosen.

### Result:

https://github.com/user-attachments/assets/366742d8-3f2c-4399-9778-28cfce134287



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The cancellation reason now defaults to "Delivered Himself" when adding a new order cancellation reason.

* **Tests**
  * Added a unit test to verify the default cancellation reason is set correctly upon initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->