### PR TITLE
Bugfix/9062-chat-opens-by-pasting-url 

### DIFF
--- a/src/app/chat/component/chat-page/chat-page.component.spec.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.spec.ts
@@ -2,11 +2,18 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Injectable } from '@angular/core';
 import { ChatComponent } from './chat-page.component';
 import { ChatFacade } from '../../facade/chat.facade';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 
 @Injectable()
 class MockChatFacade {
   init = jasmine.createSpy('init');
   loadNextPage = jasmine.createSpy('loadNextPage');
+}
+@Injectable()
+class RouteMock {
+  snapshot = { queryParams: { chatId: 123 } };
+  queryParams = of({ chatId: 123 });
 }
 
 class FakeIO implements IntersectionObserver {
@@ -52,7 +59,10 @@ describe('ChatComponent (baseline)', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ChatComponent],
-      providers: [{ provide: ChatFacade, useClass: MockChatFacade }]
+      providers: [
+        { provide: ChatFacade, useClass: MockChatFacade },
+        { provide: ActivatedRoute, useClass: RouteMock }
+      ]
     })
       .overrideComponent(ChatComponent, { set: { template: `<div>no refs</div>` } })
       .compileComponents();
@@ -65,18 +75,20 @@ describe('ChatComponent (baseline)', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
-  it('ngOnInit calls facade.init with undefined when no selectedChatId', () => {
+  it('ngOnInit calls facade.init with NaN when no chatId', () => {
     const facade = TestBed.inject(ChatFacade) as unknown as MockChatFacade;
+    component.route.snapshot.queryParams['chatId'] = undefined;
+
     facade.init.calls.reset();
-    history.replaceState({}, '');
     component.ngOnInit();
-    expect(facade.init).toHaveBeenCalledOnceWith(undefined);
+
+    expect(facade.init).toHaveBeenCalledOnceWith(NaN);
   });
 
-  it('ngOnInit calls facade.init with selectedChatId from history.state', () => {
+  it('ngOnInit calls facade.init with chatId from history.state', () => {
     const facade = TestBed.inject(ChatFacade) as unknown as MockChatFacade;
     facade.init.calls.reset();
-    history.replaceState({ selectedChatId: 321 }, '');
+    component.route.snapshot.queryParams = { chatId: 321 };
     component.ngOnInit();
     expect(facade.init).toHaveBeenCalledOnceWith(321);
   });
@@ -94,7 +106,10 @@ describe('ChatComponent (IO behavior)', () => {
 
     await TestBed.configureTestingModule({
       imports: [ChatComponent],
-      providers: [{ provide: ChatFacade, useClass: MockChatFacade }]
+      providers: [
+        { provide: ChatFacade, useClass: MockChatFacade },
+        { provide: ActivatedRoute, useClass: RouteMock }
+      ]
     })
       .overrideComponent(ChatComponent, {
         set: {
@@ -161,15 +176,22 @@ describe('ChatComponent (IO behavior)', () => {
 });
 describe('ChatComponent (ctor + ngOnInit via detectChanges)', () => {
   it('ctor runs', () => {
-    const c = new ChatComponent(new MockChatFacade() as any);
+    const c = new ChatComponent(new MockChatFacade() as any, route);
     expect(c).toBeTruthy();
   });
 
+  let route: ActivatedRoute;
   const setup = async (state: any) => {
-    history.replaceState(state, '');
     await TestBed.configureTestingModule({
       imports: [ChatComponent],
-      providers: [{ provide: ChatFacade, useClass: MockChatFacade }]
+      providers: [
+        { provide: ChatFacade, useClass: MockChatFacade },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { queryParams: { chatId: state.chatId } },
+          queryParams: of({ chatId: state.chatId }) }
+        }
+      ]
     })
       .overrideComponent(ChatComponent, { set: { template: `<div>no refs</div>` } })
       .compileComponents();
@@ -178,26 +200,30 @@ describe('ChatComponent (ctor + ngOnInit via detectChanges)', () => {
     const component = fixture.componentInstance;
     const facade = TestBed.inject(ChatFacade) as unknown as MockChatFacade;
     facade.init.calls.reset();
+    route = TestBed.inject(ActivatedRoute);
     fixture.detectChanges();
     return { fixture, component, facade };
   };
 
-  it('ngOnInit calls facade.init with undefined when no selectedChatId (via detectChanges)', async () => {
+  it('ngOnInit calls facade.init with NaN when no chatId (via detectChanges)', async () => {
     const { facade } = await setup({});
-    expect(facade.init).toHaveBeenCalledOnceWith(undefined);
+
+    expect(facade.init).toHaveBeenCalledOnceWith(NaN);
   });
 
-  it('ngOnInit calls facade.init with selectedChatId (via detectChanges)', async () => {
-    const { facade } = await setup({ selectedChatId: 999 });
+  it('ngOnInit calls facade.init with chatId (via detectChanges)', async () => {
+    const { facade } = await setup({ chatId: 999 });
     expect(facade.init).toHaveBeenCalledOnceWith(999);
   });
 });
 describe('ChatComponent (ngOnInit coverage)', () => {
-  it('covers selectedChatId read via detectChanges', async () => {
-    history.replaceState({ selectedChatId: 555 }, '');
+  it('covers chatId read via detectChanges', async () => {
     await TestBed.configureTestingModule({
       imports: [ChatComponent],
-      providers: [{ provide: ChatFacade, useClass: MockChatFacade }]
+      providers: [
+        { provide: ChatFacade, useClass: MockChatFacade },
+        { provide: ActivatedRoute, useClass: RouteMock }
+      ]
     })
       .overrideComponent(ChatComponent, { set: { template: `<div>no refs</div>` } })
       .compileComponents();
@@ -207,6 +233,6 @@ describe('ChatComponent (ngOnInit coverage)', () => {
     facade.init.calls.reset();
 
     fixture.detectChanges();
-    expect(facade.init).toHaveBeenCalledOnceWith(555);
+    expect(facade.init).toHaveBeenCalledOnceWith(123);
   });
 });

--- a/src/app/chat/component/chat-page/chat-page.component.spec.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.spec.ts
@@ -8,6 +8,7 @@ import { of } from 'rxjs';
 @Injectable()
 class MockChatFacade {
   init = jasmine.createSpy('init');
+  selectChatById = jasmine.createSpy('selectChatById');
   loadNextPage = jasmine.createSpy('loadNextPage');
 }
 @Injectable()

--- a/src/app/chat/component/chat-page/chat-page.component.spec.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.spec.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { ChatComponent } from './chat-page.component';
 import { ChatFacade } from '../../facade/chat.facade';
 import { ActivatedRoute } from '@angular/router';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 
 @Injectable()
 class MockChatFacade {
@@ -84,6 +84,16 @@ describe('ChatComponent (baseline)', () => {
     component.ngOnInit();
 
     expect(facade.init).toHaveBeenCalledOnceWith(NaN);
+  });
+
+  it('should change chatId on queryParams change', () => {
+    const facade = TestBed.inject(ChatFacade) as unknown as MockChatFacade;
+    component.route.queryParams = new BehaviorSubject({ chatId: 123 });
+    component.ngOnInit();
+
+    (component.route.queryParams as BehaviorSubject<any>).next({ chatId: 456 });
+
+    expect(facade.selectChatById).toHaveBeenCalledWith(456);
   });
 
   it('ngOnInit calls facade.init with chatId from history.state', () => {
@@ -189,8 +199,7 @@ describe('ChatComponent (ctor + ngOnInit via detectChanges)', () => {
         { provide: ChatFacade, useClass: MockChatFacade },
         {
           provide: ActivatedRoute,
-          useValue: { snapshot: { queryParams: { chatId: state.chatId } },
-          queryParams: of({ chatId: state.chatId }) }
+          useValue: { snapshot: { queryParams: { chatId: state.chatId } }, queryParams: of({ chatId: state.chatId }) }
         }
       ]
     })

--- a/src/app/chat/component/chat-page/chat-page.component.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.ts
@@ -7,7 +7,8 @@ import { ImageModalComponent } from '../image-modal/image-modal.component';
 import { ChatSidebarComponent } from '../../ui/chat-sidebar/chat-sidebar.component';
 import { MessagesListComponent } from '../../ui/messages-list/messages-list.component';
 import { MessageInputComponent } from '../../ui/message-input/message-input.component';
-import { Subject } from 'rxjs';
+import { Subject, takeUntil } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-chat',
@@ -30,12 +31,15 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('pagingAnchor') pagingAnchor!: ElementRef<HTMLElement>;
   private io?: IntersectionObserver;
   private readonly destroy$ = new Subject<void>();
-  constructor(public facade: ChatFacade) {}
+  constructor(public facade: ChatFacade, public route: ActivatedRoute) {}
 
   ngOnInit(): void {
-    const selectedChatId = (history.state as { selectedChatId?: number })?.selectedChatId;
-    this.facade.init(selectedChatId);
+    this.facade.init(Number(this.route.snapshot.queryParams['chatId']));
+    this.route.queryParams.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+      this.facade.selectChatById(Number(params['chatId']));
+    });
   }
+
   ngAfterViewInit(): void {
     if (!this.sidebarRoot || !this.pagingAnchor) {
       return;

--- a/src/app/chat/facade/chat.facade.ts
+++ b/src/app/chat/facade/chat.facade.ts
@@ -129,7 +129,7 @@ export class ChatFacade {
         this.totalPages.set(resp.totalPages);
         this.isLoading.set(false);
 
-        if (page === 0 && initialSelectedChatId != null) {
+        if (page === 0 && !Number.isNaN(initialSelectedChatId)) {
           const found = this.chats().find((c) => c.chatInternalId === initialSelectedChatId);
           if (found) {
             this.selectChat(found);
@@ -156,6 +156,13 @@ export class ChatFacade {
     const newQuery = params.toString();
     const newPath = newQuery ? `${pathOnly}?${newQuery}${hash}` : `${pathOnly}${hash}`;
     this.location.replaceState(newPath);
+  }
+
+  selectChatById(chatInternalId: number) { 
+    const chat = this.chats().find((c) => c.chatInternalId === chatInternalId);
+    if (chat) {
+      this.selectChat(chat);
+    }
   }
 
   selectChat(chat: ChatListItem) {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.spec.ts
@@ -233,7 +233,7 @@ describe('UbsAdminCustomersComponent', () => {
     component.onOpenChat(chatIdMock);
 
     expect(router.navigate).toHaveBeenCalled();
-    expect(router.navigate).toHaveBeenCalledWith(['ubs/admin', 'chat-page'], { state: { selectedChatId: chatIdMock } });
+    expect(router.navigate).toHaveBeenCalledWith(['ubs/admin', 'chat-page'], { queryParams: { chatId: chatIdMock } });
   });
 
   it('should call getCustomers and dispatch GetCustomerTable action on ngOnInit', () => {

--- a/src/app/ubs/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-customers/ubs-admin-customers.component.ts
@@ -448,7 +448,7 @@ export class UbsAdminCustomersComponent implements OnInit, AfterViewChecked, OnD
   }
 
   onOpenChat(chatId: number) {
-    this.router.navigate(['ubs/admin', 'chat-page'], { state: { selectedChatId: chatId } });
+    this.router.navigate(['ubs/admin', 'chat-page'], { queryParams: { chatId: chatId } });
   }
 
   private openCustomer(row, username): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat page reads selected conversation from the URL (?chatId=...), enabling deep links, bookmarking, and sharing.
  * Chat selection updates automatically when the chatId query parameter changes.
  * Opening a chat from Customers now navigates with chatId in the URL.

* **Bug Fixes**
  * More robust initialization when chatId is missing or invalid, preventing incorrect pre-selection.

* **Tests**
  * Tests updated to drive chatId via route/query parameters to match runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->