### PR TITLE
bugfix/street, house number and district don't get disabled and cleared if the city field is cleared

### DIFF
--- a/src/app/ubs/shared/components/address-input/address-input.component.html
+++ b/src/app/ubs/shared/components/address-input/address-input.component.html
@@ -31,7 +31,7 @@
       [disabled]="isUneditableStatus"
       [blockAutoComplete]="blockAutoComplete"
       ngDefaultControl
-      (keyupEmitter)="keyup($event)"
+      (keyupEmitter)="keyupCity($event)"
     ></app-input-google-autocomplete>
     <div *ngIf="city.invalid && (city.touched || city.dirty)">
       <app-ubs-input-error [formElement]="city" [inputName]="errorType"></app-ubs-input-error>
@@ -49,6 +49,7 @@
       [isInvalid]="street.invalid && (street.touched || street.dirty)"
       [blockAutoComplete]="blockAutoComplete"
       ngDefaultControl
+      (keyupEmitter)="keyupStreet($event)"
     ></app-input-google-autocomplete>
     <div *ngIf="isErrorMessageShown(street)">
       <app-ubs-input-error [formElement]="street" [inputName]="errorType"></app-ubs-input-error>

--- a/src/app/ubs/shared/components/address-input/address-input.component.spec.ts
+++ b/src/app/ubs/shared/components/address-input/address-input.component.spec.ts
@@ -620,17 +620,39 @@ describe('AddressInputComponent', () => {
     expect(component['handleGeolocationSuccess']).toHaveBeenCalled();
   });
 
-  it('should disable region on keyup if text exists', () => {
+  it('should disable region on keyupCity if text exists', () => {
     spyOn(component.addressForm.get('region'), 'disable');
-    component.keyup('test');
+    component.keyupCity('test');
     expect(component.addressForm.get('region').disable).toHaveBeenCalled();
     expect(component.errorType).toBe('requiredFromDropdown');
   });
 
-  it('should enable region on keyup if text is empty', () => {
+  it('should enable region on keyupCity if text is empty', () => {
     spyOn(component.addressForm.get('region'), 'enable');
-    component.keyup('');
+    component.keyupCity('');
     expect(component.addressForm.get('region').enable).toHaveBeenCalled();
+    expect(component.errorType).toBe('requiredFromDropdown');
+  });
+
+  it('should not clear and disable fields on keyupStreet if text exists', () => {
+    const onStreetValueSetSpy = spyOn(component as any, 'onStreetValueSet');
+    const resetHouseInfoSpy = spyOn(component as any, 'resetHouseInfo');
+    const resetDistrictsSpy = spyOn(component as any, 'resetDistricts');
+    component.keyupStreet('test');
+    expect(onStreetValueSetSpy).not.toHaveBeenCalled();
+    expect(resetHouseInfoSpy).not.toHaveBeenCalled();
+    expect(resetDistrictsSpy).not.toHaveBeenCalled();
+    expect(component.errorType).toBe('requiredFromDropdown');
+  });
+
+  it('should clear and disable fields on keyupStreet if text exists', () => {
+    const onStreetValueSetSpy = spyOn(component as any, 'onStreetValueSet');
+    const resetHouseInfoSpy = spyOn(component as any, 'resetHouseInfo');
+    const resetDistrictsSpy = spyOn(component as any, 'resetDistricts');
+    component.keyupStreet('');
+    expect(onStreetValueSetSpy).toHaveBeenCalled();
+    expect(resetHouseInfoSpy).toHaveBeenCalled();
+    expect(resetDistrictsSpy).toHaveBeenCalled();
     expect(component.errorType).toBe('requiredFromDropdown');
   });
 

--- a/src/app/ubs/shared/components/address-input/address-input.component.ts
+++ b/src/app/ubs/shared/components/address-input/address-input.component.ts
@@ -455,8 +455,25 @@ export class AddressInputComponent implements OnInit, AfterViewInit, OnDestroy, 
     this.delayAutocomplete();
   }
 
-  keyup(keyupText: string): void {
-    keyupText ? this.addressForm.get('region').disable() : this.addressForm.get('region').enable();
+  keyupCity(keyupText: string): void {
+    if (keyupText) {
+      this.addressForm.get('region').disable();
+    } else {
+      this.onCityValueSet(keyupText);
+      this.resetStreet();
+      this.resetDistricts();
+      this.resetHouseInfo();
+      this.addressForm.get('region').enable();
+    }
+    this.errorType = 'requiredFromDropdown';
+  }
+
+  keyupStreet(keyupText: string): void {
+    if (!keyupText) {
+      this.onStreetValueSet(keyupText);
+      this.resetHouseInfo();
+      this.resetDistricts();
+    }
     this.errorType = 'requiredFromDropdown';
   }
 
@@ -623,8 +640,11 @@ export class AddressInputComponent implements OnInit, AfterViewInit, OnDestroy, 
 
   private resetHouseInfo(): void {
     this.houseNumber.reset();
+    this.houseNumber.disable();
     this.houseCorpus.reset();
+    this.houseCorpus.disable();
     this.entranceNumber.reset();
+    this.entranceNumber.disable();
     this.addressData.resetHouseInfo();
   }
 


### PR DESCRIPTION
[#9063](https://github.com/ita-social-projects/GreenCity/issues/9063)
Fixed the ability to add an address if the city or street field gets cleared. Other values get disabled when those fields are empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Address form now responds smarter to typing: entering a city disables the region field; clearing the city re-enables region and clears dependent street/district/house details.
  - Street input now clears related house and district details when emptied, ensuring consistent state.
  - House-related inputs (number, corpus, entrance) are disabled after resets to prevent invalid entries.

- Tests
  - Expanded test coverage for city and street input behaviors to ensure consistent clearing and disabling logic across fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->