### PR TITLE
Bugfix/fix-localization-admin-order-error

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -185,7 +185,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       bag.confirmed = this.orderInfo.amountOfBagsConfirmed[bag.id] ?? bag.planned;
 
       const setAmountOfBagsExported = this.currentOrderStatus === OrderStatus.DONE ? bag.confirmed : 0;
-      bag.actual = this.isOrderStatusChanged ? 0 : this.orderInfo.amountOfBagsExported[bag.id] ?? setAmountOfBagsExported;
+      bag.actual = this.isOrderStatusChanged ? 0 : (this.orderInfo.amountOfBagsExported[bag.id] ?? setAmountOfBagsExported);
 
       return bag;
     });
@@ -253,7 +253,11 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       }),
       addressExportDetailsDto: [''],
       exportDetailsDto: this.fb.group({
-        dateExport: [this.exportInfo.dateExport ? formatDate(this.exportInfo.dateExport, 'yyyy-MM-dd', this.currentLanguage) : ''],
+        dateExport: [
+          this.exportInfo.dateExport
+            ? formatDate(this.exportInfo.dateExport, 'yyyy-MM-dd', this.currentLanguage === 'uk' ? 'uk-UA' : 'en-GB')
+            : ''
+        ],
         timeDeliveryFrom: [this.parseTimeToStr(this.exportInfo.timeDeliveryFrom)],
         timeDeliveryTo: [this.parseTimeToStr(this.exportInfo.timeDeliveryTo)],
         receivingStationId: [this.getReceivingStationById(this.exportInfo.receivingStationId)]
@@ -393,7 +397,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
   }
 
   parseTimeToStr(dateStr: string) {
-    return dateStr ? formatDate(dateStr, 'HH:mm', this.currentLanguage) : '';
+    return dateStr ? formatDate(dateStr, 'HH:mm', this.currentLanguage === 'uk' ? 'uk-UA' : 'en-GB') : '';
   }
 
   resetForm() {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-order/ubs-admin-order.component.ts
@@ -255,7 +255,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       exportDetailsDto: this.fb.group({
         dateExport: [
           this.exportInfo.dateExport
-            ? formatDate(this.exportInfo.dateExport, 'yyyy-MM-dd', this.currentLanguage === 'uk' ? 'uk-UA' : 'en-GB')
+            ? formatDate(this.exportInfo.dateExport, 'yyyy-MM-dd', this.getLocale())
             : ''
         ],
         timeDeliveryFrom: [this.parseTimeToStr(this.exportInfo.timeDeliveryFrom)],
@@ -397,7 +397,7 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
   }
 
   parseTimeToStr(dateStr: string) {
-    return dateStr ? formatDate(dateStr, 'HH:mm', this.currentLanguage === 'uk' ? 'uk-UA' : 'en-GB') : '';
+    return dateStr ? formatDate(dateStr, 'HH:mm', this.getLocale()) : '';
   }
 
   resetForm() {
@@ -664,6 +664,11 @@ export class UbsAdminOrderComponent implements OnInit, OnDestroy, AfterContentCh
       responsiblePersons.get('responsibleCaller')?.setValidators([Validators.required]);
     }
     this.statusCanceledOrDone();
+  }
+
+  getLocale(): string {
+    const lang = this.currentLanguage || '';
+    return lang.startsWith('uk') ? 'uk-UA' : 'en-GB';
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
When using the Ukrainian localization, date and time formatting did not work due to the missing "uk" locale. The usage of `this.currentLanguage` was replaced with the "uk-UA" locale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed bag quantity calculation when order status changes to prevent miscounted exported bags.
  - Standardized date and time formatting by mapping languages to explicit locales (uk-UA for Ukrainian, en-GB for others) for consistent display across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->