### PR TITLE
Hotfix/fix pipelines

### DIFF
--- a/azure-pipelines-prod.yml
+++ b/azure-pipelines-prod.yml
@@ -22,7 +22,7 @@ stages:
         pool:
           vmImage: $(agentOS)
         steps:
-          - task: AzureKeyVault@1
+          - task: AzureKeyVault@2
             displayName: Retrieve secrets from Azure Key Vault
             inputs:
               azureSubscription: '$(azureSub)'

--- a/azure-pipelines-prod.yml
+++ b/azure-pipelines-prod.yml
@@ -22,6 +22,10 @@ stages:
         pool:
           vmImage: $(agentOS)
         steps:
+          - script: |
+              chmod +w src/environments
+            displayName: Grant write permissions
+
           - task: AzureKeyVault@2
             displayName: Retrieve secrets from Azure Key Vault
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ stages:
         pool:
           vmImage: $(agentOS)
         steps:
-          - task: AzureKeyVault@1
+          - task: AzureKeyVault@2
             displayName: Retrieve secrets from Azure Key Vault
             inputs:
               azureSubscription: '$(azureSub)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,10 @@ stages:
         pool:
           vmImage: $(agentOS)
         steps:
+          - script: |
+              chmod +w src/environments
+            displayName: Grant write permissions
+
           - task: AzureKeyVault@2
             displayName: Retrieve secrets from Azure Key Vault
             inputs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Upgraded Azure Key Vault task used in build pipelines to version 2 and added a preparatory permission step prior to secrets retrieval to ensure reliable access.
  - Inputs and overall pipeline flow remain unchanged; intended to improve secret retrieval reliability and maintain compatibility without affecting deployment outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->