### PR TITLE
Bugfix/5269 Fixed invalid order of data

### DIFF
--- a/src/app/ubs/ubs/components/ubs-submit-order/ubs-submit-order.component.html
+++ b/src/app/ubs/ubs/components/ubs-submit-order/ubs-submit-order.component.html
@@ -68,14 +68,14 @@
           <p class="order-header">{{ 'order-details.recipient' | translate }}</p>
           <ul class="order-list" *ngIf="personalData.senderFirstName; else defaultCase">
             <li class="order-list-item">{{ personalData.senderFirstName }} {{ personalData.senderLastName }}</li>
-            <li class="order-list-item">{{ formattedSenderPhoneNumber }}</li>
             <li class="order-list-item">{{ personalData.senderEmail }}</li>
+            <li class="order-list-item">{{ formattedSenderPhoneNumber }}</li>
           </ul>
           <ng-template #defaultCase>
             <ul class="order-list">
               <li class="order-list-item">{{ personalData.firstName }} {{ personalData.lastName }}</li>
-              <li class="order-list-item">{{ formattedPhoneNumber }}</li>
               <li class="order-list-item">{{ personalData.email }}</li>
+              <li class="order-list-item">{{ formattedPhoneNumber }}</li>
             </ul>
           </ng-template>
         </div>
@@ -95,17 +95,17 @@
             <li class="order-list-item">
               <span>{{ 'personal-info.address-city' | translate }} </span>
               <span [appLangValue]="{ uk: personalData.city, en: personalData.cityEn }" suffix=", "></span>
-              <span [appLangValue]="{ uk: personalData.street, en: personalData.streetEn }" suffix=", "></span>
-              <span> {{ personalData.houseNumber }}, </span>
-              <span *ngIf="personalData.houseCorpus"> {{ 'personal-info.address-corp' | translate }} {{ personalData.houseCorpus }} </span>
-              <span *ngIf="personalData.entranceNumber">
-                {{ 'personal-info.address-entrance' | translate }} {{ personalData.entranceNumber }}
-              </span>
-            </li>
-            <li class="order-list-item">
               <span>{{ 'personal-info.address-district' | translate }} </span>
               <span [appLangValue]="{ uk: personalData.district.split(' ')[0], en: personalData.districtEn.split(' ')[0] }" suffix=", ">
               </span>
+              <span [appLangValue]="{ uk: personalData.street, en: personalData.streetEn }" suffix=", "></span>
+              <span> {{ personalData.houseNumber }}</span>
+              <span *ngIf="personalData.houseCorpus">, {{ 'personal-info.address-corp' | translate }} {{ personalData.houseCorpus }}</span>
+              <span *ngIf="personalData.entranceNumber"
+                >, {{ 'personal-info.address-entrance' | translate }} {{ personalData.entranceNumber }}</span
+              >
+            </li>
+            <li class="order-list-item">
               <span [appLangValue]="{ uk: personalData.region, en: personalData.regionEn }"></span>
             </li>
           </ul>


### PR DESCRIPTION
[#5269](https://github.com/ita-social-projects/GreenCity/issues/5269)
There was an issue of wrong order of data during submiting of order.

### Result:
<img width="633" height="336" alt="image" src="https://github.com/user-attachments/assets/b2f0689b-a345-43a0-ab75-bae7f12fb3b5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Reordered recipient details: phone number now appears after the email.
  - Simplified export address display to a two-line layout:
    - Line 1: city, street, house number, house corpus, and entrance in a single line with improved punctuation.
    - Line 2: shows region (replacing district) without a preceding label.
  - Visual-only changes; no impact on data or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->