### PR TITLE
Bugfix/3784 add user names instead of nicknames

### DIFF
--- a/src/app/chat/component/chat-page/chat-page.component.html
+++ b/src/app/chat/component/chat-page/chat-page.component.html
@@ -27,7 +27,7 @@
     <ng-container *ngIf="selectedChat; else placeholder">
       <div class="chat-box">
         <div class="chat-header">
-          {{ selectedChat.fullName }} ({{ selectedChat.nickname }})
+          {{ selectedChat.fullName }} {{ selectedChat.nickname !== selectedChat.fullName ? '(' + selectedChat.nickname + ')' : '' }}
           <button class="client-info-button" (click)="toggleClientInfo()" [title]="'chat.client-info' | translate">🧠</button>
         </div>
 

--- a/src/app/chat/component/chat-page/chat-page.component.html
+++ b/src/app/chat/component/chat-page/chat-page.component.html
@@ -10,7 +10,7 @@
       <li
         class="chat-item"
         *ngFor="let chat of filteredChats"
-        [class.selected]="chat.nickname === selectedChat?.nickname"
+        [class.selected]="chat.chatInternalId === selectedChat?.chatInternalId"
         (click)="selectChat(chat)"
       >
         <div class="avatar">{{ chat.initial }}</div>

--- a/src/app/chat/component/chat-page/chat-page.component.html
+++ b/src/app/chat/component/chat-page/chat-page.component.html
@@ -10,12 +10,12 @@
       <li
         class="chat-item"
         *ngFor="let chat of filteredChats"
-        [class.selected]="chat.name === selectedChat?.name"
+        [class.selected]="chat.nickname === selectedChat?.nickname"
         (click)="selectChat(chat)"
       >
         <div class="avatar">{{ chat.initial }}</div>
         <div class="chat-details">
-          <div class="chat-name">{{ chat.name }}</div>
+          <div class="chat-name">{{ chat.fullName }}</div>
           <div class="last-message">{{ chat.lastMessage }}</div>
         </div>
         <div class="timestamp">{{ chat.time }}</div>
@@ -27,7 +27,7 @@
     <ng-container *ngIf="selectedChat; else placeholder">
       <div class="chat-box">
         <div class="chat-header">
-          {{ selectedChat.name }}
+          {{ selectedChat.fullName }} ({{ selectedChat.nickname }})
           <button class="client-info-button" (click)="toggleClientInfo()" [title]="'chat.client-info' | translate">🧠</button>
         </div>
 

--- a/src/app/chat/component/chat-page/chat-page.component.spec.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.spec.ts
@@ -139,7 +139,7 @@ describe('ChatComponent · fetchMessages via stubbed HttpClient', () => {
   it('should map messages correctly on success', () => {
     component.selectedChat = {
       chatInternalId: 123,
-      name: 'Tester',
+      nickname: 'Tester',
       messages: []
     };
 
@@ -244,7 +244,9 @@ describe('ChatComponent · loadAllChats via HttpTestingController', () => {
         { username: 'u1', id: 11, chatId: 'x1', lastMessage: { text: 'm1', sendAt: '2025-07-14T10:00:00Z' } },
         { firstName: 'F', lastName: 'L', id: 22, chatId: 'x2' },
         { chatId: 'x3', id: 33 },
-        {}
+        {},
+        { firstName: 'A', id: 12, chatId: 'x4', username: 'a', user: { firstName: 'A', lastName: 'K' } },
+        { user: {} }
       ]
     };
 
@@ -257,22 +259,31 @@ describe('ChatComponent · loadAllChats via HttpTestingController', () => {
       jasmine.objectContaining({ headers: jasmine.any(Object) })
     );
 
-    const [c1, c2, c3, c4] = component.chats;
+    const [c1, c2, c3, c4, c5, c6] = component.chats;
 
-    expect(c1.name).toBe('u1');
+    expect(c1.fullName).toBe('');
+    expect(c1.nickname).toBe('u1');
     expect(c1.initial).toBe('U');
     expect(c1.chatInternalId).toBe(11);
     expect(c1.lastMessage).toBe('m1');
     expect(c1.time).toMatch(/\d{1,2}:\d{2}/);
 
-    expect(c2.name).toBe('F L');
+    expect(c2.fullName).toBe('F L');
+    expect(c2.nickname).toBe('F L');
     expect(c2.initial).toBe('F');
 
-    expect(c3.name).toBe('x3');
+    expect(c3.fullName).toBe('');
+    expect(c3.nickname).toBe('x3');
     expect(c3.initial).toBe('X');
 
-    expect(c4.name).toBe('Unknown');
+    expect(c4.fullName).toBe('');
+    expect(c4.nickname).toBe('Unknown');
     expect(c4.initial).toBe('?');
+
+    expect(c5.fullName).toBe('A K');
+    expect(c5.nickname).toBe('a');
+
+    expect(c6.fullName).toBe('');
   });
 
   xit('should log error on failure', async () => {

--- a/src/app/chat/component/chat-page/chat-page.component.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.ts
@@ -63,13 +63,19 @@ export class ChatComponent implements OnInit {
         const chatList = response.page || [];
 
         this.chats = chatList.map((chat: any) => {
-          const fullName = chat.firstName || chat.lastName ? `${chat.firstName || ''} ${chat.lastName || ''}`.trim() : '';
+          let fullName = chat.user ? `${chat.user.firstName || ''} ${chat.user.lastName || ''}`.trim() : null;
+
+          if (!fullName) {
+            fullName = chat.firstName || chat.lastName ? `${chat.firstName || ''} ${chat.lastName || ''}`.trim() : '';
+          }
+
           const raw = chat.username || fullName || chat.chatId;
-          const name = raw || 'Unknown';
+          const nickname = raw || 'Unknown';
           const initial = raw ? raw.charAt(0).toUpperCase() : '?';
 
           return {
-            name,
+            fullName,
+            nickname,
             initial,
             chatId: chat.chatId,
             chatInternalId: chat.id,
@@ -147,7 +153,7 @@ export class ChatComponent implements OnInit {
     } else {
       this.selectedChat.messages = allMessages
         .map((msg: any) => ({
-          from: msg.fromManager ? 'Me' : this.selectedChat.name,
+          from: msg.fromManager ? 'Me' : this.selectedChat.nickname,
           text: msg.text,
           time: new Date(msg.sendAt).toLocaleTimeString([], {
             hour: '2-digit',


### PR DESCRIPTION
#3784 
There was an issue that list of users and user chat disaplyed only telegram nicknames, but actual names had to be displayed.

### Result:

https://github.com/user-attachments/assets/9c5dd03c-26cc-426e-908e-9011a33e64f0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated chat list and header to display both full names and nicknames for chat participants, improving clarity in chat identification.

* **Bug Fixes**
  * Improved logic for matching and displaying selected chats, ensuring accurate selection based on internal IDs and nicknames.

* **Tests**
  * Enhanced test coverage to verify correct handling and display of full names and nicknames in chat lists and messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->