### PR TITLE
Bugfix/8990 unable to set previous district for kyiv address

### DIFF
--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
@@ -26,7 +26,7 @@ import { MatSnackBarService } from '@global-service/mat-snack-bar/mat-snack-bar.
 import { MatSelectModule } from '@angular/material/select';
 import { Router } from '@angular/router';
 import { UserOwnAuthService } from '@auth-service/user-own-auth.service';
-import { CreateAddress } from 'src/app/store/actions/order.actions';
+import { CreateAddress, UpdateAddress } from 'src/app/store/actions/order.actions';
 import { Store } from '@ngrx/store';
 
 describe('UbsUserProfilePageComponent', () => {
@@ -1042,4 +1042,32 @@ describe('UbsUserProfilePageComponent', () => {
       expect(fakeLocalStorageService.clear).toHaveBeenCalledTimes(1);
     }));
   });
+
+  it('should dispatch UpdateAddress action for a modified existing address', fakeAsync(() => {
+    const initialUserProfile: UserProfile = { ...userProfileDataMock };
+    component.userProfile = { ...initialUserProfile };
+    component.savedUserAddresses = [...initialUserProfile.addressDto];
+    component.userInit();
+    fixture.detectChanges();
+
+    const addressFormArray = component.userForm.get('address') as FormArray;
+    const addressControl = addressFormArray.at(0) as FormControl;
+
+    const updatedAddress: Address = { ...addressControl.value, streetUk: 'Updated Street' };
+    addressControl.setValue(updatedAddress);
+    addressControl.markAsDirty();
+
+    clientProfileServiceMock.postDataClientProfile.and.returnValue(of({ ...initialUserProfile, addressDto: [updatedAddress] }));
+    const store = TestBed.inject(Store) as MockStore;
+    const dispatchSpy = spyOn(store, 'dispatch');
+
+    component.onSubmit();
+    tick();
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      UpdateAddress({
+        address: jasmine.objectContaining({ streetUk: 'Updated Street', id: 2276 }) as any
+      })
+    );
+  }));
 });

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.ts
@@ -230,7 +230,7 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
 
         const isUpdated = Object.keys(formAddress).some((key) => formAddress[key] !== originalAddress[key]);
 
-        if (isUpdated) {
+        if (isUpdated && formAddress.id) {
           const updatedAddress = {
             ...formAddress,
             id: originalAddress.id,

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.ts
@@ -13,7 +13,7 @@ import { SignInIcons } from 'src/app/shared/image-paths/sign-in-icons';
 import { UBSAddAddressPopUpComponent } from '@ubs/shared/components/ubs-add-address-pop-up/ubs-add-address-pop-up.component';
 import { ResetEmployeePermissions } from 'src/app/store/actions/employee.actions';
 import { ResetFriends } from 'src/app/store/actions/friends.actions';
-import { CreateAddress, GetAddresses } from 'src/app/store/actions/order.actions';
+import { CreateAddress, GetAddresses, UpdateAddress } from 'src/app/store/actions/order.actions';
 import { addressesSelector } from 'src/app/store/selectors/order.selectors';
 import { DeletingProfileReasonPopUpComponent } from 'src/app/ubs/ubs-admin/components/shared/components/deleting-profile-reason-pop-up/deleting-profile-reason-pop-up.component';
 import { Address, UserProfile } from 'src/app/ubs/ubs-admin/models/ubs-admin.interface';
@@ -246,6 +246,7 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
           delete updatedAddress.isHouseSelected;
 
           submitData.addressDto.push(updatedAddress);
+          this.store.dispatch(UpdateAddress({ address: updatedAddress }));
         }
       });
 

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.ts
@@ -230,7 +230,7 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
 
         const isUpdated = Object.keys(formAddress).some((key) => formAddress[key] !== originalAddress[key]);
 
-        if (isUpdated && formAddress.id) {
+        if (isUpdated && originalAddress.id) {
           const updatedAddress = {
             ...formAddress,
             id: originalAddress.id,
@@ -247,6 +247,12 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
 
           submitData.addressDto.push(updatedAddress);
           this.store.dispatch(UpdateAddress({ address: updatedAddress }));
+        } else if (isUpdated) {
+          const index = this.tempAddedAddressHolder.findIndex((tempAddress) => tempAddress.placeId === formAddress.placeId);
+
+          if (index !== -1) {
+            this.tempAddedAddressHolder[index] = formAddress;
+          }
         }
       });
 


### PR DESCRIPTION
[#8990](https://github.com/ita-social-projects/GreenCity/issues/8990)

There was an issue that we could not change the district without refreshing the page.

### Result;

https://github.com/user-attachments/assets/10aae012-b148-488e-a90d-b46415a8bff5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now edit existing addresses in your profile. Changes are saved to your account without creating new entries.
  * Optional address fields (e.g., building corpus, entrance) are skipped when left empty for cleaner records.
* **Bug Fixes**
  * Improved handling of partial address edits to prevent duplicates and ensure accurate updates.
* **Tests**
  * Added automated test coverage for updating an existing address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->