### PR TITLE
bugfix/8956 selecting all option hides other options and prevents reselection and unselected value still displayed in the input field

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
@@ -138,7 +138,7 @@
       <div class="input-wrapper">
         <input
           class="station"
-          placeholder="{{ 'ubs-tariffs.placeholder-station' | translate }}"
+          [placeholder]="stationPlaceholder"
           #autocompleteTriggerStation="matAutocompleteTrigger"
           formControlName="station"
           [matAutocomplete]="autoStation"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.html
@@ -94,8 +94,8 @@
           (optionSelected)="onSelectCity($event, autocompleteTriggerCity)"
           autoActiveFirstOption
         >
-          <mat-option value="all">
-            <mat-checkbox [checked]="isCityChecked()" (change)="toggleSelectAllCity()" value="all"></mat-checkbox>
+          <mat-option [value]="'ubs-tariffs.states.all' | translate">
+            <mat-checkbox class="mr-1" [checked]="isCityChecked()" [value]="'ubs-tariffs.states.all' | translate"></mat-checkbox>
             {{ 'ubs-tariffs.states.all' | translate }}
           </mat-option>
           <mat-option *ngFor="let city of filteredCities | async">
@@ -104,7 +104,7 @@
           </mat-option>
         </mat-autocomplete>
         <div class="input-control" *ngIf="city.enabled">
-          <mat-icon *ngIf="this.city.value" class="cross-img" (click)="resetLocationValues('city')">close</mat-icon>
+          <mat-icon *ngIf="isCityChecked()" class="cross-img" (click)="resetLocationValues('city')">close</mat-icon>
           <img [src]="icons.arrowDown" class="arrowDown-img" alt="arrowDown" (click)="openAuto($event, autocompleteTriggerCity)" />
         </div>
       </div>
@@ -144,8 +144,8 @@
           [matAutocomplete]="autoStation"
         />
         <mat-autocomplete #autoStation="matAutocomplete" (optionSelected)="stationSelected($event, autocompleteTriggerStation)">
-          <mat-option value="all">
-            <mat-checkbox [checked]="isStationChecked()" (change)="toggleSelectAllStation()" value="all"></mat-checkbox>
+          <mat-option [value]="'ubs-tariffs.states.all' | translate">
+            <mat-checkbox class="mr-1" [checked]="isStationChecked()" [value]="'ubs-tariffs.states.all' | translate"></mat-checkbox>
             {{ 'ubs-tariffs.states.all' | translate }}
           </mat-option>
           <mat-option *ngFor="let option of filteredStations | async" class="option-state" [value]="option">
@@ -153,7 +153,7 @@
             <span class="checkbox-text">{{ option }}</span>
           </mat-option>
         </mat-autocomplete>
-        <mat-icon *ngIf="this.selectedStation.length" class="cross-img" (click)="resetStationValue()">close</mat-icon>
+        <mat-icon *ngIf="isStationChecked()" class="cross-img" (click)="resetStationValue()">close</mat-icon>
         <img [src]="icons.arrowDown" class="arrowDown-img" alt="arrowDown" (click)="openAuto($event, autocompleteTriggerStation)" />
       </div>
       <div class="city-list">

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { UbsAdminTariffsLocationDashboardComponent } from './ubs-admin-tariffs-location-dashboard.component';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { TranslateService } from '@ngx-translate/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { TariffsService } from '../../services/tariffs.service';
-import { of, Subject } from 'rxjs';
+import { of } from 'rxjs';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { LocalStorageService } from 'src/app/shared/services/localstorage/local-storage.service';
@@ -19,7 +19,6 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
 import { MatChipsModule } from '@angular/material/chips';
-import { MockStore } from '@ngrx/store/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { UbsAdminTariffsCourierPopUpComponent } from './ubs-admin-tariffs-courier-pop-up/ubs-admin-tariffs-courier-pop-up.component';
 import { UbsAdminTariffsStationPopUpComponent } from './ubs-admin-tariffs-station-pop-up/ubs-admin-tariffs-station-pop-up.component';
@@ -30,14 +29,11 @@ import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
 import { GoogleScript } from 'src/assets/google-script/google-script';
 import { TariffRegionAll } from './ubs-tariffs.enum';
 import { provideMockStore } from '@ngrx/store/testing';
-import { IAppState } from 'src/app/store/state/app.state';
 
