### PR TITLE
Bugfix/9016 fixed comment for the address while placing an order

### DIFF
--- a/src/app/main/component/auth/components/sign-up/sign-up.component.html
+++ b/src/app/main/component/auth/components/sign-up/sign-up.component.html
@@ -74,7 +74,7 @@
           (click)="setPasswordVisibility(inputPassword, inputPasswordImg)"
           (keydown.enter)="setPasswordVisibility(inputPassword, inputPasswordImg)"
           tabindex="0"
-          aria-label="Password Visiable Button"
+          aria-label="Password Visible Button"
         />
       </div>
       <div *ngIf="passwordControl.invalid && passwordControl.touched" class="error-message" id="password-err-msg"></div>

--- a/src/app/ubs/ubs/components/ubs-personal-information/ubs-order-address/ubs-order-address.component.ts
+++ b/src/app/ubs/ubs/components/ubs-personal-information/ubs-order-address/ubs-order-address.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
-import { Store, select } from '@ngrx/store';
+import { select, Store } from '@ngrx/store';
 import { CAddressData } from '@ubs/ubs/models/ubs.model';
 import { LanguageService } from 'src/app/shared/i18n/language.service';
 import { UBSAddAddressPopUpComponent } from '@ubs/shared/components/ubs-add-address-pop-up/ubs-add-address-pop-up.component';
@@ -16,7 +16,7 @@ import {
 import { IAddressExportDetails, IUserOrderInfo } from '@ubs/ubs-user/components/ubs-user-orders-list/models/UserOrder.interface';
 import { Address } from 'src/app/ubs/ubs/models/ubs.interface';
 import { AddressValidator } from 'src/app/ubs/ubs/validators/address-validators';
-import { of, switchMap, Subject, combineLatest, from, filter, take, takeUntil } from 'rxjs';
+import { combineLatest, filter, from, map, of, Subject, switchMap, take, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-ubs-order-address',
@@ -137,6 +137,8 @@ export class UbsOrderAddressComponent implements OnInit, OnDestroy {
 
   setCurrentAddress(address: Address): void {
     if (!address) {
+      this.addressComment.setValue('');
+      this.addressComment.disable();
       return;
     }
     const clonedAddress = { ...address };
@@ -188,6 +190,7 @@ export class UbsOrderAddressComponent implements OnInit, OnDestroy {
 
   deleteAddress(address: Address): void {
     this.store.dispatch(DeleteAddress({ address }));
+    this.addresses = this.addresses.filter((address) => address.id !== address.id);
     this.findAvailableAddress();
   }
 
@@ -214,13 +217,12 @@ export class UbsOrderAddressComponent implements OnInit, OnDestroy {
     const dialogRef = this.dialog.open(UBSAddAddressPopUpComponent, dialogConfig);
     dialogRef
       .afterClosed()
-      .pipe(takeUntil(this.$destroy))
-      .subscribe((res) => {
-        if (res) {
-          setTimeout(() => {
-            this.addressComment.setValue(res);
-          }, 500);
-        }
+      .pipe(
+        filter(Boolean),
+        map((address) => address.addressComment)
+      )
+      .subscribe((addressComment) => {
+        this.addressComment.setValue(addressComment);
       });
   }
 

--- a/src/app/ubs/ubs/components/ubs-personal-information/ubs-order-address/ubs-order-address.component.ts
+++ b/src/app/ubs/ubs/components/ubs-personal-information/ubs-order-address/ubs-order-address.component.ts
@@ -190,7 +190,7 @@ export class UbsOrderAddressComponent implements OnInit, OnDestroy {
 
   deleteAddress(address: Address): void {
     this.store.dispatch(DeleteAddress({ address }));
-    this.addresses = this.addresses.filter((address) => address.id !== address.id);
+    this.addresses = this.addresses.filter((singleAddress) => singleAddress.id !== address.id);
     this.findAvailableAddress();
   }
 


### PR DESCRIPTION
ita-social-projects/GreenCity#9016
<img width="763" height="144" alt="image" src="https://github.com/user-attachments/assets/8ea54437-324c-4c48-8f2d-18eb1dd23b5f" />
fixed [object Object] content of address comment form field
fixed comment that isn't deleted with the address and remains enabled
typo fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed accessibility label for the password visibility button on the sign-up form.
  * Address form now clears and disables the comment field when no address is selected to prevent stale input.
  * Address comment updates immediately after closing the address dialog for faster feedback.
  * Improved consistency of address handling during add/edit/delete workflows so the UI reflects current selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->