### PR TITLE
Bugfix/3871 Names display is fixed

### DIFF
--- a/src/app/chat/component/chat-page/chat-page.component.html
+++ b/src/app/chat/component/chat-page/chat-page.component.html
@@ -15,7 +15,12 @@
     <ng-container *ngIf="facade.selectedChat(); else placeholder">
       <div class="chat-box">
         <div class="chat-header">
-          {{ facade.selectedChat()!.fullName }} (&#64;{{ facade.selectedChat()!.nickname }})
+          <div>
+            <span *ngIf="facade.selectedChat().fullName">
+              {{ facade.selectedChat().fullName }}
+            </span>
+            <span> (&#64;{{ facade.selectedChat().nickname }} ) </span>
+          </div>
           <button class="client-info-button" (click)="facade.toggleClientInfo()" [title]="'chat.client-info' | translate">🧠</button>
         </div>
 


### PR DESCRIPTION
#3871 
There was an issue that user could not enter name in telegram and then null would be displayed 

### Result:

<img width="721" height="185" alt="image" src="https://github.com/user-attachments/assets/ee49a562-da36-44cf-9710-707953a99218" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined chat header display: full name now appears only when available, preventing empty or placeholder text.
  - Nickname is shown in parentheses with improved spacing and clearer separation from the full name.
  - Enhances readability and consistency without changing data retrieval or chat selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->