### PR TITLE
Bugfix/8684 Visual inconsistency button

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-card-pop-up/ubs-admin-tariffs-card-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-card-pop-up/ubs-admin-tariffs-card-pop-up.component.html
@@ -119,7 +119,7 @@
   </form>
   <div class="buttons-wrapper">
     <div class="d-flex buttons" mat-dialog-actions>
-      <button class="secondary-global-button btn m-0 mr-2" mat-button (click)="onNoClick()">
+      <button class="secondary-global-button btn m-0 mr-2" (click)="onNoClick()">
         {{ 'ubs-tariffs-add-location-pop-up.cancel_button' | translate }}
       </button>
       <button


### PR DESCRIPTION
[#8684](https://github.com/ita-social-projects/GreenCity/issues/8684)

There was an issue that button had wrong styles.

### Result:
<img width="359" height="64" alt="image" src="https://github.com/user-attachments/assets/f829a7db-d0d4-4d9b-9d14-9a033d9ff4eb" />
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the appearance of the cancel button in the tariffs card pop-up dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->