### PR TITLE
Bugfix/8579 8580 Display of "enroll money to account" worked incorrectrly

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.spec.ts
@@ -12,6 +12,7 @@ import { OrderService } from '../../services/order.service';
 import { AddPaymentComponent } from '../add-payment/add-payment.component';
 import { OrderInfoMockedData } from './../../services/orderInfoMock';
 import { UbsAdminOrderPaymentComponent } from './ubs-admin-order-payment.component';
+import { SimpleChanges } from '@angular/core';
 
 describe('UbsAdminOrderPaymentComponent', () => {
   let component: UbsAdminOrderPaymentComponent;
@@ -182,5 +183,63 @@ describe('UbsAdminOrderPaymentComponent', () => {
     expect(component.paymentsArray[0].amount).toBe(100);
     expect(component.paymentsArray[1].amount).toBe(200);
     expect(component.paymentsArray[2].amount).toBe(300);
+  });
+
+  it('should change overpayment', () => {
+    component.paidAmount = 300;
+    component.orderStatus = OrderStatus.CANCELED;
+    component['setOverpaymentForCancelledStatus']();
+
+    expect(component.overpayment).toEqual(300);
+  });
+
+  it('should not change overpayment', () => {
+    component.overpayment = 0;
+    component.orderStatus = OrderStatus.FORMED;
+    component['setOverpaymentForCancelledStatus']();
+
+    expect(component.overpayment).toEqual(0);
+  });
+
+  it('should update payment info and call setOverpaymentForCancelledStatus when paymentInfo changes', () => {
+    const newPaymentInfo = {
+      paymentTableInfoDto: { overpayment: 50, paidAmount: 150, paymentInfoDtos: [], unPaidAmount: 0 },
+      orderFullPrice: 150
+    };
+    const changes: SimpleChanges = {
+      paymentInfo: {
+        currentValue: newPaymentInfo,
+        previousValue: undefined,
+        firstChange: true,
+        isFirstChange: () => true
+      }
+    };
+    const spy = spyOn<any>(component, 'setOverpaymentForCancelledStatus');
+
+    component.ngOnChanges(changes);
+
+    expect(component.paymentInfo).toEqual(newPaymentInfo);
+    expect(component.paidAmount).toBe(150);
+    expect(component.overpayment).toBe(50);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should update order status to CANCELED and call setOverpaymentForCancelledStatus', () => {
+    component.paidAmount = 100;
+    component.overpayment = 0;
+    const changes: SimpleChanges = {
+      orderStatus: {
+        currentValue: OrderStatus.CANCELED,
+        previousValue: OrderStatus.FORMED,
+        firstChange: false,
+        isFirstChange: () => false
+      }
+    };
+    const spy = spyOn<any>(component, 'setOverpaymentForCancelledStatus');
+
+    component.ngOnChanges(changes);
+
+    expect(component.currentOrderStatus).toBe(OrderStatus.CANCELED);
+    expect(spy).toHaveBeenCalled();
   });
 });

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order-payment/ubs-admin-order-payment.component.ts
@@ -3,7 +3,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 import { ChangingOrderPaymentStatus } from 'src/app/store/actions/bigOrderTable.actions';
-import { IPaymentInfoDto, IOrderInfo, PaymentDetails, orderPaymentInfo, ReturnMoneyOrBonuses } from '../../models/ubs-admin.interface';
+import { IPaymentInfoDto, IOrderInfo, orderPaymentInfo, ReturnMoneyOrBonuses } from '../../models/ubs-admin.interface';
 import { OrderService } from '../../services/order.service';
 import { AddPaymentComponent } from '../add-payment/add-payment.component';
 import { IAppState } from 'src/app/store/state/app.state';
@@ -70,15 +70,16 @@ export class UbsAdminOrderPaymentComponent implements OnInit, OnChanges, OnDestr
       this.paidAmount = this.paymentInfo.paymentTableInfoDto.paidAmount;
       this.unPaidAmount = this.paymentInfo.paymentTableInfoDto.unPaidAmount;
       this.actualPrice = this.paymentInfo.orderFullPrice;
+      this.setOverpaymentForCancelledStatus();
     }
 
     if (changes.orderStatus) {
       this.currentOrderStatus = changes.orderStatus.currentValue;
       this.isStatusForReturnMoneyOrPaid =
         this.currentOrderStatus === OrderStatus.CANCELED || this.currentOrderStatus === OrderStatus.DONE || this.isBroughtItHimSelf;
-      if (this.currentOrderStatus === OrderStatus.CANCELED) {
-        this.overpayment = this.paidAmount;
-      }
+
+      this.setOverpaymentForCancelledStatus();
+
       if (this.currentOrderStatus === OrderStatus.BROUGHT_IT_HIMSELF) {
         this.returnMoneyOrBonuses = { ...this.returnMoneyOrBonuses, amount: 0 };
       }
@@ -205,6 +206,12 @@ export class UbsAdminOrderPaymentComponent implements OnInit, OnChanges, OnDestr
 
   isReturnPaymentLink(paymentLink): boolean {
     return paymentLink === PaymentEnrollment.bonuses || paymentLink === PaymentEnrollment.money;
+  }
+
+  private setOverpaymentForCancelledStatus(): void {
+    if (this.orderStatus === OrderStatus.CANCELED) {
+      this.overpayment = this.paidAmount;
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/ubs/ubs/services/order.service.spec.ts
+++ b/src/app/ubs/ubs/services/order.service.spec.ts
@@ -132,13 +132,13 @@ describe('OrderService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('method getOrders should return order details', () => {
+  it('method getOrders should return order details', fakeAsync(() => {
     service.getOrderDetails(1, 25).subscribe((data) => {
       service.stateOrderDetails = null;
       expect(ubsOrderServiseMock.orderDetails).not.toBeNull();
       expect(ubsOrderServiseMock.orderDetails).toEqual(data);
     });
-  });
+  }));
 
   it('method getPersonalData should return personal data', fakeAsync(() => {
     service.getPersonalData().subscribe((data) => {


### PR DESCRIPTION
[#8579](https://github.com/ita-social-projects/GreenCity/issues/8579)
[#8580](https://github.com/ita-social-projects/GreenCity/issues/8580)

There was an issue that when employee wanted to cancel the order, after saving his changes, he could not enroll money to user's accorunt. 

### Result:

https://github.com/user-attachments/assets/9c98e2d3-63d7-4ce4-9805-ba7e5bfed7d7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new unit tests to verify correct handling of overpayment and input changes for order payment management, including scenarios when an order is canceled.
  * Updated order service tests to run within Angular's asynchronous testing zone for improved reliability.
* **Refactor**
  * Improved internal logic for handling overpayment status when an order is canceled, enhancing maintainability without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->