### PR TITLE
Bugfix/3821 bug notification close icon

### DIFF
--- a/src/app/shared/services/mat-snack-bar/mat-snack-bar.service.spec.ts
+++ b/src/app/shared/services/mat-snack-bar/mat-snack-bar.service.spec.ts
@@ -37,7 +37,7 @@ describe('MatSnackBarService', () => {
     service.openSnackBar(type);
 
     expect(translateSpy.get).toHaveBeenCalledWith('snack-bar.success.default', {});
-    expect(snackBarSpy.open).toHaveBeenCalledWith(translatedMessage, 'close', {
+    expect(snackBarSpy.open).toHaveBeenCalledWith(translatedMessage, ' ', {
       duration: 3000,
       verticalPosition: 'top',
       horizontalPosition: 'center',
@@ -54,6 +54,6 @@ describe('MatSnackBarService', () => {
     service.openSnackBar(type, additionalValue);
 
     expect(translateSpy.get).toHaveBeenCalledWith('snack-bar.success.confirm-restore-password', { orderId: '12345' });
-    expect(snackBarSpy.open).toHaveBeenCalledWith(translatedMessage, 'close', jasmine.any(Object));
+    expect(snackBarSpy.open).toHaveBeenCalledWith(translatedMessage, ' ', jasmine.any(Object));
   });
 });

--- a/src/app/shared/services/mat-snack-bar/mat-snack-bar.service.ts
+++ b/src/app/shared/services/mat-snack-bar/mat-snack-bar.service.ts
@@ -114,7 +114,7 @@ export class MatSnackBarService {
     const addValue = additionalValue ? { orderId: additionalValue } : {};
     this.translate.get(key, addValue).subscribe((translation) => {
       this.message = translation;
-      this.snackBar.open(this.message, 'close', {
+      this.snackBar.open(this.message, ' ', {
         duration,
         verticalPosition: 'top',
         horizontalPosition: 'center',


### PR DESCRIPTION
Removed the word 'close' from the notification pop-up

[#3821](https://github.com/ita-social-projects/GreenCityClient/issues/3821)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Snackbar notifications no longer display a “Close” text label on the action button, providing a cleaner appearance. Timing, placement, and styling of the notification remain unchanged.

* **Tests**
  * Updated unit tests to reflect the revised snackbar action label behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->