### PR TITLE
Feature/3806 added fullnames instead of nicknames

### DIFF
--- a/src/app/chat/component/chat-page/chat-page.component.html
+++ b/src/app/chat/component/chat-page/chat-page.component.html
@@ -15,7 +15,7 @@
     <ng-container *ngIf="facade.selectedChat(); else placeholder">
       <div class="chat-box">
         <div class="chat-header">
-          {{ facade.selectedChat()!.name }}
+          {{ facade.selectedChat()!.fullName }} (&#64;{{ facade.selectedChat()!.nickname }})
           <button class="client-info-button" (click)="facade.toggleClientInfo()" [title]="'chat.client-info' | translate">🧠</button>
         </div>
 

--- a/src/app/chat/facade/chat-facade.spec.ts
+++ b/src/app/chat/facade/chat-facade.spec.ts
@@ -203,14 +203,30 @@ describe('ChatFacade', () => {
     api.sendMessage.calls.reset();
     facade.sendMessage('');
     expect(api.sendMessage).not.toHaveBeenCalled();
-    (facade as any).selectedChat.set({ name: 'N', initial: 'N', chatId: '1', chatInternalId: 1, lastMessage: '', time: '', messages: [] });
+    (facade as any).selectedChat.set({
+      nickname: 'N',
+      initial: 'N',
+      chatId: '1',
+      chatInternalId: 1,
+      lastMessage: '',
+      time: '',
+      messages: []
+    });
     api.sendMessage.calls.reset();
     facade.sendMessage('   ');
     expect(api.sendMessage).not.toHaveBeenCalled();
   });
 
   it('sendMessage appends local message and lastMessage/time on success (text only)', () => {
-    (facade as any).selectedChat.set({ name: 'N', initial: 'N', chatId: '1', chatInternalId: 1, lastMessage: '', time: '', messages: [] });
+    (facade as any).selectedChat.set({
+      nickname: 'N',
+      initial: 'N',
+      chatId: '1',
+      chatInternalId: 1,
+      lastMessage: '',
+      time: '',
+      messages: []
+    });
     api.sendMessage.and.returnValue(of('ok' as any));
 
     const urlSpy = spyOn(URL, 'createObjectURL').and.callFake(() => 'blob://x');
@@ -229,7 +245,15 @@ describe('ChatFacade', () => {
   });
 
   it('sendMessage appends with image preview when file provided', () => {
-    (facade as any).selectedChat.set({ name: 'N', initial: 'N', chatId: '1', chatInternalId: 1, lastMessage: '', time: '', messages: [] });
+    (facade as any).selectedChat.set({
+      nickname: 'N',
+      initial: 'N',
+      chatId: '1',
+      chatInternalId: 1,
+      lastMessage: '',
+      time: '',
+      messages: []
+    });
     api.sendMessage.and.returnValue(of('ok' as any));
     const file = new File([new Blob(['a'])], 'a.png', { type: 'image/png' });
     const urlSpy = spyOn(URL, 'createObjectURL').and.returnValue('blob://preview');

--- a/src/app/chat/facade/chat.facade.ts
+++ b/src/app/chat/facade/chat.facade.ts
@@ -42,10 +42,11 @@ export class ChatFacade {
       const internalId = this.resolveInternalId(nc);
 
       const chatIdStr = String(nc.chatId);
-      const { name, initial } = buildName(nc.username ?? null, nc.firstName ?? null, nc.lastName ?? null, chatIdStr);
+      const { fullName, nickname, initial } = buildName(nc.username ?? null, nc.firstName ?? null, nc.lastName ?? null, chatIdStr);
 
       const item: ChatListItem = {
-        name,
+        fullName,
+        nickname,
         initial,
         chatId: chatIdStr,
         chatInternalId: internalId,
@@ -93,9 +94,15 @@ export class ChatFacade {
     this.api.getChats(page, this.pageSize).subscribe({
       next: (resp) => {
         const mapped = (resp.page ?? []).map<ChatListItem>((chat: ChatDto) => {
-          const { name, initial } = buildName(chat.username, chat.firstName, chat.lastName, chat.chatId);
+          const { fullName, nickname, initial } = buildName(
+            chat.username,
+            chat?.user?.firstName || chat.firstName,
+            chat?.user?.lastName || chat.lastName,
+            chat.chatId
+          );
           return {
-            name,
+            fullName,
+            nickname,
             initial,
             chatId: chat.chatId,
             chatInternalId: chat.id,
@@ -156,7 +163,7 @@ export class ChatFacade {
       }
 
       current.messages.push({
-        from: m.fromManager ? 'Me' : current.name,
+        from: m.fromManager ? 'Me' : current.nickname,
         text: m.text,
         time: formatTimeOrDate(m.sendAt),
         images: (m.assets ?? []).filter((a) => a.type === 'IMAGE').map((a) => a.url),
@@ -210,7 +217,7 @@ export class ChatFacade {
 
             sel.messages = collected
               .map<ChatMessageView>((msg) => ({
-                from: msg.fromManager ? 'Me' : sel.name,
+                from: msg.fromManager ? 'Me' : sel.nickname,
                 text: msg.text,
                 time: formatTimeOrDate(msg.sendAt),
                 images: (msg.assets ?? []).filter((a) => a.type === 'IMAGE').map((a) => a.url),

--- a/src/app/chat/model/chat-page.interface.ts
+++ b/src/app/chat/model/chat-page.interface.ts
@@ -40,6 +40,7 @@ export interface ChatDto {
   firstName?: string | null;
   lastName?: string | null;
   lastMessage?: MessageDto | null;
+  user?: UserFromChat | null;
 }
 
 export interface PaginatedResponse<T> {
@@ -58,7 +59,8 @@ export interface ChatMessageView {
 }
 
 export interface ChatListItem {
-  name: string;
+  fullName: string;
+  nickname: string;
   initial: string;
   chatId: string;
   chatInternalId: number;
@@ -91,3 +93,9 @@ export interface MessageEvent {
 }
 
 export type ClientInfoRecord = Record<string, unknown>;
+
+export interface UserFromChat {
+  email: string;
+  firstName: string;
+  lastName: string;
+}

--- a/src/app/chat/ui/chat-sidebar/chat-sidebar.component.html
+++ b/src/app/chat/ui/chat-sidebar/chat-sidebar.component.html
@@ -8,7 +8,7 @@
   <li class="chat-item" *ngFor="let chat of chats; trackBy: trackById" (click)="selectChat.emit(chat)">
     <div class="avatar">{{ chat.initial }}</div>
     <div class="chat-details">
-      <div class="chat-name">{{ chat.name }}</div>
+      <div class="chat-name">{{ chat.fullName }}</div>
       <div class="last-row">
         <div class="last-message">{{ chat.lastMessage }}</div>
       </div>

--- a/src/app/chat/ui/chat-sidebar/chat-sidebar.component.spec.ts
+++ b/src/app/chat/ui/chat-sidebar/chat-sidebar.component.spec.ts
@@ -8,7 +8,8 @@ describe('ChatSidebarComponent', () => {
   let component: ChatSidebarComponent;
 
   const mkItem = (id: number, chatId = String(id)): ChatListItem => ({
-    name: `User ${id}`,
+    fullName: 'User',
+    nickname: `User ${id}`,
     initial: 'U',
     chatId,
     chatInternalId: id,

--- a/src/app/chat/utils/chat-mappers.spec.ts
+++ b/src/app/chat/utils/chat-mappers.spec.ts
@@ -23,18 +23,18 @@ describe('chat-mappers', () => {
 
   describe('buildName', () => {
     it('prefers username; falls back to full name; then to fallback; finally to Unknown/?', () => {
-      expect(buildName('johnny', 'John', 'Doe', '123')).toEqual({ name: 'johnny', initial: 'J' });
+      expect(buildName('johnny', 'John', 'Doe', '123')).toEqual({ fullName: 'John Doe', nickname: 'johnny', initial: 'J' });
 
-      expect(buildName(undefined, 'Jane', 'Doe', '123')).toEqual({ name: 'Jane Doe', initial: 'J' });
+      expect(buildName(undefined, 'Jane', 'Doe', '123')).toEqual({ fullName: 'Jane Doe', nickname: 'Jane Doe', initial: 'J' });
 
-      expect(buildName(null, null, null, 456)).toEqual({ name: '456', initial: '4' });
+      expect(buildName(null, null, null, 456)).toEqual({ fullName: '', nickname: '456', initial: '4' });
 
-      expect(buildName(null, null, null, undefined)).toEqual({ name: 'Unknown', initial: '?' });
+      expect(buildName(null, null, null, undefined)).toEqual({ fullName: '', nickname: 'Unknown', initial: '?' });
     });
 
     it('handles partial full names gracefully', () => {
-      expect(buildName(undefined, 'Solo', null, 'x')).toEqual({ name: 'Solo', initial: 'S' });
-      expect(buildName(undefined, null, 'Lastname', 'x')).toEqual({ name: 'Lastname', initial: 'L' });
+      expect(buildName(undefined, 'Solo', null, 'x')).toEqual({ fullName: 'Solo', nickname: 'Solo', initial: 'S' });
+      expect(buildName(undefined, null, 'Lastname', 'x')).toEqual({ fullName: 'Lastname', nickname: 'Lastname', initial: 'L' });
     });
   });
 

--- a/src/app/chat/utils/chat-mappers.ts
+++ b/src/app/chat/utils/chat-mappers.ts
@@ -29,13 +29,13 @@ export function buildName(
   firstName?: string | null,
   lastName?: string | null,
   fallback?: string | number
-): { name: string; initial: string } {
+): { fullName: string; nickname: string; initial: string } {
   const fullName = firstName || lastName ? `${firstName ?? ''} ${lastName ?? ''}`.trim() : '';
   const fb = fallback != null ? String(fallback) : '';
   const raw = username || fullName || fb;
-  const name = raw || 'Unknown';
+  const nickname = raw || 'Unknown';
   const initial = raw ? raw.charAt(0).toUpperCase() : '?';
-  return { name, initial };
+  return { fullName, nickname, initial };
 }
 
 export function toTime(iso: string): string {


### PR DESCRIPTION
#3806 
There was a need to display full names instead of just nickmanes

### Result:
<img width="1811" height="763" alt="image" src="https://github.com/user-attachments/assets/c65d4248-f29a-4fa3-9e78-be115b94fae0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Chat header now shows the user’s full name with @nickname.
  - Message sender labels use nicknames for clearer identification.
- Style
  - Chat list/sidebar displays full names instead of short names for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->