### PR TITLE
Bugfix/9019 frontend sends incorrect empty email

### DIFF
--- a/src/app/ubs/ubs/components/ubs-personal-information/ubs-personal-information.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-personal-information/ubs-personal-information.component.spec.ts
@@ -168,7 +168,7 @@ describe('UBSPersonalInformationComponent', () => {
       expect(component.senderFirstName.value).toBe('');
       expect(component.senderLastName.value).toBe('');
       expect(component.senderPhoneNumber.value).toBe('');
-      expect(component.senderEmail.value).toBe('');
+      expect(component.senderEmail.value).toBe(null);
     }));
   });
 

--- a/src/app/ubs/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
+++ b/src/app/ubs/ubs/components/ubs-personal-information/ubs-personal-information.component.ts
@@ -152,7 +152,7 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
       phoneNumber: [this.personalData.phoneNumber ?? '', [Validators.required, Validators.minLength(12), PhoneNumberValidator('UA')]],
       senderFirstName: [this.personalData.firstName ?? '', this.nameValidators],
       senderLastName: [this.personalData.lastName ?? '', this.nameValidators],
-      senderEmail: [this.personalData.email ?? '', [Validators.maxLength(50), Validators.pattern(this.emailPattern)]],
+      senderEmail: [this.personalData.email ?? null, [Validators.maxLength(50), Validators.pattern(this.emailPattern)]],
       senderPhoneNumber: [this.personalData.phoneNumber ?? '', [Validators.required, Validators.minLength(12), PhoneNumberValidator('UA')]],
       isAnotherClient: [this.personalData.isAnotherClient ?? false]
     });
@@ -161,7 +161,7 @@ export class UBSPersonalInformationComponent extends FormBaseComponent implement
       this.senderFirstName.setValue('');
       this.senderLastName.setValue('');
       this.senderPhoneNumber.setValue('');
-      this.senderEmail.setValue('');
+      this.senderEmail.setValue(null);
     });
 
     this.personalDataForm.valueChanges.pipe(takeUntil(this.$destroy)).subscribe(() => {


### PR DESCRIPTION
[#9019](https://github.com/ita-social-projects/GreenCity/issues/9019)

There was an issue that user could not create order for another person, because front would send empty string instead of null, if email field is not filled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Personal Information: The email field now fully clears when selecting “Another client,” ensuring the field appears empty and validations behave correctly.
  - If no saved email exists, the email field now initializes as empty for clearer input and consistent validation.
  - Other sender fields (name, phone) retain their existing clearing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->