-xdescribe('UbsAdminTariffsLocationDashboardComponent', () => {
+describe('UbsAdminTariffsLocationDashboardComponent', () => {
   let component: UbsAdminTariffsLocationDashboardComponent;
   let fixture: ComponentFixture<UbsAdminTariffsLocationDashboardComponent>;
-  let httpMock: HttpTestingController;
   let router: Router;
-  let store: MockStore<IAppState>;
   const initialState = {
     employees: null,
     error: null,
@@ -109,17 +105,12 @@ xdescribe('UbsAdminTariffsLocationDashboardComponent', () => {
     cardId: 3
   };
 
-  const fakeCards = [
-    {
-      courier: 'УБС',
-      station: 'Станція',
-      region: 'Регіон',
-      city: 'Місто',
-      tariff: 'ACTIVE',
-      regionId: 3,
-      cardId: 4
-    }
-  ];
+  const createCardObjMock = {
+    courierId: 1,
+    locationIdList: [1, 2, 3],
+    receivingStationsIdList: [1, 2, 3],
+    regionId: 5
+  };
 
   const fakeCouriers = {
     courierId: 1,
@@ -256,8 +247,6 @@ xdescribe('UbsAdminTariffsLocationDashboardComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
     router = TestBed.inject(Router);
-    httpMock = TestBed.inject(HttpTestingController);
-    store = TestBed.inject(Store) as MockStore<IAppState>;
     component.locations = [fakeLocations];
   });
 
@@ -668,6 +657,7 @@ xdescribe('UbsAdminTariffsLocationDashboardComponent', () => {
     component.toggleSelectAllCity();
     expect(spy).toHaveBeenCalled();
     expect(component.selectedCities.length).toBe(0);
+    expect(component.city.value).toEqual('');
   });
 
   it('should select all items of stations', () => {
@@ -690,6 +680,7 @@ xdescribe('UbsAdminTariffsLocationDashboardComponent', () => {
     component.toggleSelectAllStation();
     expect(spy).toHaveBeenCalled();
     expect(component.selectedStation.length).toBe(0);
+    expect(component.station.value).toEqual('');
   });
 
   it('should empty station value onSelectStation method', () => {
@@ -743,7 +734,7 @@ xdescribe('UbsAdminTariffsLocationDashboardComponent', () => {
   it('navigate to pricing page', () => {
     const spy = spyOn(router, 'navigate');
     component.page('tariff', 1);
-    expect(spy).toHaveBeenCalledWith([`ubs-admin/tariffs/location/1`]);
+    expect(spy).toHaveBeenCalledWith([`ubs/admin/tariffs/location/1`]);
   });
 
   it('should call methods in OnInit', () => {
@@ -774,19 +765,19 @@ xdescribe('UbsAdminTariffsLocationDashboardComponent', () => {
   });
 
   it('should create new card on create card method', fakeAsync(() => {
-    const spy1 = spyOn(component, 'createCardRequest');
-    const spy2 = spyOn(component, 'getExistingCard');
-    const spy3 = spyOn(component, 'setCountOfCheckedCity');
-    const spy4 = spyOn(component, 'setStationPlaceholder');
+    const getExistingCardSpy = spyOn(component, 'getExistingCard');
+    const setCountOfCheckedCitySpy = spyOn(component, 'setCountOfCheckedCity');
+    const setStationPlaceholderSpy = spyOn(component, 'setStationPlaceholder');
     matDialogMock.open.and.returnValue(fakeMatDialogRef as any);
+
     component.createTariffCard();
+
     expect(fakeMatDialogRef.afterClosed).toHaveBeenCalled();
     tick();
-    expect(spy1).toHaveBeenCalled();
-    expect(spy2).toHaveBeenCalled();
-    expect(spy2).toHaveBeenCalledWith({});
-    expect(spy3).toHaveBeenCalled();
-    expect(spy4).toHaveBeenCalled();
+    expect(getExistingCardSpy).toHaveBeenCalled();
+    expect(getExistingCardSpy).toHaveBeenCalledWith({});
+    expect(setCountOfCheckedCitySpy).toHaveBeenCalled();
+    expect(setStationPlaceholderSpy).toHaveBeenCalled();
     expect(component.region.value).toEqual('');
     expect(component.courier.value).toEqual('');
     expect(component.selectedCities).toEqual([]);
@@ -803,17 +794,6 @@ xdescribe('UbsAdminTariffsLocationDashboardComponent', () => {
       locationIdList: component.selectedCities.map((it) => it.id).sort()
     };
     expect(component.createCardObj).toEqual(fakeNewCard);
-  });
-
-  it('should call createCard', () => {
-    const fakeCard1 = {
-      courierId: 0,
-      receivingStationsIdList: [0],
-      regionId: 0,
-      locationIdList: [0]
-    };
-    component.createCardRequest(fakeCard1);
-    expect(tariffsServiceMock.createCard).toHaveBeenCalled();
   });
 
   it('should change isFieldFilled to true if all fields are filled', () => {
@@ -859,7 +839,9 @@ xdescribe('UbsAdminTariffsLocationDashboardComponent', () => {
     component.courier.setValue('fake');
     component.selectedStation = [{ name: 'stationItem', id: 1 }];
     component.selectedCities = [{ name: 'fake', id: 159, englishName: 'fake' }];
+    component.createCardObj = createCardObjMock;
     const spy = spyOn(component, 'createCardDto');
+
     component.checkisCardExist();
     expect(spy).toHaveBeenCalled();
     expect(tariffsServiceMock.checkIfCardExist).toHaveBeenCalled();
@@ -871,23 +853,6 @@ xdescribe('UbsAdminTariffsLocationDashboardComponent', () => {
     expect(spy1).toHaveBeenCalled();
   });
 
-  it('should call createCard', () => {
-    const fakeNewCard = {
-      courierId: 0,
-      receivingStationsIdList: 0,
-      regionId: 0,
-      locationIdList: 0
-    };
-    component.createCardRequest(fakeNewCard);
-    expect(tariffsServiceMock.createCard).toHaveBeenCalled();
-  });
-
-  it('should call createCardRequest after matDialogRef closed', () => {
-    const spy = spyOn(component, 'createCardRequest');
-    component.createTariffCard();
-    expect(spy).toHaveBeenCalled();
-  });
-
   it('should return false if card do not exist', () => {
     component.region.setValue('Fake1');
     component.courier.setValue('Fake1');
@@ -896,7 +861,7 @@ xdescribe('UbsAdminTariffsLocationDashboardComponent', () => {
     component.cards = [];
     component.checkisCardExist();
     tariffsServiceMock.checkIfCardExist.and.returnValue(of(false));
-    expect(component.isCardExist).toBe(true);
+    expect(component.isCardExist).toBe(false);
   });
 
   it('should call openAddCourierDialog', () => {
@@ -1052,5 +1017,55 @@ xdescribe('UbsAdminTariffsLocationDashboardComponent', () => {
     fixture.whenStable().then(() => {
       expect(spy).toHaveBeenCalled();
     });
+  });
+
+  it('should call isAllOptionSelected on stationSelected', () => {
+    const mockEvent = { option: { value: 'All' } };
+    const isAllOptionSelectedSpy = spyOn(component, 'isAllOptionSelected').and.callThrough();
+
+    component.stationSelected(mockEvent as any);
+
+    expect(isAllOptionSelectedSpy).toHaveBeenCalled();
+    expect(isAllOptionSelectedSpy).toHaveBeenCalledWith(mockEvent.option.value);
+  });
+  it('should call isAllOptionSelected on onSelectCity', () => {
+    const mockEvent = { option: { value: 'All' } };
+    const isAllOptionSelectedSpy = spyOn(component, 'isAllOptionSelected').and.callThrough();
+
+    component.onSelectCity(mockEvent as any);
+
+    expect(isAllOptionSelectedSpy).toHaveBeenCalled();
+    expect(isAllOptionSelectedSpy).toHaveBeenCalledWith(mockEvent.option.value);
+  });
+
+  it('isAllOptionSelected should return true if option all selected in En', () => {
+    expect(component.isAllOptionSelected('All')).toBeTrue();
+  });
+  it('isAllOptionSelected should return true if option all selected in Ua', () => {
+    expect(component.isAllOptionSelected('Все')).toBeTrue();
+  });
+  it('isAllOptionSelected should return false if option other than all selected', () => {
+    expect(component.isAllOptionSelected('test')).toBeFalse();
+  });
+  it('isAllOptionSelected should return false if no option selected', () => {
+    expect(component.isAllOptionSelected('')).toBeFalsy();
+  });
+  it('should return false for null', () => {
+    expect(component.isAllOptionSelected(null as any)).toBeFalsy();
+  });
+
+  it('should return false for undefined', () => {
+    expect(component.isAllOptionSelected(undefined as any)).toBeFalsy();
+  });
+
+  it('toggleSelectAllStation should call filterOptions', () => {
+    const filterOptionsSpy = spyOn(component, 'filterOptions');
+    component.toggleSelectAllStation();
+    expect(filterOptionsSpy).toHaveBeenCalled();
+  });
+  it('toggleSelectAllCity should call filterOptions', () => {
+    const filterOptionsSpy = spyOn(component, 'filterOptions');
+    component.toggleSelectAllCity();
+    expect(filterOptionsSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.spec.ts
@@ -30,7 +30,7 @@ import { GoogleScript } from 'src/assets/google-script/google-script';
 import { TariffRegionAll } from './ubs-tariffs.enum';
 import { provideMockStore } from '@ngrx/store/testing';
 
-describe('UbsAdminTariffsLocationDashboardComponent', () => {
+fdescribe('UbsAdminTariffsLocationDashboardComponent', () => {
   let component: UbsAdminTariffsLocationDashboardComponent;
   let fixture: ComponentFixture<UbsAdminTariffsLocationDashboardComponent>;
   let router: Router;
@@ -1040,21 +1040,27 @@ describe('UbsAdminTariffsLocationDashboardComponent', () => {
 
   it('isAllOptionSelected should return true if option all selected in En', () => {
     expect(component.isAllOptionSelected('All')).toBeTrue();
+    expect(component.isAllOptionSelected('all')).toBeTrue();
+    expect(component.isAllOptionSelected(TariffRegionAll.en)).toBeTrue();
+    expect('all'.toLowerCase()).toEqual(TariffRegionAll.en);
   });
   it('isAllOptionSelected should return true if option all selected in Ua', () => {
     expect(component.isAllOptionSelected('Все')).toBeTrue();
+    expect(component.isAllOptionSelected('все')).toBeTrue();
+    expect(component.isAllOptionSelected(TariffRegionAll.ua)).toBeTrue();
+    expect('все'.toLowerCase()).toEqual(TariffRegionAll.ua);
   });
   it('isAllOptionSelected should return false if option other than all selected', () => {
     expect(component.isAllOptionSelected('test')).toBeFalse();
+    expect(component.isAllOptionSelected('2')).toBeFalse();
+    expect(component.isAllOptionSelected('.')).toBeFalse();
   });
   it('isAllOptionSelected should return false if no option selected', () => {
     expect(component.isAllOptionSelected('')).toBeFalsy();
+    expect(component.isAllOptionSelected('  ')).toBeFalsy();
   });
-  it('should return false for null', () => {
+  it('isAllOptionSelected should return false for null and undefined', () => {
     expect(component.isAllOptionSelected(null as any)).toBeFalsy();
-  });
-
-  it('should return false for undefined', () => {
     expect(component.isAllOptionSelected(undefined as any)).toBeFalsy();
   });
 

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -329,13 +329,14 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
     });
   }
 
+  isAllOptionSelected(value: string) {
+    return value && (value.toLowerCase() === TariffRegionAll.ua || value.toLowerCase() === TariffRegionAll.en);
+  }
+
   onSelectCity(event: MatAutocompleteSelectedEvent, trigger?: MatAutocompleteTrigger): void {
     const panel = document.querySelector('.mat-autocomplete-panel');
     this.scrollPosition = panel ? panel.scrollTop : 0;
-    if (
-      event.option.value &&
-      (event.option.value.toLowerCase() === TariffRegionAll.ua || event.option.value.toLowerCase() === TariffRegionAll.en)
-    ) {
+    if (this.isAllOptionSelected(event.option.value)) {
       this.toggleSelectAllCity();
       const locationsId = this.locations.map((location) => location.locationsDto.map((elem) => elem.locationId)).flat(2);
       Object.assign(this.filterData, { location: locationsId });
@@ -401,10 +402,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
   }
 
   stationSelected(event: MatAutocompleteSelectedEvent, trigger?: MatAutocompleteTrigger) {
-    if (
-      event.option.value &&
-      (event.option.value.toLowerCase() === TariffRegionAll.ua || event.option.value.toLowerCase() === TariffRegionAll.en)
-    ) {
+    if (this.isAllOptionSelected(event.option.value)) {
       this.toggleSelectAllStation();
       const stationsId = this.stations.map((station) => station.id);
       Object.assign(this.filterData, { receivingStation: stationsId });
@@ -806,10 +804,6 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
     this.selectedCard.regionUk = res.regionUk;
     this.selectedCard.regionId = res.regionId;
     this.selectedCard.station = res.station;
-  }
-
-  createCardRequest(card): void {
-    this.tariffsService.createCard(card).pipe(takeUntil(this.destroy)).subscribe();
   }
 
   openAddCourierDialog(): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -328,11 +328,9 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
       }
     });
   }
-
   isAllOptionSelected(value: string) {
     return value && (value.toLowerCase() === TariffRegionAll.ua || value.toLowerCase() === TariffRegionAll.en);
   }
-
   onSelectCity(event: MatAutocompleteSelectedEvent, trigger?: MatAutocompleteTrigger): void {
     const panel = document.querySelector('.mat-autocomplete-panel');
     this.scrollPosition = panel ? panel.scrollTop : 0;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -332,12 +332,13 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
   onSelectCity(event: MatAutocompleteSelectedEvent, trigger?: MatAutocompleteTrigger): void {
     const panel = document.querySelector('.mat-autocomplete-panel');
     this.scrollPosition = panel ? panel.scrollTop : 0;
-
-    if (event.option.value === 'all') {
+    if (
+      event.option.value &&
+      (event.option.value.toLowerCase() === TariffRegionAll.ua || event.option.value.toLowerCase() === TariffRegionAll.en)
+    ) {
       this.toggleSelectAllCity();
       const locationsId = this.locations.map((location) => location.locationsDto.map((elem) => elem.locationId)).flat(2);
       Object.assign(this.filterData, { location: locationsId });
-      this.city.setValue(this.translate.instant('ubs-tariffs.states.all'));
     } else {
       this.selectCity(event);
       const locationId = this.selectedCities.map((it) => it.id);
@@ -400,11 +401,13 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
   }
 
   stationSelected(event: MatAutocompleteSelectedEvent, trigger?: MatAutocompleteTrigger) {
-    if (event.option.value === 'all') {
+    if (
+      event.option.value &&
+      (event.option.value.toLowerCase() === TariffRegionAll.ua || event.option.value.toLowerCase() === TariffRegionAll.en)
+    ) {
       this.toggleSelectAllStation();
       const stationsId = this.stations.map((station) => station.id);
       Object.assign(this.filterData, { receivingStation: stationsId });
-      this.station.setValue(this.translate.instant('ubs-tariffs.states.all'));
     } else {
       this.onSelectStation(event);
       const receivingStationId = this.selectedStation.map((it) => it.id);
@@ -454,7 +457,13 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
       });
     } else {
       this.selectedCities.length = 0;
+      this.city.setValue('');
     }
+
+    this.filteredCities = this.filterOptions(
+      this.city,
+      this.cities.map((elem) => elem.name)
+    );
   }
 
   transformCityToSelectedCity(city: any) {
@@ -486,7 +495,9 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
       });
     } else {
       this.selectedStation.length = 0;
+      this.station.setValue('');
     }
+    this.filteredStations = this.filterOptions(this.station, this.stationName);
   }
 
   onSelectCourier(event): void {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-dashboard.component.ts
@@ -410,6 +410,7 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
       this.onSelectStation(event);
       const receivingStationId = this.selectedStation.map((it) => it.id);
       Object.assign(this.filterData, { receivingStation: receivingStationId });
+      this.station.setValue('');
     }
     this.getExistingCard(this.filterData);
     this.setStationPlaceholder();
@@ -495,7 +496,10 @@ export class UbsAdminTariffsLocationDashboardComponent implements OnInit, AfterV
       this.selectedStation.length = 0;
       this.station.setValue('');
     }
-    this.filteredStations = this.filterOptions(this.station, this.stationName);
+    this.filteredStations = this.filterOptions(
+      this.station,
+      this.stations.map((elem) => elem.name)
+    );
   }
 
   onSelectCourier(event): void {


### PR DESCRIPTION
[#8956](https://github.com/ita-social-projects/GreenCity/issues/8956)

<img width="1643" height="706" alt="image" src="https://github.com/user-attachments/assets/f23be820-f99a-442b-872c-7686c0589bc9" />
<img width="1766" height="601" alt="image" src="https://github.com/user-attachments/assets/3c7571d0-3f79-4660-a186-1d3a08f6dbc2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of the "all" option in city and station selection, now supporting both English and Ukrainian translations.
  * Enhanced UI consistency for autocomplete dropdowns and reset icons in city and station filters.

* **Bug Fixes**
  * Fixed issues with resetting city and station selections, ensuring accurate checked states and placeholder updates.

* **Tests**
  * Expanded and refined test coverage for selection logic, including the "all" option and related utility methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->