### PR TITLE
Bugfix/#8595 accessibility fix, #8873 close dialog after exporting excel

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table-excel-popup/ubs-admin-table-excel-popup.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table-excel-popup/ubs-admin-table-excel-popup.component.spec.ts
@@ -1,14 +1,14 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { TranslateModule } from '@ngx-translate/core';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { TranslateModule } from '@ngx-translate/core';
 import { UbsAdminTableExcelPopupComponent } from './ubs-admin-table-excel-popup.component';
 import { AdminTableService } from 'src/app/ubs/ubs-admin/services/admin-table.service';
 import { AdminCertificateService } from 'src/app/ubs/ubs-admin/services/admin-certificate.service';
 import { AdminCustomersService } from 'src/app/ubs/ubs-admin/services/admin-customers.service';
 import { LanguageService } from 'src/app/shared/i18n/language.service';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import * as XLSX from 'xlsx';
 
 describe('UbsAdminTableExcelPopupComponent', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table-excel-popup/ubs-admin-table-excel-popup.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table-excel-popup/ubs-admin-table-excel-popup.component.spec.ts
@@ -1,15 +1,14 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { FormsModule, ReactiveFormsModule, FormGroup } from '@angular/forms';
+import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { UbsAdminTableExcelPopupComponent } from './ubs-admin-table-excel-popup.component';
 import { AdminTableService } from 'src/app/ubs/ubs-admin/services/admin-table.service';
 import { AdminCertificateService } from 'src/app/ubs/ubs-admin/services/admin-certificate.service';
 import { AdminCustomersService } from 'src/app/ubs/ubs-admin/services/admin-customers.service';
 import { LanguageService } from 'src/app/shared/i18n/language.service';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { MatDialogModule } from '@angular/material/dialog';
-import { of } from 'rxjs';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import * as XLSX from 'xlsx';
 
 describe('UbsAdminTableExcelPopupComponent', () => {
@@ -25,6 +24,8 @@ describe('UbsAdminTableExcelPopupComponent', () => {
   const AdminCertificateServiceFake = jasmine.createSpyObj('adminCertificateService', ['getTable']);
 
   const AdminCustomerServiceFake = jasmine.createSpyObj('adminCustomerService', ['getCustomers']);
+
+  const matDialogRefMock = jasmine.createSpyObj('MatDialogRef', ['close']);
 
   const dataForTranslation = [
     {
@@ -52,7 +53,8 @@ describe('UbsAdminTableExcelPopupComponent', () => {
         { provide: AdminTableService, useValue: AdminTableServiceFake },
         { provide: AdminCertificateService, useValue: AdminCertificateServiceFake },
         { provide: AdminCustomersService, useValue: AdminCustomerServiceFake },
-        { provide: LanguageService, useValue: languageServiceMock }
+        { provide: LanguageService, useValue: languageServiceMock },
+        { provide: MatDialogRef, useValue: matDialogRefMock }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table-excel-popup/ubs-admin-table-excel-popup.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table-excel-popup/ubs-admin-table-excel-popup.component.ts
@@ -35,11 +35,11 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
   columnToDisplay: string[] = [];
 
   constructor(
-    private adminTableService: AdminTableService,
-    private adminCertificateService: AdminCertificateService,
-    private adminCustomerService: AdminCustomersService,
-    private languageService: LanguageService,
-    private matDialogRef: MatDialogRef<UbsAdminTableExcelPopupComponent>
+    private readonly adminTableService: AdminTableService,
+    private readonly adminCertificateService: AdminCertificateService,
+    private readonly adminCustomerService: AdminCustomersService,
+    private readonly languageService: LanguageService,
+    private readonly matDialogRef: MatDialogRef<UbsAdminTableExcelPopupComponent>
   ) {}
 
   ngOnInit() {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table-excel-popup/ubs-admin-table-excel-popup.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table-excel-popup/ubs-admin-table-excel-popup.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
 import { AdminTableService } from 'src/app/ubs/ubs-admin/services/admin-table.service';
 import { AdminCertificateService } from 'src/app/ubs/ubs-admin/services/admin-certificate.service';
 import { AdminCustomersService } from 'src/app/ubs/ubs-admin/services/admin-customers.service';
@@ -37,7 +38,8 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
     private adminTableService: AdminTableService,
     private adminCertificateService: AdminCertificateService,
     private adminCustomerService: AdminCustomersService,
-    private languageService: LanguageService
+    private languageService: LanguageService,
+    private matDialogRef: MatDialogRef<UbsAdminTableExcelPopupComponent>
   ) {}
 
   ngOnInit() {
@@ -215,6 +217,7 @@ export class UbsAdminTableExcelPopupComponent implements OnInit {
 
       XLSX.utils.book_append_sheet(wb, wst, 'Sheet1');
       XLSX.writeFile(wb, this.name);
+      this.matDialogRef.close();
     } else {
       alert('Error. Please try again');
     }

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.html
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.html
@@ -61,18 +61,18 @@
         <div class="btns-group">
           <div *ngIf="isOrderPaymentAccess(order)" class="btns-group">
             <div *ngIf="canOrderBeCancel(order)" class="btn-box">
-              <button class="ubs-secondary-global-button s-btn" (click)="openOrderCancelDialog(order)">
+              <button tabindex="0" class="ubs-secondary-global-button s-btn" (keydown.enter)="$event.preventDefault(); $event.stopPropagation(); openOrderCancelDialog(order)" (click)="$event.stopPropagation(); openOrderCancelDialog(order)">
                 {{ 'user-orders.btn.cancel' | translate }}
               </button>
             </div>
             <div *ngIf="!isOrderCanceled(order)" class="btn-box">
-              <button class="ubs-primary-global-button s-btn" (click)="openOrderPaymentDialog(order)">
+              <button class="ubs-primary-global-button s-btn" (keydown.enter)="$event.preventDefault(); $event.stopPropagation(); openOrderPaymentDialog(order)" (click)="$event.stopPropagation(); openOrderPaymentDialog(order)">
                 {{ 'user-orders.btn.pay' | translate }}
               </button>
             </div>
           </div>
           <div *ngIf="!isOrderCanceled(order)" class="btn-box export-btn">
-            <button class="ubs-primary-global-button s-btn" (click)="exportAsPDF(order)">
+            <button class="ubs-primary-global-button s-btn" (keydown.enter)="$event.preventDefault(); $event.stopPropagation(); exportAsPDF(order)" (click)="$event.stopPropagation(); exportAsPDF(order)">
               <img [ngSrc]="pdfExportIcon" width="24" height="24" alt="{{ 'user-orders.btn.export-pdf-alt' | translate }}" />
             </button>
           </div>

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.html
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.html
@@ -61,18 +61,30 @@
         <div class="btns-group">
           <div *ngIf="isOrderPaymentAccess(order)" class="btns-group">
             <div *ngIf="canOrderBeCancel(order)" class="btn-box">
-              <button tabindex="0" class="ubs-secondary-global-button s-btn" (keydown.enter)="$event.preventDefault(); $event.stopPropagation(); openOrderCancelDialog(order)" (click)="$event.stopPropagation(); openOrderCancelDialog(order)">
+              <button
+                class="ubs-secondary-global-button s-btn"
+                (keydown.enter)="$event.preventDefault(); openOrderCancelDialog($event, order)"
+                (click)="openOrderCancelDialog($event, order)"
+              >
                 {{ 'user-orders.btn.cancel' | translate }}
               </button>
             </div>
             <div *ngIf="!isOrderCanceled(order)" class="btn-box">
-              <button class="ubs-primary-global-button s-btn" (keydown.enter)="$event.preventDefault(); $event.stopPropagation(); openOrderPaymentDialog(order)" (click)="$event.stopPropagation(); openOrderPaymentDialog(order)">
+              <button
+                class="ubs-primary-global-button s-btn"
+                (keydown.enter)="$event.preventDefault(); openOrderPaymentDialog($event, order)"
+                (click)="openOrderPaymentDialog($event, order)"
+              >
                 {{ 'user-orders.btn.pay' | translate }}
               </button>
             </div>
           </div>
           <div *ngIf="!isOrderCanceled(order)" class="btn-box export-btn">
-            <button class="ubs-primary-global-button s-btn" (keydown.enter)="$event.preventDefault(); $event.stopPropagation(); exportAsPDF(order)" (click)="$event.stopPropagation(); exportAsPDF(order)">
+            <button
+              class="ubs-primary-global-button s-btn"
+              (keydown.enter)="$event.preventDefault(); exportAsPDF($event, order)"
+              (click)="exportAsPDF($event, order)"
+            >
               <img [ngSrc]="pdfExportIcon" width="24" height="24" alt="{{ 'user-orders.btn.export-pdf-alt' | translate }}" />
             </button>
           </div>

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.spec.ts
@@ -27,7 +27,7 @@ describe('UbsUserOrdersListComponent', () => {
   let matDialogMock: jasmine.SpyObj<MatDialog>;
   let dialogRefSpy: jasmine.SpyObj<any>;
 
-  const fakeIputOrderData = [
+  const fakeInputOrderData = [
     { id: 3, dateForm: 55, orderStatusEn: 'Done', paymentStatusEn: 'Unpaid', orderFullPrice: 55, amountBeforePayment: 55, extend: true },
     {
       id: 7,
@@ -88,7 +88,7 @@ describe('UbsUserOrdersListComponent', () => {
     'getPersonalData'
   ]);
   orderServiceMock.getOrderPdf.and.returnValue(of(new Blob(['pdf content'], { type: 'application/pdf' })));
-  orderServiceMock.getExistingOrderDetails.and.returnValue(of(fakeIputOrderData[1] as any));
+  orderServiceMock.getExistingOrderDetails.and.returnValue(of(fakeInputOrderData[1] as any));
   orderServiceMock.getPersonalData.and.returnValue(of(fakePersonalData));
 
   const storeMock = jasmine.createSpyObj('Store', ['select', 'dispatch']);
@@ -126,7 +126,7 @@ describe('UbsUserOrdersListComponent', () => {
     fixture = TestBed.createComponent(UbsUserOrdersListComponent);
     component = fixture.componentInstance;
     component.bonuses = fakePoints;
-    component.orders = JSON.parse(JSON.stringify(fakeIputOrderData)) as any;
+    component.orders = JSON.parse(JSON.stringify(fakeInputOrderData)) as any;
     fixture.detectChanges();
   });
 
@@ -142,36 +142,36 @@ describe('UbsUserOrdersListComponent', () => {
 
   describe('isOrderUnpaid', () => {
     it('order is unpaid', () => {
-      const isOrderPaidRes = component.isOrderUnpaid(fakeIputOrderData[0] as any);
+      const isOrderPaidRes = component.isOrderUnpaid(fakeInputOrderData[0] as any);
       expect(isOrderPaidRes).toBeTruthy();
     });
 
     it('order is not unpaid', () => {
-      const isOrderPaidRes = component.isOrderUnpaid(fakeIputOrderData[1] as any);
+      const isOrderPaidRes = component.isOrderUnpaid(fakeInputOrderData[1] as any);
       expect(isOrderPaidRes).toBeFalsy();
     });
   });
 
   describe('isOrderHalfPaid', () => {
     it('order is half paid', () => {
-      const isOrderHalfPaidRes = component.isOrderHalfPaid(fakeIputOrderData[1] as any);
+      const isOrderHalfPaidRes = component.isOrderHalfPaid(fakeInputOrderData[1] as any);
       expect(isOrderHalfPaidRes).toBeTruthy();
     });
 
     it('order is not half paid', () => {
-      const isOrderHalfPaidRes = component.isOrderHalfPaid(fakeIputOrderData[2] as any);
+      const isOrderHalfPaidRes = component.isOrderHalfPaid(fakeInputOrderData[2] as any);
       expect(isOrderHalfPaidRes).toBeFalsy();
     });
   });
 
   describe('isOrderPriceGreaterThenZero', () => {
     it('price is greater then zero', () => {
-      const isOrderPriceGreaterThenZeroRes = component.isOrderPriceGreaterThenZero(fakeIputOrderData[0] as any);
+      const isOrderPriceGreaterThenZeroRes = component.isOrderPriceGreaterThenZero(fakeInputOrderData[0] as any);
       expect(isOrderPriceGreaterThenZeroRes).toBeTruthy();
     });
 
     it('price is less then zero', () => {
-      const isOrderPriceGreaterThenZeroRes = component.isOrderPriceGreaterThenZero(fakeIputOrderData[2] as any);
+      const isOrderPriceGreaterThenZeroRes = component.isOrderPriceGreaterThenZero(fakeInputOrderData[2] as any);
       expect(isOrderPriceGreaterThenZeroRes).toBeFalsy();
     });
   });
@@ -180,32 +180,32 @@ describe('UbsUserOrdersListComponent', () => {
     it('isOrderPriceGreaterThenZero and isOrderPaid are true', () => {
       spyOn(component, 'isOrderPriceGreaterThenZero').and.returnValue(true);
       spyOn(component, 'isOrderUnpaid').and.returnValue(true);
-      const isOrderPaymentAccessRes = component.isOrderPaymentAccess(fakeIputOrderData[0] as any);
+      const isOrderPaymentAccessRes = component.isOrderPaymentAccess(fakeInputOrderData[0] as any);
       expect(isOrderPaymentAccessRes).toBeTruthy();
     });
 
     it('isOrderPriceGreaterThenZero and isOrderHalfPaid are true', () => {
       spyOn(component, 'isOrderPriceGreaterThenZero').and.returnValue(true);
       spyOn(component, 'isOrderHalfPaid').and.returnValue(true);
-      const isOrderPaymentAccessRes = component.isOrderPaymentAccess(fakeIputOrderData[1] as any);
+      const isOrderPaymentAccessRes = component.isOrderPaymentAccess(fakeInputOrderData[1] as any);
       expect(isOrderPaymentAccessRes).toBeTruthy();
     });
 
     it('isOrderPriceGreaterThenZero is false', () => {
       spyOn(component, 'isOrderPriceGreaterThenZero').and.returnValue(false);
-      const isOrderPaymentAccessRes = component.isOrderPaymentAccess(fakeIputOrderData[2] as any);
+      const isOrderPaymentAccessRes = component.isOrderPaymentAccess(fakeInputOrderData[2] as any);
       expect(isOrderPaymentAccessRes).toBeFalsy();
     });
 
     it('canOrderBeCancel return false', () => {
       spyOn(component, 'canOrderBeCancel').and.returnValue(false);
-      const canOrderBeCancel = component.canOrderBeCancel(fakeIputOrderData[3] as any);
+      const canOrderBeCancel = component.canOrderBeCancel(fakeInputOrderData[3] as any);
       expect(canOrderBeCancel).toBeFalsy();
     });
 
     it('canOrderBeCancel return true', () => {
       spyOn(component, 'canOrderBeCancel').and.returnValue(true);
-      const canOrderBeCancel = component.canOrderBeCancel(fakeIputOrderData[1] as any);
+      const canOrderBeCancel = component.canOrderBeCancel(fakeInputOrderData[1] as any);
       expect(canOrderBeCancel).toBeTruthy();
     });
   });
@@ -221,7 +221,7 @@ describe('UbsUserOrdersListComponent', () => {
 
   describe('openOrderPaymentDialog', () => {
     it('makes expected calls', () => {
-      component.openOrderPaymentDialog(fakeIputOrderData[1] as any);
+      component.openOrderPaymentDialog(fakeInputOrderData[1] as any);
       expect(matDialogMock.open).toHaveBeenCalledWith(UbsUserOrderPaymentPopUpComponent, {
         maxWidth: '500px',
         panelClass: 'ubs-user-order-payment-pop-up-vertical-scroll',
@@ -229,7 +229,8 @@ describe('UbsUserOrdersListComponent', () => {
           orderId: 7,
           price: 55,
           bonuses: 111
-        }
+        },
+        autoFocus: true
       });
     });
 
@@ -261,12 +262,12 @@ describe('UbsUserOrdersListComponent', () => {
       const editOrPayPopupSpy = spyOn(component, 'editOrPayPopup');
       spyOn(component, 'isOrderUnpaid').and.returnValue(false);
 
-      component.openOrderPaymentDialog(fakeIputOrderData[1] as any);
+      component.openOrderPaymentDialog(fakeInputOrderData[1] as any);
 
-      expect(component.isOrderUnpaid(fakeIputOrderData[1] as any)).toBeFalse();
+      expect(component.isOrderUnpaid(fakeInputOrderData[1] as any)).toBeFalse();
       expect(editOrPayPopupSpy).not.toHaveBeenCalled();
       expect(openOrderPaymentPopUpSpy).toHaveBeenCalled();
-      expect(openOrderPaymentPopUpSpy).toHaveBeenCalledWith(fakeIputOrderData[1] as any);
+      expect(openOrderPaymentPopUpSpy).toHaveBeenCalledWith(fakeInputOrderData[1] as any);
       expect(orderServiceMock.cleanOrderState).toHaveBeenCalled();
     });
 
@@ -274,11 +275,11 @@ describe('UbsUserOrdersListComponent', () => {
       const openOrderPaymentPopUpSpy = spyOn(component as any, 'openOrderPaymentPopUp');
       const editOrPayPopupSpy = spyOn(component, 'editOrPayPopup');
 
-      component.openOrderPaymentDialog(fakeIputOrderData[0] as any);
+      component.openOrderPaymentDialog(fakeInputOrderData[0] as any);
 
       expect(editOrPayPopupSpy).not.toHaveBeenCalled();
       expect(openOrderPaymentPopUpSpy).toHaveBeenCalled();
-      expect(openOrderPaymentPopUpSpy).toHaveBeenCalledWith(fakeIputOrderData[0] as any);
+      expect(openOrderPaymentPopUpSpy).toHaveBeenCalledWith(fakeInputOrderData[0] as any);
       expect(orderServiceMock.cleanOrderState).toHaveBeenCalled();
     });
 
@@ -303,7 +304,7 @@ describe('UbsUserOrdersListComponent', () => {
     });
 
     it('should always call cleanOrderState', () => {
-      component.openOrderPaymentDialog(fakeIputOrderData[0] as any);
+      component.openOrderPaymentDialog(fakeInputOrderData[0] as any);
       expect(orderServiceMock.cleanOrderState).toHaveBeenCalled();
     });
 
@@ -369,7 +370,7 @@ describe('UbsUserOrdersListComponent', () => {
 
   describe('openOrderCancelDialog', () => {
     it('makes expected calls', () => {
-      component.openOrderCancelDialog(fakeIputOrderData[0] as any);
+      component.openOrderCancelDialog(fakeInputOrderData[0] as any);
       expect(matDialogMock.open).toHaveBeenCalled();
     });
   });
@@ -421,7 +422,7 @@ describe('UbsUserOrdersListComponent', () => {
 
   describe('editOrPayPopup', () => {
     it('should open the dialog and handle afterClosed result', fakeAsync(() => {
-      component.editOrPayPopup(fakeIputOrderData[1] as any);
+      component.editOrPayPopup(fakeInputOrderData[1] as any);
       tick();
       expect(matDialogMock.open).toHaveBeenCalled();
       expect(dialogRefSpy.afterClosed).toHaveBeenCalled();
@@ -429,10 +430,10 @@ describe('UbsUserOrdersListComponent', () => {
     }));
 
     it('should open editOrPayPopup with editOrPayDialogData', fakeAsync(() => {
-      component.editOrPayPopup(fakeIputOrderData[1] as any);
+      component.editOrPayPopup(fakeInputOrderData[1] as any);
       tick();
 
-      expect(matDialogMock.open).toHaveBeenCalledWith(DialogPopUpComponent, { data: component.editOrPayDialogData });
+      expect(matDialogMock.open).toHaveBeenCalledWith(DialogPopUpComponent, { data: component.editOrPayDialogData, autoFocus: true });
 
       expect(component.editOrPayDialogData).toBeDefined();
       expect(matDialogMock.open).toHaveBeenCalled();
@@ -448,12 +449,12 @@ describe('UbsUserOrdersListComponent', () => {
       const orderPaymentPopupSpy = spyOn(component as any, 'openOrderPaymentPopUp');
       const getDataForLocalStorageSpy = spyOn(component, 'getDataForLocalStorage');
 
-      component.editOrPayPopup(fakeIputOrderData[1] as any);
+      component.editOrPayPopup(fakeInputOrderData[1] as any);
       tick();
 
       expect(matDialogMock.open).toHaveBeenCalled();
       expect(orderPaymentPopupSpy).toHaveBeenCalled();
-      expect(orderPaymentPopupSpy).toHaveBeenCalledWith(fakeIputOrderData[1] as any);
+      expect(orderPaymentPopupSpy).toHaveBeenCalledWith(fakeInputOrderData[1] as any);
       expect(getDataForLocalStorageSpy).not.toHaveBeenCalled();
     }));
 
@@ -462,12 +463,12 @@ describe('UbsUserOrdersListComponent', () => {
       const getDataForLocalStorageSpy = spyOn(component, 'getDataForLocalStorage').and.callThrough();
       const orderPaymentPopupSpy = spyOn(component as any, 'openOrderPaymentPopUp');
 
-      component.editOrPayPopup(fakeIputOrderData[1] as any);
+      component.editOrPayPopup(fakeInputOrderData[1] as any);
       tick();
 
       expect(matDialogMock.open).toHaveBeenCalled();
       expect(getDataForLocalStorageSpy).toHaveBeenCalled();
-      expect(getDataForLocalStorageSpy).toHaveBeenCalledWith(fakeIputOrderData[1] as any);
+      expect(getDataForLocalStorageSpy).toHaveBeenCalledWith(fakeInputOrderData[1] as any);
       expect(orderPaymentPopupSpy).not.toHaveBeenCalled();
     }));
 
@@ -476,7 +477,7 @@ describe('UbsUserOrdersListComponent', () => {
       const orderPaymentPopupSpy = spyOn(component as any, 'openOrderPaymentPopUp');
       const getDataForLocalStorageSpy = spyOn(component, 'getDataForLocalStorage');
 
-      component.editOrPayPopup(fakeIputOrderData[1] as any);
+      component.editOrPayPopup(fakeInputOrderData[1] as any);
       tick();
 
       expect(matDialogMock.open).toHaveBeenCalled();
@@ -494,11 +495,11 @@ describe('UbsUserOrdersListComponent', () => {
     });
 
     it('should call orderService.getOrderPdf with correct parameters', fakeAsync(() => {
-      const orderIdMock = fakeIputOrderData[0].id;
+      const orderIdMock = fakeInputOrderData[0].id;
       const langMock = 'en';
       component.currentLanguage = langMock;
 
-      component.exportAsPDF(fakeIputOrderData[0] as any);
+      component.exportAsPDF(fakeInputOrderData[0] as any);
       tick();
 
       expect(orderServiceMock.getOrderPdf).toHaveBeenCalledWith(orderIdMock, langMock);
@@ -507,7 +508,7 @@ describe('UbsUserOrdersListComponent', () => {
     it('should create blob on exportAsPDF call', fakeAsync(() => {
       const blobSpy = spyOn(window, 'Blob').and.callThrough();
 
-      component.exportAsPDF(fakeIputOrderData[0] as any);
+      component.exportAsPDF(fakeInputOrderData[0] as any);
       tick();
 
       expect(blobSpy).toHaveBeenCalled();
@@ -516,7 +517,7 @@ describe('UbsUserOrdersListComponent', () => {
     it('should create a download link with correct filename and blob', fakeAsync(() => {
       const createObjectURLSpy = spyOn(window.URL, 'createObjectURL').and.returnValue('mock-url');
 
-      component.exportAsPDF(fakeIputOrderData[0] as any);
+      component.exportAsPDF(fakeInputOrderData[0] as any);
       tick();
 
       expect(createObjectURLSpy).toHaveBeenCalled();
@@ -526,7 +527,7 @@ describe('UbsUserOrdersListComponent', () => {
       const createObjectURLSpy = spyOn(window.URL, 'createObjectURL');
       const revokeObjectURLSpy = spyOn(window.URL, 'revokeObjectURL');
 
-      component.exportAsPDF(fakeIputOrderData[0] as any);
+      component.exportAsPDF(fakeInputOrderData[0] as any);
       tick();
 
       expect(createObjectURLSpy).toHaveBeenCalled();

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.spec.ts
@@ -221,7 +221,7 @@ describe('UbsUserOrdersListComponent', () => {
 
   describe('openOrderPaymentDialog', () => {
     it('makes expected calls', () => {
-      component.openOrderPaymentDialog(fakeInputOrderData[1] as any);
+      component.openOrderPaymentDialog(new Event('click'), fakeInputOrderData[1] as any);
       expect(matDialogMock.open).toHaveBeenCalledWith(UbsUserOrderPaymentPopUpComponent, {
         maxWidth: '500px',
         panelClass: 'ubs-user-order-payment-pop-up-vertical-scroll',
@@ -248,7 +248,7 @@ describe('UbsUserOrdersListComponent', () => {
       const openOrderPaymentPopUpSpy = spyOn(component as any, 'openOrderPaymentPopUp');
       spyOn(component, 'isOrderUnpaid').and.returnValue(true);
 
-      component.openOrderPaymentDialog(orderMock as any);
+      component.openOrderPaymentDialog(new Event('click'), orderMock as any);
 
       expect(openOrderPaymentPopUpSpy).not.toHaveBeenCalled();
       expect(component.isOrderUnpaid).toHaveBeenCalledWith(orderMock as any);
@@ -262,7 +262,7 @@ describe('UbsUserOrdersListComponent', () => {
       const editOrPayPopupSpy = spyOn(component, 'editOrPayPopup');
       spyOn(component, 'isOrderUnpaid').and.returnValue(false);
 
-      component.openOrderPaymentDialog(fakeInputOrderData[1] as any);
+      component.openOrderPaymentDialog(new Event('click'), fakeInputOrderData[1] as any);
 
       expect(component.isOrderUnpaid(fakeInputOrderData[1] as any)).toBeFalse();
       expect(editOrPayPopupSpy).not.toHaveBeenCalled();
@@ -275,7 +275,7 @@ describe('UbsUserOrdersListComponent', () => {
       const openOrderPaymentPopUpSpy = spyOn(component as any, 'openOrderPaymentPopUp');
       const editOrPayPopupSpy = spyOn(component, 'editOrPayPopup');
 
-      component.openOrderPaymentDialog(fakeInputOrderData[0] as any);
+      component.openOrderPaymentDialog(new Event('click'), fakeInputOrderData[0] as any);
 
       expect(editOrPayPopupSpy).not.toHaveBeenCalled();
       expect(openOrderPaymentPopUpSpy).toHaveBeenCalled();
@@ -297,14 +297,14 @@ describe('UbsUserOrdersListComponent', () => {
       const openOrderPaymentPopUpSpy = spyOn(component as any, 'openOrderPaymentPopUp');
       const editOrPayPopupSpy = spyOn(component, 'editOrPayPopup');
 
-      component.openOrderPaymentDialog(orderMock as any);
+      component.openOrderPaymentDialog(new Event('click'), orderMock as any);
 
       expect(openOrderPaymentPopUpSpy).toHaveBeenCalledWith(orderMock as any);
       expect(editOrPayPopupSpy).not.toHaveBeenCalled();
     });
 
     it('should always call cleanOrderState', () => {
-      component.openOrderPaymentDialog(fakeInputOrderData[0] as any);
+      component.openOrderPaymentDialog(new Event('click'), fakeInputOrderData[0] as any);
       expect(orderServiceMock.cleanOrderState).toHaveBeenCalled();
     });
 
@@ -322,7 +322,7 @@ describe('UbsUserOrdersListComponent', () => {
       const editOrPayPopupSpy = spyOn(component, 'editOrPayPopup');
       const openOrderPaymentPopUpSpy = spyOn(component as any, 'openOrderPaymentPopUp');
 
-      component.openOrderPaymentDialog(formedUnpaidOrder as any);
+      component.openOrderPaymentDialog(new Event('click'), formedUnpaidOrder as any);
 
       expect(editOrPayPopupSpy).toHaveBeenCalledWith(formedUnpaidOrder as any);
       expect(openOrderPaymentPopUpSpy).not.toHaveBeenCalled();
@@ -342,7 +342,7 @@ describe('UbsUserOrdersListComponent', () => {
       const editOrPayPopupSpy = spyOn(component, 'editOrPayPopup');
       const openOrderPaymentPopUpSpy = spyOn(component as any, 'openOrderPaymentPopUp');
 
-      component.openOrderPaymentDialog(formedUnpaidOrder as any);
+      component.openOrderPaymentDialog(new Event('click'), formedUnpaidOrder as any);
 
       expect(editOrPayPopupSpy).toHaveBeenCalled();
       expect(openOrderPaymentPopUpSpy).not.toHaveBeenCalled();
@@ -361,7 +361,7 @@ describe('UbsUserOrdersListComponent', () => {
 
       (component.isOrderUnpaid as jasmine.Spy).and.returnValue(false);
 
-      component.openOrderPaymentDialog(otherOrder as any);
+      component.openOrderPaymentDialog(new Event('click'), otherOrder as any);
 
       expect(openOrderPaymentPopUpSpy).toHaveBeenCalled();
       expect(editOrPayPopupSpy).not.toHaveBeenCalled();
@@ -370,7 +370,7 @@ describe('UbsUserOrdersListComponent', () => {
 
   describe('openOrderCancelDialog', () => {
     it('makes expected calls', () => {
-      component.openOrderCancelDialog(fakeInputOrderData[0] as any);
+      component.openOrderCancelDialog(new Event('click'), fakeInputOrderData[0] as any);
       expect(matDialogMock.open).toHaveBeenCalled();
     });
   });
@@ -499,7 +499,7 @@ describe('UbsUserOrdersListComponent', () => {
       const langMock = 'en';
       component.currentLanguage = langMock;
 
-      component.exportAsPDF(fakeInputOrderData[0] as any);
+      component.exportAsPDF(new Event('click'), fakeInputOrderData[0] as any);
       tick();
 
       expect(orderServiceMock.getOrderPdf).toHaveBeenCalledWith(orderIdMock, langMock);
@@ -508,7 +508,7 @@ describe('UbsUserOrdersListComponent', () => {
     it('should create blob on exportAsPDF call', fakeAsync(() => {
       const blobSpy = spyOn(window, 'Blob').and.callThrough();
 
-      component.exportAsPDF(fakeInputOrderData[0] as any);
+      component.exportAsPDF(new Event('click'), fakeInputOrderData[0] as any);
       tick();
 
       expect(blobSpy).toHaveBeenCalled();
@@ -517,7 +517,7 @@ describe('UbsUserOrdersListComponent', () => {
     it('should create a download link with correct filename and blob', fakeAsync(() => {
       const createObjectURLSpy = spyOn(window.URL, 'createObjectURL').and.returnValue('mock-url');
 
-      component.exportAsPDF(fakeInputOrderData[0] as any);
+      component.exportAsPDF(new Event('click'), fakeInputOrderData[0] as any);
       tick();
 
       expect(createObjectURLSpy).toHaveBeenCalled();
@@ -527,7 +527,7 @@ describe('UbsUserOrdersListComponent', () => {
       const createObjectURLSpy = spyOn(window.URL, 'createObjectURL');
       const revokeObjectURLSpy = spyOn(window.URL, 'revokeObjectURL');
 
-      component.exportAsPDF(fakeInputOrderData[0] as any);
+      component.exportAsPDF(new Event('click'), fakeInputOrderData[0] as any);
       tick();
 
       expect(createObjectURLSpy).toHaveBeenCalled();

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.ts
@@ -3,7 +3,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { LocalStorageService } from 'src/app/shared/services/localstorage/local-storage.service';
 import { forkJoin, Observable, Subject } from 'rxjs';
-import { take, takeUntil, tap } from 'rxjs/operators';
+import { takeUntil, tap } from 'rxjs/operators';
 import { Bag, OrderDetails, PersonalData } from '../../../ubs/models/ubs.interface';
 import { OrderService } from '../../../ubs/services/order.service';
 import { UBSOrderFormService } from '../../../ubs/services/ubs-order-form.service';
@@ -112,7 +112,8 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
         orderId: order.id,
         price: order.amountBeforePayment,
         bonuses: this.bonuses
-      }
+      },
+      autoFocus: true
     });
   }
 
@@ -124,9 +125,8 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
 
   editOrPayPopup(order: IUserOrderInfo) {
     this.dialog
-      .open(DialogPopUpComponent, { data: this.editOrPayDialogData })
+      .open(DialogPopUpComponent, { data: this.editOrPayDialogData, autoFocus: true })
       .afterClosed()
-      .pipe(take(1))
       .subscribe((res) => {
         if (res) {
           this.openOrderPaymentPopUp(order);
@@ -234,7 +234,8 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
       data: {
         orderId: order.id,
         orders: this.orders
-      }
+      },
+      autoFocus: true
     });
   }
 

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.ts
@@ -117,7 +117,8 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
     });
   }
 
-  openOrderPaymentDialog(order: IUserOrderInfo): void {
+  openOrderPaymentDialog(event: Event, order: IUserOrderInfo): void {
+    event.stopPropagation();
     const isOrderFormed = order.orderStatusEn === OrderStatusEn.FORMED;
     this.isOrderUnpaid(order) && isOrderFormed ? this.editOrPayPopup(order) : this.openOrderPaymentPopUp(order);
     this.orderService.cleanOrderState();
@@ -137,7 +138,8 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
       });
   }
 
-  exportAsPDF(order: IUserOrderInfo): void {
+  exportAsPDF(event: Event, order: IUserOrderInfo): void {
+    event.stopPropagation();
     const orderId = order.id;
     const lang = this.currentLanguage;
 
@@ -229,7 +231,8 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
     this.router.navigate(['ubs/order'], { queryParams: { existingOrderId: this.orderId } });
   }
 
-  openOrderCancelDialog(order: IUserOrderInfo): void {
+  openOrderCancelDialog(event: Event, order: IUserOrderInfo): void {
+    event.stopPropagation();
     this.dialog.open(UbsUserOrderCancelPopUpComponent, {
       data: {
         orderId: order.id,


### PR DESCRIPTION
ita-social-projects/GreenCity#8595
ita-social-projects/GreenCity#8873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Excel export popup now closes automatically after download.
  - Payment, edit/pay, and cancel dialogs open with autofocus for faster interaction.

- **Accessibility**
  - Order action buttons respond to Enter key for keyboard activation.
  - Actions now stop event propagation to prevent unintended side effects.

- **Tests**
  - Test setup updated for dialog support (dialog mock and autofocus expectations) and cleaned/renamed test data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->