### PR TITLE
bugfix/fixed empty district address creation

### DIFF
--- a/src/app/ubs/shared/components/address-input/address-input.component.ts
+++ b/src/app/ubs/shared/components/address-input/address-input.component.ts
@@ -266,7 +266,9 @@ export class AddressInputComponent implements OnInit, AfterViewInit, OnDestroy, 
         this.onRegionValueSet(region);
         this.onCityValueSet(city);
         this.onStreetValueSet(street);
-        this.district.setValue(this.langService.getLangValue(addressData.districtUk, addressData.districtEn));
+        if (addressData.districtEn != 'Kyiv') {
+          this.district.setValue(this.langService.getLangValue(addressData.districtUk, addressData.districtEn));
+        }
         this.houseNumber.setValue(addressData.houseNumber);
 
         this.onChange(this.addressData.getValues());
@@ -472,6 +474,7 @@ export class AddressInputComponent implements OnInit, AfterViewInit, OnDestroy, 
 
       this.placeId.setValue(street.place_id);
       this.allowDistrictEdit && this.district.enable();
+      this.district.markAsTouched();
     } else {
       this.addressData.resetStreet();
       this.district.reset();


### PR DESCRIPTION
[#9014](https://github.com/ita-social-projects/GreenCity/issues/9014)
<img width="1240" height="739" alt="image" src="https://github.com/user-attachments/assets/a4e4b496-b3cf-4944-83db-6e72292b766a" />

Fixed the ability to add an address without entering the district. The problem was that the district was selected based on the city name (Kyiv). I've added a condition to set the district value only if it is not Kyiv.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Address form no longer overrides the district when Kyiv is selected, preserving the user’s chosen district.
  * District field now shows validation state immediately after selecting a street (when district editing is allowed), improving feedback during entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->