### PR TITLE
bugfix/added correct confirm page

### DIFF
--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
@@ -19,7 +19,7 @@ describe('UbsConfirmPageComponent', () => {
   let router: Router;
   let activatedRoute: ActivatedRoute;
   const fakeSnackBar = jasmine.createSpyObj('fakeSnackBar', ['openSnackBar']);
-  const fakeUBSOrderFormService = jasmine.createSpyObj('fakeUBSService', [
+  const fakeUBSOrderFormService = jasmine.createSpyObj('UBSOrderFormService', [
     'getOrderResponseErrorStatus',
     'getOrderStatus',
     'setOrderStatus',
@@ -145,40 +145,75 @@ describe('UbsConfirmPageComponent', () => {
     expect(saveDataOnLocalStorageMock).toHaveBeenCalled();
     expect(navigateSpy).toHaveBeenCalledWith(['ubs/user', 'orders']);
   });
-  it('should handle paid status correctly', () => {
-    (activatedRoute as any).queryParams = of({ status: 'paid', orderId: '1' });
 
-    component.ngOnInit();
+  describe('ngOnInit', () => {
+    beforeEach(() => {
+      fakeLocalStorageService.setUserPagePayment.calls.reset();
+      fakeLocalStorageService.setUbsPaymentOrderId.calls.reset();
+      fakeUBSOrderFormService.setOrderStatus.calls.reset();
+      fakeUBSOrderFormService.setOrderResponseErrorStatus.calls.reset();
+    });
 
-    expect(fakeLocalStorageService.setUserPagePayment).toHaveBeenCalledWith(true);
-    expect(fakeUBSOrderFormService.setOrderStatus).toHaveBeenCalledWith(true);
-    expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).toHaveBeenCalledWith(false);
-    expect(fakeLocalStorageService.setUbsPaymentOrderId).toHaveBeenCalledWith('1');
-  });
+    it('should handle paid status correctly', () => {
+      (activatedRoute as any).queryParams = of({ status: 'paid', orderId: '1' });
 
-  it('should handle unpaid/other status correctly', () => {
-    (activatedRoute as any).queryParams = of({ status: 'unpaid', orderId: '1' });
+      component.ngOnInit();
 
-    component.ngOnInit();
+      expect(fakeLocalStorageService.setUserPagePayment).toHaveBeenCalledWith(true);
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).toHaveBeenCalledWith('1');
 
-    expect(fakeLocalStorageService.setUserPagePayment).toHaveBeenCalledWith(false);
-    expect(fakeUBSOrderFormService.setOrderStatus).toHaveBeenCalledWith(false);
-    expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).toHaveBeenCalledWith(true);
-    expect(fakeLocalStorageService.setUbsPaymentOrderId).toHaveBeenCalledWith('1');
-  });
+      expect(fakeUBSOrderFormService.setOrderStatus).toHaveBeenCalled();
+      expect(fakeUBSOrderFormService.setOrderStatus).toHaveBeenCalledWith(true);
+      expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).toHaveBeenCalled();
+      expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).toHaveBeenCalledWith(false);
+    });
 
-  it('should not call anything if status is missing', () => {
-    fakeLocalStorageService.setUserPagePayment.calls.reset();
-    fakeLocalStorageService.setUbsPaymentOrderId.calls.reset();
-    fakeUBSOrderFormService.setOrderStatus.calls.reset();
-    fakeUBSOrderFormService.setOrderResponseErrorStatus.calls.reset();
-    (activatedRoute as any).queryParams = of({ status: undefined, orderId: undefined });
+    it('should handle unpaid/other status correctly', () => {
+      (activatedRoute as any).queryParams = of({ status: 'unpaid', orderId: '1' });
 
-    component.ngOnInit();
+      component.ngOnInit();
 
-    expect(fakeLocalStorageService.setUserPagePayment).not.toHaveBeenCalled();
-    expect(fakeUBSOrderFormService.setOrderStatus).not.toHaveBeenCalled();
-    expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).not.toHaveBeenCalled();
-    expect(fakeLocalStorageService.setUbsPaymentOrderId).not.toHaveBeenCalled();
+      expect(fakeLocalStorageService.setUserPagePayment).toHaveBeenCalledWith(false);
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).toHaveBeenCalledWith('1');
+
+      expect(fakeUBSOrderFormService.setOrderStatus).toHaveBeenCalled();
+      expect(fakeUBSOrderFormService.setOrderStatus).toHaveBeenCalledWith(false);
+      expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).toHaveBeenCalledWith(true);
+      expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).toHaveBeenCalled();
+    });
+
+    it('should not call anything if status is missing', () => {
+      (activatedRoute as any).queryParams = of({ status: undefined, orderId: undefined });
+
+      component.ngOnInit();
+
+      expect(fakeLocalStorageService.setUserPagePayment).not.toHaveBeenCalled();
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).not.toHaveBeenCalled();
+
+      expect(fakeUBSOrderFormService.setOrderStatus).not.toHaveBeenCalled();
+      expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).not.toHaveBeenCalled();
+    });
+    it('should not call anything if status is empty string', () => {
+      (activatedRoute as any).queryParams = of({ status: '', orderId: 1 });
+
+      component.ngOnInit();
+
+      expect(fakeLocalStorageService.setUserPagePayment).not.toHaveBeenCalled();
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).not.toHaveBeenCalled();
+
+      expect(fakeUBSOrderFormService.setOrderStatus).not.toHaveBeenCalled();
+      expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).not.toHaveBeenCalled();
+    });
+    it('should not call anything if status is null', () => {
+      (activatedRoute as any).queryParams = of({ status: null, orderId: 1 });
+
+      component.ngOnInit();
+
+      expect(fakeLocalStorageService.setUserPagePayment).not.toHaveBeenCalled();
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).not.toHaveBeenCalled();
+
+      expect(fakeUBSOrderFormService.setOrderStatus).not.toHaveBeenCalled();
+      expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
@@ -215,5 +215,37 @@ describe('UbsConfirmPageComponent', () => {
       expect(fakeUBSOrderFormService.setOrderStatus).not.toHaveBeenCalled();
       expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).not.toHaveBeenCalled();
     });
