### PR TITLE
Bugfix/8578 Buttons overlaps other content user orders list

### DIFF
--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.html
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.html
@@ -11,7 +11,7 @@
 </div>
 <mat-accordion multi="false">
   <div *ngFor="let order of orders">
-    <mat-expansion-panel>
+    <mat-expansion-panel class="custom-panel">
       <mat-expansion-panel-header [collapsedHeight]="'none'" [expandedHeight]="'none'">
         <div class="mat-content-wrapper" (click)="changeCard(order.id)" [id]="order.id">
           <div class="mobile_list">

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.scss
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.scss
@@ -189,7 +189,7 @@ button {
     height: 25px;
   }
 
-  .custom-panel ::ng-deep .mat-expansion-panel-header {
+  .custom-panel .mat-expansion-panel-header {
     height: 100px;
   }
 
@@ -239,7 +239,7 @@ button {
     }
   }
 
-  .custom-panel ::ng-deep .mat-expansion-panel-header {
+  .custom-panel .mat-expansion-panel-header {
     height: fit-content;
     padding: 20px 24px;
 

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.scss
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.scss
@@ -189,7 +189,7 @@ button {
     height: 25px;
   }
 
-  .mat-expansion-panel-header {
+  .custom-panel ::ng-deep .mat-expansion-panel-header {
     height: 100px;
   }
 
@@ -239,7 +239,7 @@ button {
     }
   }
 
-  .mat-expansion-panel-header {
+  .custom-panel ::ng-deep .mat-expansion-panel-header {
     height: fit-content;
     padding: 20px 24px;
 


### PR DESCRIPTION
[#8578](https://github.com/ita-social-projects/GreenCity/issues/8578)

There was an issue that content was overlaping each other.

### Result:
<img width="1049" height="595" alt="image" src="https://github.com/user-attachments/assets/53d669dd-f86b-4c7b-9d63-217ab2610cf9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Prevented expansion-panel styles from leaking to other parts of the app by restricting selectors to the orders list.

- Style
  - Applied a dedicated class to expansion panels in the orders list and updated CSS selectors so responsive heights and padding remain the same but only within that scoped container.
  - No functional or behavioral changes for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->