### PR TITLE
bugfix/ added chat id to the url on the admins chat page

### DIFF
--- a/src/app/chat/component/chat-page/chat-page.component.spec.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.spec.ts
@@ -3,22 +3,29 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { NgClass, NgForOf, NgIf, NgStyle } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { of, throwError } from 'rxjs';
+import { of, takeUntil, throwError } from 'rxjs';
 import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { TranslateModule } from '@ngx-translate/core';
 import { setupChatComponentTest } from './setupChatComponentTest';
 import { provideMockStore } from '@ngrx/store/testing';
+import { ActivatedRoute } from '@angular/router';
+import { Location } from '@angular/common';
+
 describe('ChatComponent', () => {
   let component: ChatComponent;
   let fixture: ComponentFixture<ChatComponent>;
   let httpMock: HttpTestingController;
   let historyMock: jasmine.Spy;
+  let route: ActivatedRoute;
+  let location: Location;
 
   beforeEach(async () => {
     const setup = await setupChatComponentTest();
     component = setup.component;
     fixture = setup.fixture;
     httpMock = setup.httpMock;
+    location = setup.location;
+    route = TestBed.inject(ActivatedRoute);
 
     localStorage.setItem('accessToken', 'mock-token');
     historyMock = spyOnProperty(history, 'state', 'get').and.returnValue({ selectedChatId: 123 });
@@ -33,17 +40,27 @@ describe('ChatComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should set selectedChatId if chatId is in history state', () => {
+  it('should spy on params', () => {
+    component.ngOnInit();
+    expect(component.selectedChatId).toBe(123);
+  });
+
+  it('should set selectedChatId if chatId is in history state and update URL', () => {
     historyMock.and.returnValue({ selectedChatId: 123 });
+    const replaceStateSpy = spyOn(location, 'replaceState');
     component.ngOnInit();
     expect(component.selectedChatId).toEqual(123);
+    expect(replaceStateSpy).toHaveBeenCalledWith('/ubs/admin/chat-page/123');
   });
   it('should not set selectedChatId if no chatId is in history state', () => {
+    (route.params as any) = of({ id: undefined });
+
     historyMock.and.returnValue({ selectedChatId: undefined });
     component.ngOnInit();
-    expect(component.selectedChatId).toEqual(undefined);
+    expect(component.selectedChatId).toBeFalsy();
   });
-  it('should call selectChat method if selectedChatId was provided', fakeAsync(() => {
+  it('should call selectChat method if selectedChatId was provided and change url', fakeAsync(() => {
+    const replaceStateSpy = spyOn(location, 'replaceState');
     const selectChatSpy = spyOn(component, 'selectChat').and.callThrough();
     component.selectedChatId = 123;
     spyOn(component['http'], 'get').and.returnValue(
@@ -65,15 +82,26 @@ describe('ChatComponent', () => {
     expect(component.selectedChatId).toEqual(123);
     expect(selectChatSpy).toHaveBeenCalled();
     expect(selectChatSpy).toHaveBeenCalledWith(jasmine.objectContaining({ chatInternalId: 123 }));
+    expect(replaceStateSpy).toHaveBeenCalledWith('/ubs/admin/chat-page/123');
+    expect(component.clientInfoVisible).toBeFalse();
+    expect(component.clientInfoData).toBeNull();
   }));
 
   it('should not call selectChat method if selectedChatId was not provided', () => {
     const selectChatSpy = spyOn(component, 'selectChat');
+    const replaceStateSpy = spyOn(location, 'replaceState');
 
     component.loadAllChats();
 
     expect(component.selectedChatId).toEqual(undefined);
     expect(selectChatSpy).not.toHaveBeenCalled();
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('should update selectedChatId when route params change', () => {
+    (route.params as any) = of({ id: '456' });
+    component.ngOnInit?.();
+    expect(component.selectedChatId).toBe(456);
   });
 
   it('should not send message if newMessage is blank or no chat', () => {
@@ -509,5 +537,24 @@ describe('toggleClientInfo', () => {
 
     expect(component.selectedImageUrl).toBeNull();
     expect(console.log).toHaveBeenCalledWith('close image modal');
+  });
+
+  it('should emit and complete destroy subject on ngOnDestroy', () => {
+    spyOn(component['destroy'], 'next');
+    spyOn(component['destroy'], 'complete');
+    component.ngOnDestroy();
+    expect(component['destroy'].next).toHaveBeenCalledWith();
+    expect(component['destroy'].complete).toHaveBeenCalled();
+  });
+
+  it('should unsubscribe subscriptions when ngOnDestroy is called', () => {
+    let called = false;
+    const subscription = of(true)
+      .pipe(takeUntil(component['destroy']))
+      .subscribe(() => (called = true));
+
+    component.ngOnDestroy();
+
+    expect(subscription.closed).toBeTrue();
   });
 });

--- a/src/app/chat/component/chat-page/chat-page.component.spec.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.spec.ts
@@ -1,15 +1,14 @@
 import { ChatComponent } from './chat-page.component';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { NgClass, NgForOf, NgIf, NgStyle } from '@angular/common';
+import { NgClass, NgForOf, NgIf, NgStyle, Location } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { of, takeUntil, throwError } from 'rxjs';
 import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { TranslateModule } from '@ngx-translate/core';
 import { setupChatComponentTest } from './setupChatComponentTest';
 import { provideMockStore } from '@ngrx/store/testing';
-import { ActivatedRoute } from '@angular/router';
-import { Location } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
 
 describe('ChatComponent', () => {
   let component: ChatComponent;
@@ -18,6 +17,7 @@ describe('ChatComponent', () => {
   let historyMock: jasmine.Spy;
   let route: ActivatedRoute;
   let location: Location;
+  let router: Router;
 
   beforeEach(async () => {
     const setup = await setupChatComponentTest();
@@ -25,6 +25,7 @@ describe('ChatComponent', () => {
     fixture = setup.fixture;
     httpMock = setup.httpMock;
     location = setup.location;
+    router = setup.router;
     route = TestBed.inject(ActivatedRoute);
 
     localStorage.setItem('accessToken', 'mock-token');
@@ -45,12 +46,12 @@ describe('ChatComponent', () => {
     expect(component.selectedChatId).toBe(123);
   });
 
-  it('should set selectedChatId if chatId is in history state and update URL', () => {
+  it('should set selectedChatId if chatId is in history state', () => {
+    spyOn(router, 'navigate');
     historyMock.and.returnValue({ selectedChatId: 123 });
-    const replaceStateSpy = spyOn(location, 'replaceState');
     component.ngOnInit();
     expect(component.selectedChatId).toEqual(123);
-    expect(replaceStateSpy).toHaveBeenCalledWith('/ubs/admin/chat-page/123');
+    expect(router.navigate).toHaveBeenCalledWith(['/ubs/admin/chat-page/', 123], { relativeTo: jasmine.any(Object) });
   });
   it('should not set selectedChatId if no chatId is in history state', () => {
     (route.params as any) = of({ id: undefined });

--- a/src/app/chat/component/chat-page/chat-page.component.spec.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.spec.ts
@@ -47,12 +47,21 @@ describe('ChatComponent', () => {
   });
 
   it('should set selectedChatId if chatId is in history state', () => {
-    spyOn(router, 'navigate');
     historyMock.and.returnValue({ selectedChatId: 123 });
     component.ngOnInit();
     expect(component.selectedChatId).toEqual(123);
     expect(router.navigate).toHaveBeenCalledWith(['/ubs/admin/chat-page/', 123], { relativeTo: jasmine.any(Object) });
   });
+  it('should preserve history.state selectedChatId when initial route params lack id', fakeAsync(() => {
+    historyMock.and.returnValue({ selectedChatId: 123 });
+    spyOn(component['http'], 'get').and.returnValue(of({ page: [{ id: 123, chatId: 'x', username: 'u' }] }));
+    const selectSpy = spyOn(component, 'selectChat').and.callThrough();
+    component.ngOnInit();
+    tick();
+    expect(component.selectedChatId).toBe(123);
+    expect(selectSpy).toHaveBeenCalled();
+    expect(component.selectedChat?.chatInternalId).toBe(123);
+  }));
   it('should not set selectedChatId if no chatId is in history state', () => {
     (route.params as any) = of({ id: undefined });
 

--- a/src/app/chat/component/chat-page/chat-page.component.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.ts
@@ -46,8 +46,7 @@ export class ChatComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     if (history.state.selectedChatId) {
-      this.selectedChatId = history.state.selectedChatId;
-      this.location.replaceState(`/ubs/admin/chat-page/${this.selectedChatId}`);
+      this.router.navigate(['/ubs/admin/chat-page/', history.state.selectedChatId], { relativeTo: this.route });
     }
     this.route.params.pipe(takeUntil(this.destroy)).subscribe((params) => {
       this.selectedChatId = Number(params.id);

--- a/src/app/chat/component/chat-page/chat-page.component.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { HttpClient, HttpClientModule, HttpHeaders } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
-import { NgClass, NgForOf, NgIf } from '@angular/common';
+import { NgClass, NgForOf, NgIf, Location } from '@angular/common';
 import { ClientInfoPanelComponent } from '../client-info-panel/client-info-panel.component';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -10,7 +10,6 @@ import { Subject, take, takeUntil } from 'rxjs';
 import { userRoleSelector } from 'src/app/store/selectors/auth.selectors';
 import { environment } from '@environment/environment';
 import { ImageModalComponent } from '../image-modal/image-modal.component';
-import { Location } from '@angular/common';
 
 @Component({
   selector: 'app-chat',
@@ -21,7 +20,7 @@ import { Location } from '@angular/common';
   styleUrls: ['./chat-page.component.scss']
 })
 export class ChatComponent implements OnInit, OnDestroy {
-  private destroy = new Subject<void>();
+  private readonly destroy = new Subject<void>();
   chats: any[] = [];
   selectedChat: any = null;
   selectedChatId?: number;
@@ -39,8 +38,8 @@ export class ChatComponent implements OnInit, OnDestroy {
   constructor(
     private http: HttpClient,
     private router: Router,
-    private route: ActivatedRoute,
-    private location: Location,
+    private readonly route: ActivatedRoute,
+    private readonly location: Location,
     private readonly store: Store,
     private readonly translate: TranslateService
   ) {}

--- a/src/app/chat/component/chat-page/chat-page.component.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.ts
@@ -1,15 +1,16 @@
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { HttpClient, HttpClientModule, HttpHeaders } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { NgClass, NgForOf, NgIf } from '@angular/common';
 import { ClientInfoPanelComponent } from '../client-info-panel/client-info-panel.component';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { take } from 'rxjs';
+import { Subject, take, takeUntil } from 'rxjs';
 import { userRoleSelector } from 'src/app/store/selectors/auth.selectors';
 import { environment } from '@environment/environment';
 import { ImageModalComponent } from '../image-modal/image-modal.component';
+import { Location } from '@angular/common';
 
 @Component({
   selector: 'app-chat',
@@ -19,7 +20,8 @@ import { ImageModalComponent } from '../image-modal/image-modal.component';
   imports: [NgForOf, FormsModule, NgClass, NgIf, HttpClientModule, ClientInfoPanelComponent, ImageModalComponent, TranslateModule],
   styleUrls: ['./chat-page.component.scss']
 })
-export class ChatComponent implements OnInit {
+export class ChatComponent implements OnInit, OnDestroy {
+  private destroy = new Subject<void>();
   chats: any[] = [];
   selectedChat: any = null;
   selectedChatId?: number;
@@ -37,6 +39,8 @@ export class ChatComponent implements OnInit {
   constructor(
     private http: HttpClient,
     private router: Router,
+    private route: ActivatedRoute,
+    private location: Location,
     private readonly store: Store,
     private readonly translate: TranslateService
   ) {}
@@ -44,7 +48,11 @@ export class ChatComponent implements OnInit {
   ngOnInit(): void {
     if (history.state.selectedChatId) {
       this.selectedChatId = history.state.selectedChatId;
+      this.location.replaceState(`/ubs/admin/chat-page/${this.selectedChatId}`);
     }
+    this.route.params.pipe(takeUntil(this.destroy)).subscribe((params) => {
+      this.selectedChatId = Number(params.id);
+    });
     this.store.select(userRoleSelector).pipe(take(1));
     this.loadAllChats();
   }
@@ -103,6 +111,7 @@ export class ChatComponent implements OnInit {
   selectChat(chat: any): void {
     if (chat) {
       this.selectedChat = chat;
+      this.location.replaceState(`/ubs/admin/chat-page/${chat.chatInternalId}`);
       this.clientInfoVisible = false;
       this.clientInfoData = null;
       this.fetchMessages(chat.chatInternalId);
@@ -300,5 +309,10 @@ export class ChatComponent implements OnInit {
   closeImageModal(): void {
     console.log('close image modal');
     this.selectedImageUrl = null;
+  }
+
+  ngOnDestroy(): void {
+    this.destroy.next();
+    this.destroy.complete();
   }
 }

--- a/src/app/chat/component/chat-page/setupChatComponentTest.ts
+++ b/src/app/chat/component/chat-page/setupChatComponentTest.ts
@@ -28,7 +28,7 @@ export async function setupChatComponentTest(mockRole: string | null = null) {
       { provide: TranslateService, useClass: MockTranslateService },
       { provide: ActivatedRoute, useValue: { params: of({ id: '123' }) } },
       { provide: Location },
-      { privide: Router, useValue: jasmine.createSpyObj('Router', ['navigate']) },
+      { provide: Router, useValue: jasmine.createSpyObj('Router', ['navigate']) },
       provideMockStore({
         selectors: [
           {

--- a/src/app/chat/component/chat-page/setupChatComponentTest.ts
+++ b/src/app/chat/component/chat-page/setupChatComponentTest.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { ChatComponent } from './chat-page.component';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { FormsModule } from '@angular/forms';
-import { NgClass, NgForOf, NgIf, NgStyle } from '@angular/common';
+import { NgClass, NgForOf, NgIf, NgStyle, Location } from '@angular/common';
 import { TranslateService } from '@ngx-translate/core';
 import { MockTranslatePipe, MockTranslateService } from './mock-translate.mock';
 import { provideMockStore } from '@ngrx/store/testing';
@@ -10,7 +10,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { userRoleSelector } from 'src/app/store/selectors/auth.selectors';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
-import { Location } from '@angular/common';
 
 export async function setupChatComponentTest(mockRole: string | null = null) {
   await TestBed.configureTestingModule({

--- a/src/app/chat/component/chat-page/setupChatComponentTest.ts
+++ b/src/app/chat/component/chat-page/setupChatComponentTest.ts
@@ -8,16 +8,27 @@ import { MockTranslatePipe, MockTranslateService } from './mock-translate.mock';
 import { provideMockStore } from '@ngrx/store/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { userRoleSelector } from 'src/app/store/selectors/auth.selectors';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { of } from 'rxjs';
 
 export async function setupChatComponentTest(mockRole: string | null = null) {
   await TestBed.configureTestingModule({
-    imports: [ChatComponent, HttpClientTestingModule, FormsModule, NgForOf, NgClass, NgIf, NgStyle, MockTranslatePipe, RouterTestingModule],
+    imports: [
+      ChatComponent,
+      HttpClientTestingModule,
+      FormsModule,
+      NgForOf,
+      NgClass,
+      NgIf,
+      NgStyle,
+      MockTranslatePipe,
+      RouterTestingModule.withRoutes([{ path: 'ubs/admin/chat-page/:id', component: ChatComponent }])
+    ],
     providers: [
       { provide: TranslateService, useClass: MockTranslateService },
       { provide: ActivatedRoute, useValue: { params: of({ id: '123' }) } },
       { provide: Location },
+      { privide: Router, useValue: jasmine.createSpyObj('Router', ['navigate']) },
       provideMockStore({
         selectors: [
           {
@@ -39,6 +50,7 @@ export async function setupChatComponentTest(mockRole: string | null = null) {
   const component = fixture.componentInstance;
   const httpMock = TestBed.inject(HttpTestingController);
   const location = TestBed.inject(Location);
+  const router = TestBed.inject(Router);
 
-  return { fixture, component, httpMock, location };
+  return { fixture, component, httpMock, location, router };
 }

--- a/src/app/chat/component/chat-page/setupChatComponentTest.ts
+++ b/src/app/chat/component/chat-page/setupChatComponentTest.ts
@@ -8,12 +8,17 @@ import { MockTranslatePipe, MockTranslateService } from './mock-translate.mock';
 import { provideMockStore } from '@ngrx/store/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { userRoleSelector } from 'src/app/store/selectors/auth.selectors';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+import { Location } from '@angular/common';
 
 export async function setupChatComponentTest(mockRole: string | null = null) {
   await TestBed.configureTestingModule({
     imports: [ChatComponent, HttpClientTestingModule, FormsModule, NgForOf, NgClass, NgIf, NgStyle, MockTranslatePipe, RouterTestingModule],
     providers: [
       { provide: TranslateService, useClass: MockTranslateService },
+      { provide: ActivatedRoute, useValue: { params: of({ id: '123' }) } },
+      { provide: Location },
       provideMockStore({
         selectors: [
           {
@@ -34,6 +39,7 @@ export async function setupChatComponentTest(mockRole: string | null = null) {
   const fixture = TestBed.createComponent(ChatComponent);
   const component = fixture.componentInstance;
   const httpMock = TestBed.inject(HttpTestingController);
+  const location = TestBed.inject(Location);
 
-  return { fixture, component, httpMock };
+  return { fixture, component, httpMock, location };
 }

--- a/src/app/ubs/ubs-admin/ubs-admin-routing.module.ts
+++ b/src/app/ubs/ubs-admin/ubs-admin-routing.module.ts
@@ -38,10 +38,8 @@ const ubsAdminRoutes: Routes = [
       { path: 'notifications', component: UbsAdminNotificationListComponent },
       { path: 'user-agreement', component: UbsAdminEditUserAgreementComponent },
       { path: 'notification/create', component: UbsAdminNotificationCreateFormComponent },
-      {
-        path: 'chat-page',
-        component: ChatComponent
-      },
+      { path: 'chat-page', component: ChatComponent },
+      { path: 'chat-page/:id', component: ChatComponent },
       { path: 'notification/:id', component: UbsAdminNotificationComponent }
     ]
   }


### PR DESCRIPTION
[#8963](https://github.com/ita-social-projects/GreenCity/issues/8963)

<img width="1918" height="980" alt="image" src="https://github.com/user-attachments/assets/893a8ffb-3092-471d-a558-2249c479603c" />


Added id change in the url on chat click. Added the ability to change chat view using url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Open a specific chat via direct URL (/ubs/admin/chat-page/:id) and have the app reflect that selection on load.
  * Selecting a chat updates the browser address (URL replaced) so links can be shared or bookmarked.
  * Route parameter changes keep the selected chat synced with the UI.

* **Bug Fixes**
  * Improved cleanup when leaving the chat page to prevent stale subscriptions and improve stability.

* **Tests**
  * Added tests for route/history-driven selection, URL updates, route param changes, and lifecycle cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->