### PR TITLE
fix-sending-2-same-imgs

### DIFF
--- a/src/app/chat/ui/message-input/message-input.component.html
+++ b/src/app/chat/ui/message-input/message-input.component.html
@@ -20,7 +20,7 @@
 
   <div class="file-attach">
     <label class="file-label">
-      <input type="file" (change)="onFileSelected($event)" hidden />
+      <input type="file" (change)="onFileSelected($event)" hidden #fileInput />
       <span>{{ 'chat.attach-file' | translate }}</span>
     </label>
     <div class="file-name" *ngIf="file">{{ file.name }}</div>

--- a/src/app/chat/ui/message-input/message-input.component.spec.ts
+++ b/src/app/chat/ui/message-input/message-input.component.spec.ts
@@ -66,6 +66,46 @@ describe('MessageInputComponent', () => {
     expect(component.file).toBeUndefined();
   });
 
+  it('send(): clears file input value when fileInput ViewChild is available', () => {
+    const spy = jasmine.createSpy('sendText');
+    component.sendText.subscribe(spy);
+
+    const mockFileInput = {
+      nativeElement: {
+        value: 'some-file-path'
+      }
+    };
+    component.fileInput = mockFileInput as any;
+
+    component.text = 'hello';
+    const testFile = makeFile(10, 'test.txt');
+    component.file = testFile;
+
+    component.send();
+
+    expect(spy).toHaveBeenCalledOnceWith({ text: 'hello', file: testFile });
+    expect(mockFileInput.nativeElement.value).toBe('');
+    expect(component.text).toBe('');
+    expect(component.file).toBeUndefined();
+  });
+
+  it('send(): handles case when fileInput ViewChild is not available', () => {
+    const spy = jasmine.createSpy('sendText');
+    component.sendText.subscribe(spy);
+
+    component.fileInput = undefined as any;
+
+    component.text = 'hello';
+    const testFile = makeFile(10, 'test.txt');
+    component.file = testFile;
+
+    expect(() => component.send()).not.toThrow();
+
+    expect(spy).toHaveBeenCalledOnceWith({ text: 'hello', file: testFile });
+    expect(component.text).toBe('');
+    expect(component.file).toBeUndefined();
+  });
+
   it('onFileSelected(): sets file when within size limit (<= 5MB)', () => {
     const okFile = makeFile(1 * 1024 * 1024, 'ok.txt');
     const event = {

--- a/src/app/chat/ui/message-input/message-input.component.ts
+++ b/src/app/chat/ui/message-input/message-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Output, ViewChild, ElementRef } from '@angular/core';
 import { NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -11,6 +11,7 @@ import { TranslateModule } from '@ngx-translate/core';
 })
 export class MessageInputComponent {
   @Output() sendText = new EventEmitter<{ text: string; file?: File }>();
+  @ViewChild('fileInput', { static: false }) fileInput!: ElementRef<HTMLInputElement>;
 
   text = '';
   file?: File;
@@ -23,6 +24,10 @@ export class MessageInputComponent {
     this.sendText.emit({ text: this.text, file: this.file });
     this.text = '';
     this.file = undefined;
+
+    if (this.fileInput) {
+      this.fileInput.nativeElement.value = '';
+    }
   }
 
   onFileSelected(event: Event): void {


### PR DESCRIPTION
 Same image can be sent multiple times now
 
 Added ViewChild reference to access the file input element
 Clear file input after sending
 Added template reference variable #fileInput

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - After sending a message, any selected file is now automatically cleared from the attachment field, preventing stale files from carrying over to subsequent messages.
  - Sending behavior unchanged: messages still send when text or a file is present.
  - Works consistently whether the attachment input is available or not.

- **Localization / UI**
  - The attachment label now uses the translated "Attach" text.

- **Tests**
  - Added unit tests covering send() behavior with and without the attachment input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->