+    it('should handle mixed-case status correctly', () => {
+      (activatedRoute as any).queryParams = of({ status: 'PaId', orderId: '2' });
+
+      component.ngOnInit();
+
+      expect(fakeLocalStorageService.setUserPagePayment).toHaveBeenCalledWith(true);
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).toHaveBeenCalledWith('2');
+      expect(fakeUBSOrderFormService.setOrderStatus).toHaveBeenCalledWith(true);
+      expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).toHaveBeenCalledWith(false);
+    });
+
+    it('should set payment status but not orderId if orderId is missing', () => {
+      (activatedRoute as any).queryParams = of({ status: 'paid' });
+
+      component.ngOnInit();
+
+      expect(fakeLocalStorageService.setUserPagePayment).toHaveBeenCalledWith(true);
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).not.toHaveBeenCalled();
+      expect(fakeUBSOrderFormService.setOrderStatus).toHaveBeenCalledWith(true);
+      expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).toHaveBeenCalledWith(false);
+    });
+
+    it('should not call anything if status is missing', () => {
+      (activatedRoute as any).queryParams = of({ status: undefined, orderId: undefined });
+
+      component.ngOnInit();
+
+      expect(fakeLocalStorageService.setUserPagePayment).not.toHaveBeenCalled();
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).not.toHaveBeenCalled();
+      expect(fakeUBSOrderFormService.setOrderStatus).not.toHaveBeenCalled();
+      expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
@@ -247,5 +247,41 @@ describe('UbsConfirmPageComponent', () => {
       expect(fakeUBSOrderFormService.setOrderStatus).not.toHaveBeenCalled();
       expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).not.toHaveBeenCalled();
     });
+    it('should set orderId when status is truthy and orderId exists', () => {
+      (activatedRoute as any).queryParams = of({ status: 'paid', orderId: '123' });
+
+      component.ngOnInit();
+
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).toHaveBeenCalledWith('123');
+    });
+    it('should not set orderId when orderId empty string', () => {
+      (activatedRoute as any).queryParams = of({ status: 'unpaid', orderId: '' });
+
+      component.ngOnInit();
+
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).not.toHaveBeenCalled();
+    });
+    it('should not set orderId when no orderId', () => {
+      (activatedRoute as any).queryParams = of({ status: 'unpaid' });
+
+      component.ngOnInit();
+
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).not.toHaveBeenCalled();
+    });
+    it('should not set orderId when status is not set', () => {
+      (activatedRoute as any).queryParams = of({ orderId: 1 });
+
+      component.ngOnInit();
+
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).not.toHaveBeenCalled();
+    });
+    it('should not set orderId when status is set as string', () => {
+      (activatedRoute as any).queryParams = of({ status: 'unpaid', orderId: '1' });
+
+      component.ngOnInit();
+
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).toHaveBeenCalled();
+      expect(fakeLocalStorageService.setUbsPaymentOrderId).toHaveBeenCalledWith('1');
+    });
   });
 });

--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.spec.ts
@@ -1,6 +1,6 @@
 import { of } from 'rxjs';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { Router, NavigationEnd } from '@angular/router';
