### PR TITLE
bugfix/8347 certificates could not be activated

### DIFF
--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.spec.ts
@@ -8,6 +8,8 @@ import { OrderService } from '../../../services/order.service';
 import { GetUserBonuses } from 'src/app/store/actions/ubs-user.actions';
 import { TranslateModule } from '@ngx-translate/core';
 import { CCertificate } from '@ubs/ubs/models/ubs.model';
+import { UbsSharedModule } from '@ubs/shared/ubs-shared.module';
+import { IMaskModule } from 'angular-imask';
 
 const orderServiceMock = {
   processCertificate: jasmine.createSpy('processCertificate')
@@ -26,7 +28,7 @@ describe('UbsOrderCertificateComponent (Partial Tests)', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [UbsOrderCertificateComponent],
-      imports: [ReactiveFormsModule, HttpClientTestingModule, TranslateModule.forRoot()],
+      imports: [IMaskModule, UbsSharedModule, ReactiveFormsModule, HttpClientTestingModule, TranslateModule.forRoot()],
       providers: [
         FormBuilder,
         { provide: OrderService, useValue: orderServiceMock },
@@ -41,6 +43,7 @@ describe('UbsOrderCertificateComponent (Partial Tests)', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(UbsOrderCertificateComponent);
     component = fixture.componentInstance;
+    fixture.detectChanges();
   });
 
   describe('ngOnInit()', () => {
@@ -174,6 +177,29 @@ describe('UbsOrderCertificateComponent (Partial Tests)', () => {
 
       component.clearCertificates();
       expect(spyOnDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('areBonusesSelectedAndNotUsed', () => {
+    beforeEach(() => {
+      component.initForm();
+      component.points = 100;
+      fixture.detectChanges();
+    });
+
+    it('should return true if bonuses are chosen and not used', () => {
+      Object.defineProperty(component.bonus, 'value', { value: true });
+      expect(component['areBonusesSelectedAndNotUsed']()).toBeTrue();
+    });
+
+    it('should return false if bonuses are chosen and used', () => {
+      component.pointsUsed = 100;
+
+      expect(component['areBonusesSelectedAndNotUsed']()).toBeFalse();
+    });
+
+    it('should return false if bonuses are not chosen', () => {
+      expect(component['areBonusesSelectedAndNotUsed']()).toBeFalse();
     });
   });
 });

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.spec.ts
@@ -179,27 +179,4 @@ describe('UbsOrderCertificateComponent (Partial Tests)', () => {
       expect(spyOnDelete).not.toHaveBeenCalled();
     });
   });
-
-  describe('areBonusesSelectedAndNotUsed', () => {
-    beforeEach(() => {
-      component.initForm();
-      component.points = 100;
-      fixture.detectChanges();
-    });
-
-    it('should return true if bonuses are chosen and not used', () => {
-      Object.defineProperty(component.bonus, 'value', { value: true });
-      expect(component['areBonusesSelectedAndNotUsed']()).toBeTrue();
-    });
-
-    it('should return false if bonuses are chosen and used', () => {
-      component.pointsUsed = 100;
-
-      expect(component['areBonusesSelectedAndNotUsed']()).toBeFalse();
-    });
-
-    it('should return false if bonuses are not chosen', () => {
-      expect(component['areBonusesSelectedAndNotUsed']()).toBeFalse();
-    });
-  });
 });

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -140,9 +140,9 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
     const invalidInput = this.formArrayCertificates.controls[index].invalid;
     const formInvalid = !this.isFirstFormValid;
     const noAmountLeft = this.getFinalSum() === 0;
-    const bonusesNotSelected = !this.orderBonusesForm.get('bonus')?.value;
+    const bonusesUsed = this.areBonusesSelectedAndNotUsed();
 
-    return alreadyEntered || invalidInput || formInvalid || noAmountLeft || bonusesNotSelected;
+    return alreadyEntered || invalidInput || formInvalid || noAmountLeft || bonusesUsed;
   }
 
   isCanAddCertificate(): boolean {
@@ -182,6 +182,10 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
     this.certificateSum = validCertificates.reduce((sum, certificate) => sum + certificate.points, 0);
     this.store.dispatch(SetCertificateUsed({ certificateUsed: Math.min(this.orderSum, this.certificateSum) }));
     this.store.dispatch(SetCertificates({ certificates: validCertificates.map((certificate) => certificate.code) }));
+  }
+
+  private areBonusesSelectedAndNotUsed(): boolean {
+    return this.points - this.pointsUsed !== 0 && this.bonus.value;
   }
 
   ngOnDestroy(): void {

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.ts
@@ -140,9 +140,8 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
     const invalidInput = this.formArrayCertificates.controls[index].invalid;
     const formInvalid = !this.isFirstFormValid;
     const noAmountLeft = this.getFinalSum() === 0;
-    const bonusesUsed = this.areBonusesSelectedAndNotUsed();
 
-    return alreadyEntered || invalidInput || formInvalid || noAmountLeft || bonusesUsed;
+    return alreadyEntered || invalidInput || formInvalid || noAmountLeft;
   }
 
   isCanAddCertificate(): boolean {
@@ -182,10 +181,6 @@ export class UbsOrderCertificateComponent implements OnInit, OnDestroy {
     this.certificateSum = validCertificates.reduce((sum, certificate) => sum + certificate.points, 0);
     this.store.dispatch(SetCertificateUsed({ certificateUsed: Math.min(this.orderSum, this.certificateSum) }));
     this.store.dispatch(SetCertificates({ certificates: validCertificates.map((certificate) => certificate.code) }));
-  }
-
-  private areBonusesSelectedAndNotUsed(): boolean {
-    return this.points - this.pointsUsed !== 0 && this.bonus.value;
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
[#8347](https://github.com/ita-social-projects/GreenCity/issues/8347)

There was an issue that user could not activate active certificate.

### Result:

https://github.com/user-attachments/assets/7a8e638a-5637-4165-825a-8ba197894d85



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Corrected certificate activation logic so the activate button reflects remaining points accurately and no longer depends on bonus selection.
  - Prevents inconsistent states that could previously allow activation when points were insufficient or block it when eligible.

- Tests
  - Updated tests to cover bonus selection and usage scenarios, validating certificate activation behavior and preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->