### PR TITLE
Bugfix/8843 Menu was not up to mockup

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.scss
@@ -123,26 +123,6 @@
 
         .menu-item {
           height: 56px !important;
-
-          .menu-item-content {
-            display: flex;
-            align-items: center;
-            gap: 10px;
-            height: 100%;
-
-            .menu-item-action {
-              font-family: var(--primary-font);
-              font-weight: 400;
-              font-size: 16px;
-              line-height: 24px;
-              color: var(--ubs-primary-grey);
-            }
-
-            .menu-item-img {
-              width: 20px;
-              height: 20px;
-            }
-          }
         }
       }
     }
@@ -469,4 +449,24 @@
 
 .region-placeholder {
   height: 20px;
+}
+
+.menu-item-content {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 100%;
+
+  .menu-item-action {
+    font-family: var(--primary-font);
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 24px;
+    color: var(--ubs-primary-grey);
+  }
+
+  .menu-item-img {
+    width: 16px;
+    height: 16px;
+  }
 }


### PR DESCRIPTION
[#8843](https://github.com/ita-social-projects/GreenCity/issues/8843)

### Result:
<img width="342" height="214" alt="image" src="https://github.com/user-attachments/assets/34edbb67-6bff-46b5-81e0-0e01faf493f2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Refined menu item appearance in the UBS Admin employee table context menus.
  - Reduced menu icons from 20px to 16px for a cleaner look.
  - Preserved menu item height (56px) and flex-based alignment to maintain consistent spacing.
  - Improved visual consistency and readability across menu actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->