+import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { JwtService } from 'src/app/shared/services/jwt/jwt.service';
@@ -17,8 +17,14 @@ describe('UbsConfirmPageComponent', () => {
   let component: UbsConfirmPageComponent;
   let fixture: ComponentFixture<UbsConfirmPageComponent>;
   let router: Router;
+  let activatedRoute: ActivatedRoute;
   const fakeSnackBar = jasmine.createSpyObj('fakeSnackBar', ['openSnackBar']);
-  const fakeUBSOrderFormService = jasmine.createSpyObj('fakeUBSService', ['getOrderResponseErrorStatus', 'getOrderStatus']);
+  const fakeUBSOrderFormService = jasmine.createSpyObj('fakeUBSService', [
+    'getOrderResponseErrorStatus',
+    'getOrderStatus',
+    'setOrderStatus',
+    'setOrderResponseErrorStatus'
+  ]);
   const fakeLocalStorageService = jasmine.createSpyObj('localStorageService', [
     'getFinalSumOfOrder',
     'clearPaymentInfo',
@@ -30,10 +36,11 @@ describe('UbsConfirmPageComponent', () => {
     'getExistingOrderId',
     'removeUBSExistingOrderId',
     'getUserId',
-    'getUserPagePayment'
+    'getUserPagePayment',
+    'setUserPagePayment',
+    'setUbsPaymentOrderId'
   ]);
   const fakeJwtService = jasmine.createSpyObj('fakeJwtService', ['']);
-
   const storeMock = jasmine.createSpyObj('Store', ['select', 'dispatch']);
   storeMock.select.and.returnValue(of({ order: ubsOrderServiseMock }));
 
@@ -56,6 +63,7 @@ describe('UbsConfirmPageComponent', () => {
     fixture = TestBed.createComponent(UbsConfirmPageComponent);
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
+    activatedRoute = TestBed.inject(ActivatedRoute);
     fakeUBSOrderFormService.orderId = of('123');
     fakeJwtService.userRole$ = of('ROLE_UBS_EMPLOYEE');
     fixture.detectChanges();
@@ -136,5 +144,41 @@ describe('UbsConfirmPageComponent', () => {
     component.toPersonalAccount();
     expect(saveDataOnLocalStorageMock).toHaveBeenCalled();
     expect(navigateSpy).toHaveBeenCalledWith(['ubs/user', 'orders']);
+  });
+  it('should handle paid status correctly', () => {
+    (activatedRoute as any).queryParams = of({ status: 'paid', orderId: '1' });
+
+    component.ngOnInit();
+
+    expect(fakeLocalStorageService.setUserPagePayment).toHaveBeenCalledWith(true);
+    expect(fakeUBSOrderFormService.setOrderStatus).toHaveBeenCalledWith(true);
+    expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).toHaveBeenCalledWith(false);
+    expect(fakeLocalStorageService.setUbsPaymentOrderId).toHaveBeenCalledWith('1');
+  });
+
+  it('should handle unpaid/other status correctly', () => {
+    (activatedRoute as any).queryParams = of({ status: 'unpaid', orderId: '1' });
+
+    component.ngOnInit();
+
+    expect(fakeLocalStorageService.setUserPagePayment).toHaveBeenCalledWith(false);
+    expect(fakeUBSOrderFormService.setOrderStatus).toHaveBeenCalledWith(false);
+    expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).toHaveBeenCalledWith(true);
+    expect(fakeLocalStorageService.setUbsPaymentOrderId).toHaveBeenCalledWith('1');
+  });
+
+  it('should not call anything if status is missing', () => {
+    fakeLocalStorageService.setUserPagePayment.calls.reset();
+    fakeLocalStorageService.setUbsPaymentOrderId.calls.reset();
+    fakeUBSOrderFormService.setOrderStatus.calls.reset();
+    fakeUBSOrderFormService.setOrderResponseErrorStatus.calls.reset();
+    (activatedRoute as any).queryParams = of({ status: undefined, orderId: undefined });
+
+    component.ngOnInit();
+
+    expect(fakeLocalStorageService.setUserPagePayment).not.toHaveBeenCalled();
+    expect(fakeUBSOrderFormService.setOrderStatus).not.toHaveBeenCalled();
+    expect(fakeUBSOrderFormService.setOrderResponseErrorStatus).not.toHaveBeenCalled();
+    expect(fakeLocalStorageService.setUbsPaymentOrderId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
@@ -47,6 +47,10 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
     this.activatedRoute.queryParams.pipe(take(1)).subscribe((qp) => {
       const status = (qp['status'] || '').toLowerCase();
       if (status) {
+        const orderId = qp['orderId']?.trim() ?? '';
+        if (orderId.length > 0) {
+          this.localStorageService.setUbsPaymentOrderId(orderId);
+        }
         const isPaid = status === 'paid';
         if (isPaid) {
           this.localStorageService.setUserPagePayment(true);
@@ -56,9 +60,6 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
           this.localStorageService.setUserPagePayment(false);
           this.ubsOrderFormService.setOrderStatus(false);
           this.ubsOrderFormService.setOrderResponseErrorStatus(true);
-        }
-        if (qp['orderId']) {
-          this.localStorageService.setUbsPaymentOrderId(qp['orderId']);
         }
       }
     });

--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
@@ -4,7 +4,7 @@ import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
 import { JwtService } from 'src/app/shared/services/jwt/jwt.service';
 import { LocalStorageService } from 'src/app/shared/services/localstorage/local-storage.service';
 import { Subject, Subscription } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { take, takeUntil } from 'rxjs/operators';
 import { OrderService } from '../../services/order.service';
 import { UBSOrderFormService } from '../../services/ubs-order-form.service';
 import { MatSnackBarService } from '@global-service/mat-snack-bar/mat-snack-bar.service';
@@ -44,9 +44,11 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.activatedRoute.queryParams.subscribe((qp) => {
-      if (qp['status']) {
-        if (qp['status'] === 'paid') {
+    this.activatedRoute.queryParams.pipe(take(1)).subscribe((qp) => {
+      const status = (qp['status'] || '').toLowerCase();
+      if (status) {
+        const isPaid = status === 'paid';
+        if (isPaid) {
           this.localStorageService.setUserPagePayment(true);
           this.ubsOrderFormService.setOrderStatus(true);
           this.ubsOrderFormService.setOrderResponseErrorStatus(false);
@@ -55,7 +57,9 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
           this.ubsOrderFormService.setOrderStatus(false);
           this.ubsOrderFormService.setOrderResponseErrorStatus(true);
         }
-        this.localStorageService.setUbsPaymentOrderId(qp['orderId']);
+        if (qp['orderId']) {
+          this.localStorageService.setUbsPaymentOrderId(qp['orderId']);
+        }
       }
     });
 

--- a/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
+++ b/src/app/ubs/ubs/components/ubs-confirm-page/ubs-confirm-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Router, NavigationEnd } from '@angular/router';
+import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
 
 import { JwtService } from 'src/app/shared/services/jwt/jwt.service';
 import { LocalStorageService } from 'src/app/shared/services/localstorage/local-storage.service';
@@ -30,7 +30,8 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
     private readonly shareFormService: UBSOrderFormService,
     public readonly localStorageService: LocalStorageService,
     private readonly orderService: OrderService,
-    public readonly router: Router
+    public readonly router: Router,
+    public readonly activatedRoute: ActivatedRoute
   ) {}
 
   toPersonalAccount(): void {
@@ -43,6 +44,21 @@ export class UbsConfirmPageComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.activatedRoute.queryParams.subscribe((qp) => {
+      if (qp['status']) {
+        if (qp['status'] === 'paid') {
+          this.localStorageService.setUserPagePayment(true);
+          this.ubsOrderFormService.setOrderStatus(true);
+          this.ubsOrderFormService.setOrderResponseErrorStatus(false);
+        } else {
+          this.localStorageService.setUserPagePayment(false);
+          this.ubsOrderFormService.setOrderStatus(false);
+          this.ubsOrderFormService.setOrderResponseErrorStatus(true);
+        }
+        this.localStorageService.setUbsPaymentOrderId(qp['orderId']);
+      }
+    });
+
     const orderIdWithoutPayment = this.localStorageService.getUbsPaymentOrderId();
     this.ubsOrderFormService.orderId.pipe(takeUntil(this.destroy$)).subscribe((oderID) => {
       if (!oderID && this.localStorageService.getUbsBonusesOrderId()) {


### PR DESCRIPTION
[#9029](https://github.com/ita-social-projects/GreenCity/issues/9029)

Added correct confirmation pages for paid and unpaid order cases.
For paid, it shows "Your order was successfully paid" with the order ID.
For unpaid ones, it shows "Opps... Your order wasn't paid" with the order ID.

<img width="774" height="472" alt="image" src="https://github.com/user-attachments/assets/fd97605d-caca-437f-b5bd-30b337d64458" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confirmation page reads payment status and orderId from return-link query parameters on load, updates the UI for paid vs. unpaid/other, stores order ID when present, and treats status case-insensitively (e.g., "PaId" recognized as paid). Missing/empty status leaves state unchanged; missing orderId still applies the payment flag but does not store an ID.

* **Tests**
  * Added unit tests covering paid, unpaid/other, mixed-case, empty, null, missing status scenarios and cases with/without orderId.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->