### PR TITLE
fix: employees table now adjusts to window resizing #8845

### DIFF
--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.html
@@ -59,6 +59,7 @@
             <div class="text">
               <span class="name">{{ employee.firstName }} {{ employee.lastName }}</span>
               <div class="positions">
+                <span class="mobile-label">{{ 'employees.position' | translate }}</span>
                 <ng-container *ngFor="let position of employee.employeePositions; let i = index">
                   <ng-container *ngIf="!employee.expanded; else allPositions">
                     <span class="link" *ngIf="employee.employeePositions.length > 2 && i <= 2">
@@ -80,6 +81,7 @@
             </div>
 
             <div class="description-item contacts" [class.expanded]="employee.expanded">
+              <span class="mobile-label">{{ 'employees.contacts' | translate }}</span>
               <div class="description-sub-item phone">
                 <img [src]="icons.phone" alt="phone" />&nbsp;
                 <span class="description-item-text">{{ employee.phoneNumber }}</span>
@@ -91,6 +93,7 @@
             </div>
 
             <div class="description-item receiving-station">
+              <span class="mobile-label">{{ 'employees.region' | translate }}</span>
               <div class="description-sub-item description-item-text" *ngFor="let tariff of employee.tariffs; let i = index">
                 <div [appLangValue]="{ uk: tariff.region.nameUk, en: tariff.region.nameEn }"></div>
                 <div
@@ -101,6 +104,7 @@
               </div>
             </div>
             <div class="description-item">
+              <span class="mobile-label">{{ 'employees.city' | translate }}</span>
               <div class="description-sub-item description-item-text" *ngFor="let tariff of employee.tariffs; let i = index">
                 <div *ngIf="!tariff.locations.additional.length; else moreThanThreeLocations" class="locations-list">
                   <div
@@ -130,6 +134,7 @@
             </div>
 
             <div class="description-item">
+              <span class="mobile-label">{{ 'employees.courier' | translate }}</span>
               <div class="description-sub-item description-item-text" *ngFor="let tariff of employee.tariffs; let i = index">
                 <div [appLangValue]="{ uk: tariff.courier.nameUk, en: tariff.courier.nameEn }"></div>
                 <div *ngFor="let placeholder of tariff.locations.displayed.length - 1 | repeat" class="region-placeholder"></div>
@@ -137,6 +142,7 @@
             </div>
 
             <div class="description-item">
+              <span class="mobile-label">{{ 'employees.state' | translate }}</span>
               <div class="description-sub-item description-item-text">
                 <div>
                   {{ (employee.employeeStatus === 'ACTIVE' ? 'employees.status.active' : 'employees.status.inactive') | translate }}

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/ubs-admin-employee-table.component.scss
@@ -136,6 +136,10 @@
   height: 24px;
   border-bottom: 1px solid var(--ubs-primary-light-grey);
 
+  @media screen and (max-width: 820px) {
+    display: none;
+  }
+
   .head-item {
     display: flex;
     align-items: center;
@@ -319,6 +323,57 @@
             line-height: 20px;
             letter-spacing: 0.1px;
             margin-bottom: 4px;
+          }
+        }
+
+        .contacts {
+          max-width: 100%;
+          overflow: hidden;
+          min-width: 0;
+
+          @media screen and (max-width: 820px) {
+            align-items: center;
+          }
+
+          .description-sub-item {
+            max-width: 100%;
+            display: flex;
+            align-items: center;
+            white-space: nowrap;
+            overflow: hidden;
+
+            img {
+              flex-shrink: 0;
+            }
+
+            .link,
+            .description-item-text {
+              overflow: hidden;
+              text-overflow: ellipsis;
+              min-width: 0;
+            }
+          }
+        }
+
+        .mobile-label {
+          display: none;
+          font-weight: 700;
+          font-size: 14px;
+          line-height: 20px;
+          letter-spacing: 0.1px;
+          color: var(--ubs-secondary-grey);
+          margin-top: 8px;
+        }
+
+        @media screen and (max-width: 820px) {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+          gap: 10px;
+
+          .mobile-label {
+            display: block;
           }
         }
       }

--- a/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee.component.scss
@@ -132,11 +132,25 @@
     min-height: 120px;
     align-items: center;
     justify-content: center;
+
+    @media screen and (max-width: 820px) {
+      padding: 0 10px;
+    }
   }
 
   .d-flex {
     margin-bottom: 18px;
     margin-top: 24px;
+
+    @media screen and (max-width: 820px) {
+      flex-direction: column;
+
+      .col-item {
+        width: 100%;
+        margin-bottom: 16px;
+        margin-right: 0;
+      }
+    }
   }
 
   .col-text {


### PR DESCRIPTION
## Changes:
- Employees table now has vertical view for narrower screen sizes
- Added labels to employee's card fields to differentiate them from one another

Fixes #8845

<img width="444" height="945" alt="image" src="https://github.com/user-attachments/assets/693d17a2-ce02-4c7e-8006-c8439342f4ff" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added mobile-friendly field labels in the employee table for position, contacts, region, city, courier, and status.

- Style
  - Introduced responsive styling for screens ≤820px: hides table header, shows mobile labels, and reorganizes content vertically for better readability.
  - Adjusted layouts to stack columns, center content, and add spacing on small screens.
  - Improved contacts display with constrained width, overflow handling, ellipsis for long text, and optimized image sizing.
  - Tweaked padding in filter/showing blocks for better mobile fit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->