### PR TITLE
Bugfix/9092-amount-of-bonuses-displays-with-2-digits-after-point

### DIFF
--- a/src/app/ubs/ubs-user/components/ubs-user-order-details/ubs-user-order-details.component.html
+++ b/src/app/ubs/ubs-user/components/ubs-user-order-details/ubs-user-order-details.component.html
@@ -32,7 +32,7 @@
       <td colspan="4">{{ 'user-orders.details.bonuses' | translate }}</td>
       <td>-{{ order.bonuses | localizedCurrency: true }}</td>
     </tr>
-    <tr *ngIf="isPaid(order) || order.paidAmount > 0" class="optional_row">
+    <tr *ngIf="order.paidAmount > 0" class="optional_row">
       <td colspan="4">{{ 'user-orders.details.paid-amount' | translate }}</td>
       <td>-{{ order.paidAmount | localizedCurrency: true }}</td>
     </tr>

--- a/src/app/ubs/ubs-user/components/ubs-user-order-details/ubs-user-order-details.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-order-details/ubs-user-order-details.component.spec.ts
@@ -41,18 +41,4 @@ describe('UbsUserOrderDetailsComponent', () => {
     component.ngOnInit();
     expect(component.certificatesAmount).toBe(510);
   });
-
-  describe('isOrderPaid', () => {
-    it('order  is paid', () => {
-      fakeInputOrderData.paymentStatusEn = 'Paid';
-      const isOrderPaidRes = component.isPaid(fakeInputOrderData as IUserOrderInfo);
-      expect(isOrderPaidRes).toBeTruthy();
-    });
-
-    it('order is not unpaid', () => {
-      fakeInputOrderData.paymentStatusEn = 'Unpaid';
-      const isOrderPaidRes = component.isPaid(fakeInputOrderData as IUserOrderInfo);
-      expect(isOrderPaidRes).toBeFalsy();
-    });
-  });
 });

--- a/src/app/ubs/ubs-user/components/ubs-user-order-details/ubs-user-order-details.component.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-order-details/ubs-user-order-details.component.ts
@@ -14,8 +14,4 @@ export class UbsUserOrderDetailsComponent implements OnInit {
   ngOnInit(): void {
     this.certificatesAmount = this.order.certificate.reduce((acc, item) => acc + item.points, 0);
   }
-
-  isPaid(order: IUserOrderInfo): boolean {
-    return order.paymentStatusEn === PaymentStatusEn.PAID;
-  }
 }

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.html
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-certificate/ubs-order-certificate.component.html
@@ -73,7 +73,7 @@
 
   <div class="points">
     <h5>{{ 'order-details.bonus-need' | translate }}</h5>
-    <p>{{ 'order-details.bonus-left' | translate }} {{ points | localizedCurrency }}</p>
+    <p>{{ 'order-details.bonus-left' | translate }} {{ points | localizedCurrency: true }}</p>
     <div class="radio-btn" *ngIf="points !== 0 && orderSum - certificateSum > 0" appSpacePrevent>
       <label class="custom-radio-btn">
         {{ 'order-details.no' | translate }}
@@ -88,10 +88,10 @@
     </div>
     <div class="points-balance">
       <small class="text-message" [class.d-none]="pointsUsed === 0">
-        <span>{{ 'order-details.used' | translate }} {{ pointsUsed | localizedCurrency }}</span>
+        <span>{{ 'order-details.used' | translate }} {{ pointsUsed | localizedCurrency: true }}</span>
       </small>
       <small class="text-message" [class.d-none]="pointsUsed === 0">
-        <span>{{ 'order-details.balance' | translate }} {{ points - pointsUsed | localizedCurrency }}</span>
+        <span>{{ 'order-details.balance' | translate }} {{ points - pointsUsed | localizedCurrency: true }}</span>
       </small>
     </div>
   </div>

--- a/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.html
+++ b/src/app/ubs/ubs/components/ubs-order-details/ubs-order-details.component.html
@@ -72,13 +72,13 @@
               <p class="total-content" *ngIf="certificateUsed">
                 <span>{{ 'order-details.certificate' | translate }} </span>
                 <span>
-                  <strong class="money-saved">-{{ certificateUsed | localizedCurrency }}</strong>
+                  <strong class="money-saved">-{{ certificateUsed | localizedCurrency: true }}</strong>
                 </span>
               </p>
               <p class="total-content" *ngIf="pointsUsed">
                 <span>{{ 'order-details.bonuses' | translate }}</span>
                 <span>
-                  <strong class="money-saved">-{{ pointsUsed | localizedCurrency }}</strong>
+                  <strong class="money-saved">-{{ pointsUsed | localizedCurrency: true }}</strong>
                 </span>
               </p>
               <p class="total-content">


### PR DESCRIPTION
[#9095](https://github.com/ita-social-projects/GreenCity/issues/9095)
[#9092](https://github.com/ita-social-projects/GreenCity/issues/9092)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Paid amount row now appears only when the amount is greater than zero, preventing misleading displays.

* UI/Formatting
  * Updated currency formatting for certificates and bonus points to ensure consistent display across values (including used and remaining balances).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->