### PR TITLE
Bugfix/8707 The calendar cannot be opened with Enter key

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.html
@@ -37,8 +37,8 @@
                     [matDatepicker]="picker1"
                     [placeholder]="'ubs-tables.date-placeholder' | translate"
                   />
-                  <button matSuffix class="calendar-btn">
-                    <img src="assets/img/icon/econews/calendar-icon.svg" alt="Calendar button" (click)="picker1.open()" />
+                  <button matSuffix class="calendar-btn" (click)="picker1.open()">
+                    <img src="assets/img/icon/econews/calendar-icon.svg" alt="Calendar button" />
                   </button>
                   <mat-datepicker #picker1></mat-datepicker>
                 </div>
@@ -54,8 +54,8 @@
                     [matDatepicker]="picker2"
                     [placeholder]="'ubs-tables.date-placeholder' | translate"
                   />
-                  <button matSuffix class="calendar-btn">
-                    <img src="assets/img/icon/econews/calendar-icon.svg" alt="Calendar button" (click)="picker2.open()" />
+                  <button matSuffix class="calendar-btn" (click)="picker2.open()">
+                    <img src="assets/img/icon/econews/calendar-icon.svg" alt="Calendar button" />
                   </button>
                   <mat-datepicker #picker2></mat-datepicker>
                 </div>
@@ -76,8 +76,8 @@
                     [matDatepicker]="picker3"
                     [placeholder]="'ubs-tables.date-placeholder' | translate"
                   />
-                  <button matSuffix class="calendar-btn">
-                    <img src="assets/img/icon/econews/calendar-icon.svg" alt="Calendar button" (click)="picker3.open()" />
+                  <button matSuffix class="calendar-btn" (click)="picker3.open()">
+                    <img src="assets/img/icon/econews/calendar-icon.svg" alt="Calendar button" />
                   </button>
                   <mat-datepicker #picker3></mat-datepicker>
                 </div>
@@ -93,8 +93,8 @@
                     [matDatepicker]="picker4"
                     [placeholder]="'ubs-tables.date-placeholder' | translate"
                   />
-                  <button matSuffix class="calendar-btn">
-                    <img src="assets/img/icon/econews/calendar-icon.svg" alt="Calendar button" (click)="picker4.open()" />
+                  <button matSuffix class="calendar-btn" (click)="picker4.open()">
+                    <img src="assets/img/icon/econews/calendar-icon.svg" alt="Calendar button" />
                   </button>
                   <mat-datepicker #picker4></mat-datepicker>
                 </div>


### PR DESCRIPTION
[#8707](url)
There was an issue that user could not user Enter key to open the calendar pop-up.

### Result:

https://github.com/user-attachments/assets/4deda178-c3a0-48d3-9d20-b1f411ce2daa



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved datepicker trigger behavior for four date fields (Registration Date From/To, Last Order Date From/To). Clicking anywhere on the button now opens the datepicker, not just the calendar icon.
  * Enhances accessibility and usability, especially on touch devices, by enlarging the clickable area and ensuring consistent interaction across all affected inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->