### PR TITLE
Bugfix/hide msedge pswd btn, accessibility, selection fix, navigation to order from chat

### DIFF
--- a/src/app/chat/component/client-info-panel/client-info-panel.component.html
+++ b/src/app/chat/component/client-info-panel/client-info-panel.component.html
@@ -9,7 +9,7 @@
     <div class="info-grid">
       <div class="info-row">
         <span class="label">{{ 'client-panel.order-id' | translate }}</span>
-        <span class="value">{{ clientData.id }}</span>
+        <a class="value-id" [routerLink]="['/ubs/admin/order', clientData.id]">{{ clientData.id }}</a>
       </div>
       <div class="info-row">
         <span class="label">{{ 'client-panel.date-form' | translate }}</span>

--- a/src/app/chat/component/client-info-panel/client-info-panel.component.scss
+++ b/src/app/chat/component/client-info-panel/client-info-panel.component.scss
@@ -53,6 +53,11 @@
 
     .value {
       color: var(--secondary-dark-grey);
+
+      &-id {
+        color: black;
+        text-decoration: underline;
+      }
     }
   }
 

--- a/src/app/chat/ui/message-input/message-input.component.html
+++ b/src/app/chat/ui/message-input/message-input.component.html
@@ -38,6 +38,6 @@
       <span>{{ 'chat.attach-file' | translate }}</span>
       <input type="file" (change)="onFileSelected($event)" hidden #fileInput />
     </label>
-    <span class="file-name">No file chosen</span>
+    <span class="file-name"> {{ 'chat.no-file-chosen' | translate }}</span>
   </div>
 </div>

--- a/src/app/main/component/auth/components/sign-in/sign-in.component.scss
+++ b/src/app/main/component/auth/components/sign-in/sign-in.component.scss
@@ -243,3 +243,8 @@ h2 {
     }
   }
 }
+
+input[type='password']::-ms-reveal,
+input[type='password']::-ms-clear {
+  display: none;
+}

--- a/src/app/main/component/auth/components/sign-up/sign-up.component.scss
+++ b/src/app/main/component/auth/components/sign-up/sign-up.component.scss
@@ -198,3 +198,8 @@
     text-align: left;
   }
 }
+
+input[type='password']::-ms-reveal,
+input[type='password']::-ms-clear {
+  display: none;
+}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.html
@@ -143,8 +143,7 @@
                 </div>
               </div>
             </div>
-            <span
-              tabindex="0"
+            <button
               class="toggle-icon"
               *ngIf="!employee.expanded && userHasRights; else deleteIcon"
               #menuTrigger="matMenuTrigger"
@@ -154,7 +153,7 @@
               (keydown.space)="menuTrigger.openMenu(); $event.preventDefault(); $event.stopPropagation()"
             >
               <img [src]="icons.crumbs" alt="options" />
-            </span>
+            </button>
             <div [ngClass]="employee.expanded ? 'toggle-icon-down' : 'toggle-icon-up'"></div>
             <mat-menu class="menu" #crumbs="matMenu">
               <button *ngIf="isThisUserCanEditEmployee" class="menu-item" (click)="openEditDialog(employee, $event)" mat-menu-item>
@@ -198,15 +197,15 @@
               </button>
             </mat-menu>
             <ng-template #deleteIcon>
-              <span
-                tabindex="0"
+              <button
+                class="toggle-icon"
                 *ngIf="isThisUserCanDeleteEmployee && employee.employeeStatus === isStatusActive"
                 (click)="openDeleteDialog(employee, $event)"
                 (keydown.enter)="openDeleteDialog(employee, $event)"
                 (keydown.space)="$event.preventDefault(); openDeleteDialog(employee, $event)"
               >
                 <img [src]="icons.delete" alt="deactivate" />
-              </span>
+              </button>
               <span
                 *ngIf="isThisUserCanDeleteEmployee && employee.employeeStatus === isStatusInactive"
                 (click)="openActivateDialog(employee, $event)"

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.html
@@ -144,10 +144,14 @@
               </div>
             </div>
             <span
+              tabindex="0"
               class="toggle-icon"
               *ngIf="!employee.expanded && userHasRights; else deleteIcon"
+              #menuTrigger="matMenuTrigger"
               [matMenuTriggerFor]="crumbs"
               (click)="$event.stopPropagation()"
+              (keydown.enter)="menuTrigger.openMenu(); $event.preventDefault(); $event.stopPropagation()"
+              (keydown.space)="menuTrigger.openMenu(); $event.preventDefault(); $event.stopPropagation()"
             >
               <img [src]="icons.crumbs" alt="options" />
             </span>
@@ -195,8 +199,11 @@
             </mat-menu>
             <ng-template #deleteIcon>
               <span
+                tabindex="0"
                 *ngIf="isThisUserCanDeleteEmployee && employee.employeeStatus === isStatusActive"
                 (click)="openDeleteDialog(employee, $event)"
+                (keydown.enter)="openDeleteDialog(employee, $event)"
+                (keydown.space)="$event.preventDefault(); openDeleteDialog(employee, $event)"
               >
                 <img [src]="icons.delete" alt="deactivate" />
               </span>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.scss
@@ -324,6 +324,11 @@
       }
 
       .toggle-icon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        background: none;
         height: 46px;
       }
 

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.spec.ts
@@ -238,7 +238,8 @@ describe('UbsAdminEmployeeTableComponent', () => {
       hasBackdrop: true,
       closeOnNavigation: true,
       disableClose: true,
-      panelClass: 'delete-dialog-container'
+      panelClass: 'delete-dialog-container',
+      autoFocus: true
     });
   });
 });

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.ts
@@ -174,7 +174,8 @@ export class UbsAdminEmployeeTableComponent implements OnInit {
       hasBackdrop: true,
       closeOnNavigation: true,
       disableClose: true,
-      panelClass: 'delete-dialog-container'
+      panelClass: 'delete-dialog-container',
+      autoFocus: true
     });
 
     matDialogRef

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee.component.html
@@ -34,11 +34,15 @@
           <mat-autocomplete #autoposition="matAutocomplete" (optionSelected)="onSelectPosition($event, autocompleteTriggerPosition)">
             <div class="option-wrapper">
               <mat-option value="all">
-                <mat-checkbox [checked]="isPositionChecked()" value="all"></mat-checkbox>
+                <mat-checkbox [checked]="isPositionChecked()" value="all" [value]="selectOptions.all"></mat-checkbox>
                 {{ 'ubs-tariffs.states.all' | translate }}</mat-option
               >
-              <mat-option *ngFor="let position of positionName">
-                <mat-checkbox class="mr-1" [checked]="checkSelectedItem(position, selectedPositions)"></mat-checkbox>
+              <mat-option *ngFor="let position of positionName" [value]="position">
+                <mat-checkbox
+                  class="mr-1"
+                  (click)="$event.stopPropagation()"
+                  [checked]="checkSelectedItem(position, selectedPositions)"
+                ></mat-checkbox>
                 <span class="checkbox-text">{{ position }}</span>
               </mat-option>
             </div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee.component.ts
@@ -35,6 +35,7 @@ export class UbsAdminEmployeeComponent implements OnInit, OnDestroy {
   @Input() locationCard: Locations;
 
   private readonly restrictedSymbols = /[#&?]/;
+  readonly selectOptions = selectOptions;
   searchValueIncorrect = false;
   employeePositions: EmployeePositions[];
   locations: Locations[];
@@ -131,7 +132,7 @@ export class UbsAdminEmployeeComponent implements OnInit, OnDestroy {
     this.languageService
       .getCurrentLangObs()
       .pipe(takeUntil(this.destroy$))
-      .subscribe((i) => {
+      .subscribe(() => {
         this.getLocations();
         this.getCouriers();
         this.getPositions();
@@ -230,10 +231,9 @@ export class UbsAdminEmployeeComponent implements OnInit, OnDestroy {
     this.locations$.pipe(skip(1)).subscribe((item: Locations[]) => {
       if (item) {
         this.locations = item;
-        const regions = this.locations
+        this.filteredRegions = this.locations
           .map((element) => element.regionTranslationDtos.filter((it) => it.languageCode === this.currentLang).map((it) => it.regionName))
           .flat(2);
-        this.filteredRegions = regions;
         this.cities = this.mapCities(this.locations);
         this.filteredCities = this.filterOptions(
           this.city,
@@ -746,6 +746,4 @@ export class UbsAdminEmployeeComponent implements OnInit, OnDestroy {
       panelClass: 'admin-cabinet-dialog-container'
     });
   }
-
-  protected readonly selectOptions = selectOptions;
 }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee.component.ts
@@ -333,7 +333,8 @@ export class UbsAdminEmployeeComponent implements OnInit, OnDestroy {
   }
 
   onSelectPosition(event: MatAutocompleteSelectedEvent, trigger?: MatAutocompleteTrigger): void {
-    if (event.option.value === selectOptions.all) {
+    const value = event.option.value;
+    if (value === selectOptions.all) {
       this.toggleSelectAllPositions();
       const positionsId = this.employeePositions.map((position) => position.id);
       Object.assign(this.filterData, { positions: positionsId });
@@ -419,10 +420,10 @@ export class UbsAdminEmployeeComponent implements OnInit, OnDestroy {
 
   transformPositionToSelectedPosition(position: any) {
     return {
-      name: this.languageService.getLangValue(position.name, position.nameEn),
+      name: this.languageService.getLangValue(position.nameUk, position.nameEn),
       id: position.id,
       englishName: position.nameEn,
-      ukrainianName: position.name
+      ukrainianName: position.nameUk
     };
   }
 
@@ -745,4 +746,6 @@ export class UbsAdminEmployeeComponent implements OnInit, OnDestroy {
       panelClass: 'admin-cabinet-dialog-container'
     });
   }
+
+  protected readonly selectOptions = selectOptions;
 }

--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -645,6 +645,7 @@
     "delete-message-cancel": "No",
     "active-chat-placeholder": "Enter your message",
     "attach-file": "Attach a file",
+    "no-file-chosen": "No file chosen",
     "status": {
       "READ": "Read",
       "UNREAD": "Unread"

--- a/src/assets/i18n/ubs-admin/uk.json
+++ b/src/assets/i18n/ubs-admin/uk.json
@@ -643,6 +643,7 @@
     "delete-message-cancel": "Ні",
     "active-chat-placeholder": "Введіть ваше повідомлення",
     "attach-file": "Прикріпити файл",
+    "no-file-chosen": "Файл не обрано",
     "status": {
       "READ": "Прочитано",
       "UNREAD": "Не прочитано"


### PR DESCRIPTION
#3798  added navigation to the order by id within chat
ita-social-projects/GreenCity#9017 [ms edge] removed show/hide btn for password 
ita-social-projects/GreenCity#9021 added localization for file choose label
accessibility fixes and position autocomplete fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Order ID in the client info panel is now a clickable link to the order details.
  * “No file chosen” message is now localized (EN/UK).

* Bug Fixes
  * Positions filter: clearer option labels/values; checkbox clicks no longer unintentionally select options.
  * Improved keyboard accessibility for employee options menu and delete action.

* Style
  * Added distinct styling for the ID link (black, underlined).
  * Hid password reveal/clear icons in Microsoft browsers for password fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->