### PR TITLE
Bugfix/7852 no event filtering by date

### DIFF
--- a/src/app/greencity/modules/events/components/events-list/events-list.component.html
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.html
@@ -29,10 +29,15 @@
     <div class="filter-container">
       <p class="filter-by">{{ 'homepage.events.filter-title' | translate }}</p>
       <div class="filter-list">
-        <div class="dropdown" (click)="timeFilter.open()">
+        <div class="dropdown" (click)="timeFilter.open()" (keydown.enter)="timeFilter.open()">
           <mat-label class="filter">{{ 'homepage.events.time' | translate }}</mat-label>
           <mat-select #timeFilter [formControl]="eventTimeStatusFilterControl" [multiple]="true">
-            <mat-option [value]="'homepage.events.time-any-time' | translate" (click)="toggleAllOptions('eventTimeStatus', timeFilter)">
+            <mat-select-trigger></mat-select-trigger>
+            <mat-option
+              [value]="'homepage.events.time-any-time' | translate"
+              (click)="toggleAllOptions('eventTimeStatus', timeFilter)"
+              (keydown.enter)="toggleAllOptions('eventTimeStatus', timeFilter)"
+            >
               {{ 'homepage.events.time-any-time' | translate }}
             </mat-option>
             <mat-divider></mat-divider>
@@ -40,17 +45,20 @@
               [value]="eventTimeStatusFilter.nameEn"
               *ngFor="let eventTimeStatusFilter of eventTimeStatusFiltersList"
               (click)="updateListOfFilters(eventTimeStatusFilter)"
+              (keydown.enter)="updateListOfFilters(eventTimeStatusFilter)"
               ><span [appLangValue]="{ uk: eventTimeStatusFilter.nameUk, en: eventTimeStatusFilter.nameEn }"></span>
             </mat-option>
           </mat-select>
         </div>
 
-        <div class="dropdown" (click)="locationFilter.open()">
+        <div class="dropdown" (click)="locationFilter.open()" (keydown.enter)="locationFilter.open()">
           <mat-label class="filter">{{ 'homepage.events.filter-location' | translate }}</mat-label>
           <mat-select #locationFilter [formControl]="locationFilterControl" [multiple]="true">
+            <mat-select-trigger></mat-select-trigger>
             <mat-option
               [value]="'homepage.events.filter-location-аny-location' | translate"
               (click)="toggleAllOptions('location', locationFilter)"
+              (keydown.enter)="toggleAllOptions('location', locationFilter)"
             >
               {{ 'homepage.events.filter-location-аny-location' | translate }}
             </mat-option>
@@ -59,11 +67,12 @@
               [value]="locationFilter.nameEn"
               *ngFor="let locationFilter of relevantLocationFiltersList"
               (click)="updateListOfFilters(locationFilter)"
+              (keydown.enter)="updateListOfFilters(locationFilter)"
             >
               <span [appLangValue]="{ uk: locationFilter.nameUk, en: locationFilter.nameEn }"></span>
             </mat-option>
             <mat-divider></mat-divider>
-            <div (click)="openCityModal()" class="add-location-option" *ngIf="!showAddCityInput">
+            <div *ngIf="!showAddCityInput" (click)="openCityModal()" (keydown.enter)="openCityModal()" class="add-location-option">
               <div class="add-location-content">
                 <span>{{ 'add-cities-modal.dropdown' | translate }}</span>
               </div>
@@ -105,10 +114,15 @@
           </div>
         </ng-template>
 
-        <div class="dropdown" (click)="statusFilter.open()">
+        <div class="dropdown" (click)="statusFilter.open()" (keydown.enter)="statusFilter.open()">
           <mat-label class="filter">{{ 'homepage.events.filter-status' | translate }}</mat-label>
           <mat-select #statusFilter [formControl]="statusFilterControl" [multiple]="true">
-            <mat-option [value]="'homepage.events.filter-status-аny-status' | translate" (click)="toggleAllOptions('status', statusFilter)">
+            <mat-select-trigger></mat-select-trigger>
+            <mat-option
+              [value]="'homepage.events.filter-status-аny-status' | translate"
+              (click)="toggleAllOptions('status', statusFilter)"
+              (keydown.enter)="toggleAllOptions('status', statusFilter)"
+            >
               {{ 'homepage.events.filter-status-аny-status' | translate }}
             </mat-option>
             <mat-divider></mat-divider>
@@ -116,23 +130,57 @@
               [value]="statusFilter.nameEn"
               *ngFor="let statusFilter of statusFiltersList"
               (click)="updateListOfFilters(statusFilter)"
-              ><span [appLangValue]="{ uk: statusFilter.nameUk, en: statusFilter.nameEn }"></span>
+              (keydown.enter)="updateListOfFilters(statusFilter)"
+            >
+              <span [appLangValue]="{ uk: statusFilter.nameUk, en: statusFilter.nameEn }"></span>
             </mat-option>
           </mat-select>
         </div>
 
-        <div class="dropdown" (click)="typeFilter.open()">
+        <div class="dropdown" (click)="typeFilter.open()" (keydown.enter)="typeFilter.open()">
           <mat-label class="filter">{{ 'homepage.events.filter-type' | translate }}</mat-label>
           <mat-select #typeFilter [formControl]="typeFilterControl" [multiple]="true">
-            <mat-option [value]="'homepage.events.filter-аny-type' | translate" (click)="toggleAllOptions('type', typeFilter)">
+            <mat-select-trigger></mat-select-trigger>
+            <mat-option
+              [value]="'homepage.events.filter-аny-type' | translate"
+              (click)="toggleAllOptions('type', typeFilter)"
+              (keydown.enter)="toggleAllOptions('type', typeFilter)"
+            >
               {{ 'homepage.events.filter-аny-type' | translate }}
             </mat-option>
             <mat-divider></mat-divider>
-            <mat-option [value]="typeFilter.nameEn" *ngFor="let typeFilter of typeFiltersList" (click)="updateListOfFilters(typeFilter)">
+            <mat-option
+              [value]="typeFilter.nameEn"
+              *ngFor="let typeFilter of typeFiltersList"
+              (click)="updateListOfFilters(typeFilter)"
+              (keydown.enter)="updateListOfFilters(typeFilter)"
+            >
               <span [appLangValue]="{ uk: typeFilter.nameUk, en: typeFilter.nameEn }"></span>
             </mat-option>
           </mat-select>
         </div>
+
+        <div class="dropdown" (click)="dateRangePicker.open()" (keydown.enter)="dateRangePicker.open()">
+          <mat-label class="filter">{{ 'homepage.events.date' | translate }}</mat-label>
+          <mat-date-range-input
+            class="date-range-input"
+            (closedStream)="updateListOfFilters(dateRangeFilter)"
+            [formGroup]="dateRangeFilterForm"
+            [rangePicker]="dateRangePicker"
+          >
+            <input matStartDate formControlName="from" placeholder="{{ 'homepage.events.date-start' | translate }}" />
+            <input matEndDate formControlName="to" placeholder="{{ 'homepage.events.date-end' | translate }}" />
+          </mat-date-range-input>
+          <div class="mat-mdc-select-arrow-wrapper">
+            <div class="mat-mdc-select-arrow">
+              <svg viewBox="0 0 24 24" width="24px" height="24px" focusable="false" aria-hidden="true">
+                <path d="M7 10l5 5 5-5z"></path>
+              </svg>
+            </div>
+          </div>
+          <mat-date-range-picker class="custom-calendar" #dateRangePicker></mat-date-range-picker>
+        </div>
+
         <div>
           <button class="reset" [disabled]="selectedFilters.length === 0" (click)="resetAllFilters()">
             {{ 'homepage.events.filter-reset-all' | translate }}

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.html
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.html
@@ -35,8 +35,7 @@
             <mat-select-trigger></mat-select-trigger>
             <mat-option
               [value]="'homepage.events.time-any-time' | translate"
-              (click)="toggleAllOptions('eventTimeStatus', timeFilter)"
-              (keydown.enter)="toggleAllOptions('eventTimeStatus', timeFilter)"
+              (onSelectionChange)="toggleAllOptions('eventTimeStatus', timeFilter, $event)"
             >
               {{ 'homepage.events.time-any-time' | translate }}
             </mat-option>
@@ -44,8 +43,7 @@
             <mat-option
               [value]="eventTimeStatusFilter.nameEn"
               *ngFor="let eventTimeStatusFilter of eventTimeStatusFiltersList"
-              (click)="updateListOfFilters(eventTimeStatusFilter)"
-              (keydown.enter)="updateListOfFilters(eventTimeStatusFilter)"
+              (onSelectionChange)="updateListOfFilters(eventTimeStatusFilter, $event)"
               ><span [appLangValue]="{ uk: eventTimeStatusFilter.nameUk, en: eventTimeStatusFilter.nameEn }"></span>
             </mat-option>
           </mat-select>
@@ -57,8 +55,7 @@
             <mat-select-trigger></mat-select-trigger>
             <mat-option
               [value]="'homepage.events.filter-location-аny-location' | translate"
-              (click)="toggleAllOptions('location', locationFilter)"
-              (keydown.enter)="toggleAllOptions('location', locationFilter)"
+              (onSelectionChange)="toggleAllOptions('location', locationFilter, $event)"
             >
               {{ 'homepage.events.filter-location-аny-location' | translate }}
             </mat-option>
@@ -66,8 +63,7 @@
             <mat-option
               [value]="locationFilter.nameEn"
               *ngFor="let locationFilter of relevantLocationFiltersList"
-              (click)="updateListOfFilters(locationFilter)"
-              (keydown.enter)="updateListOfFilters(locationFilter)"
+              (onSelectionChange)="updateListOfFilters(locationFilter, $event)"
             >
               <span [appLangValue]="{ uk: locationFilter.nameUk, en: locationFilter.nameEn }"></span>
             </mat-option>
@@ -120,8 +116,7 @@
             <mat-select-trigger></mat-select-trigger>
             <mat-option
               [value]="'homepage.events.filter-status-аny-status' | translate"
-              (click)="toggleAllOptions('status', statusFilter)"
-              (keydown.enter)="toggleAllOptions('status', statusFilter)"
+              (onSelectionChange)="toggleAllOptions('status', statusFilter, $event)"
             >
               {{ 'homepage.events.filter-status-аny-status' | translate }}
             </mat-option>
@@ -129,8 +124,7 @@
             <mat-option
               [value]="statusFilter.nameEn"
               *ngFor="let statusFilter of statusFiltersList"
-              (click)="updateListOfFilters(statusFilter)"
-              (keydown.enter)="updateListOfFilters(statusFilter)"
+              (onSelectionChange)="updateListOfFilters(statusFilter, $event)"
             >
               <span [appLangValue]="{ uk: statusFilter.nameUk, en: statusFilter.nameEn }"></span>
             </mat-option>
@@ -143,8 +137,7 @@
             <mat-select-trigger></mat-select-trigger>
             <mat-option
               [value]="'homepage.events.filter-аny-type' | translate"
-              (click)="toggleAllOptions('type', typeFilter)"
-              (keydown.enter)="toggleAllOptions('type', typeFilter)"
+              (onSelectionChange)="toggleAllOptions('type', typeFilter, $event)"
             >
               {{ 'homepage.events.filter-аny-type' | translate }}
             </mat-option>
@@ -152,8 +145,7 @@
             <mat-option
               [value]="typeFilter.nameEn"
               *ngFor="let typeFilter of typeFiltersList"
-              (click)="updateListOfFilters(typeFilter)"
-              (keydown.enter)="updateListOfFilters(typeFilter)"
+              (onSelectionChange)="updateListOfFilters(typeFilter, $event)"
             >
               <span [appLangValue]="{ uk: typeFilter.nameUk, en: typeFilter.nameEn }"></span>
             </mat-option>

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.html
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.html
@@ -29,9 +29,9 @@
     <div class="filter-container">
       <p class="filter-by">{{ 'homepage.events.filter-title' | translate }}</p>
       <div class="filter-list">
-        <div class="dropdown" (click)="timeFilter.open()" (keydown.enter)="timeFilter.open()">
+        <div class="dropdown" tabindex="0" (click)="timeFilter.open()" (keydown.enter)="timeFilter.open(); timeFilter.focus()">
           <mat-label class="filter">{{ 'homepage.events.time' | translate }}</mat-label>
-          <mat-select #timeFilter [formControl]="eventTimeStatusFilterControl" [multiple]="true">
+          <mat-select tabindex="-1" #timeFilter [formControl]="eventTimeStatusFilterControl" [multiple]="true">
             <mat-select-trigger></mat-select-trigger>
             <mat-option
               [value]="'homepage.events.time-any-time' | translate"
@@ -51,9 +51,9 @@
           </mat-select>
         </div>
 
-        <div class="dropdown" (click)="locationFilter.open()" (keydown.enter)="locationFilter.open()">
+        <div class="dropdown" tabindex="0" (click)="locationFilter.open()" (keydown.enter)="locationFilter.open(); locationFilter.focus()">
           <mat-label class="filter">{{ 'homepage.events.filter-location' | translate }}</mat-label>
-          <mat-select #locationFilter [formControl]="locationFilterControl" [multiple]="true">
+          <mat-select tabindex="-1" #locationFilter [formControl]="locationFilterControl" [multiple]="true">
             <mat-select-trigger></mat-select-trigger>
             <mat-option
               [value]="'homepage.events.filter-location-аny-location' | translate"
@@ -114,9 +114,9 @@
           </div>
         </ng-template>
 
-        <div class="dropdown" (click)="statusFilter.open()" (keydown.enter)="statusFilter.open()">
+        <div class="dropdown" tabindex="0" (click)="statusFilter.open()" (keydown.enter)="statusFilter.open(); statusFilter.focus()">
           <mat-label class="filter">{{ 'homepage.events.filter-status' | translate }}</mat-label>
-          <mat-select #statusFilter [formControl]="statusFilterControl" [multiple]="true">
+          <mat-select tabindex="-1" #statusFilter [formControl]="statusFilterControl" [multiple]="true">
             <mat-select-trigger></mat-select-trigger>
             <mat-option
               [value]="'homepage.events.filter-status-аny-status' | translate"
@@ -137,9 +137,9 @@
           </mat-select>
         </div>
 
-        <div class="dropdown" (click)="typeFilter.open()" (keydown.enter)="typeFilter.open()">
+        <div class="dropdown" tabindex="0" (click)="typeFilter.open()" (keydown.enter)="typeFilter.open(); typeFilter.focus()">
           <mat-label class="filter">{{ 'homepage.events.filter-type' | translate }}</mat-label>
-          <mat-select #typeFilter [formControl]="typeFilterControl" [multiple]="true">
+          <mat-select tabindex="-1" #typeFilter [formControl]="typeFilterControl" [multiple]="true">
             <mat-select-trigger></mat-select-trigger>
             <mat-option
               [value]="'homepage.events.filter-аny-type' | translate"
@@ -160,7 +160,7 @@
           </mat-select>
         </div>
 
-        <div class="dropdown" (click)="dateRangePicker.open()" (keydown.enter)="dateRangePicker.open()">
+        <div class="dropdown" tabindex="0" (click)="dateRangePicker.open()" (keydown.enter)="dateRangePicker.open()">
           <mat-label class="filter">{{ 'homepage.events.date' | translate }}</mat-label>
           <mat-date-range-input
             class="date-range-input"

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.scss
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.scss
@@ -219,7 +219,7 @@
   justify-content: space-between;
   width: min-content;
   -ms-overflow-style: none;
-  
+
   &::-webkit-scrollbar {
     display: none;
   }
@@ -232,6 +232,7 @@
     .mat-mdc-select-arrow svg {
       top: 100%;
     }
+
     .mat-date-range-input {
       visibility: hidden;
     }

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.scss
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.scss
@@ -215,13 +215,26 @@
 
 .filter-list {
   display: flex;
-  align-items: center;
+  align-items: end;
   justify-content: space-between;
   width: min-content;
   -ms-overflow-style: none;
-
+  
   &::-webkit-scrollbar {
     display: none;
+  }
+
+  ::ng-deep {
+    .mat-mdc-select-placeholder {
+      display: none !important;
+    }
+
+    .mat-mdc-select-arrow svg {
+      top: 100%;
+    }
+    .mat-date-range-input {
+      visibility: hidden;
+    }
   }
 
   @include responsivePCFirst(sm) {
@@ -234,12 +247,13 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  padding-right: 10px;
 }
 
 .dropdown {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: end;
   margin-right: 15px;
   white-space: nowrap;
   cursor: pointer;
@@ -283,7 +297,7 @@ p {
 .active-filter-container {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: end;
   margin: 10px 0 32px;
 
   p {
@@ -512,4 +526,18 @@ p {
 
 ::ng-deep .mat-option:first-child .mat-pseudo-checkbox {
   display: none;
+}
+
+.date-range-input {
+  display: hidden;
+  position: absolute;
+  pointer-events: none;
+}
+
+.custom-select-arrow {
+  color: var(--mat-select-enabled-arrow-color);
+}
+
+::ng-deep .mat-mdc-focus-indicator {
+    display: none !important;
 }

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
@@ -16,6 +16,7 @@ import { addressesMock, eventStateMock } from '@assets/mocks/events/mock-events'
 import { EventStoreService } from '../../services/event-store.service';
 import { MatNativeDateModule } from '@angular/material/core';
 import { Language } from 'src/app/shared/i18n/Language';
+import { LanguageService } from 'src/app/shared/i18n/language.service';
 
 describe('EventsListComponent', () => {
   let component: EventsListComponent;
@@ -27,10 +28,6 @@ describe('EventsListComponent', () => {
   const storeMock = jasmine.createSpyObj('store', ['select', 'dispatch']);
   storeMock.select = () => of(eventStateMock);
 
-  const languageServiceMock = jasmine.createSpyObj('languageService', ['getLangValue']);
-  languageServiceMock.getLangValue = (valUa: string, valEn: string) => {
-    return of(valEn);
-  };
   const matDialogService: jasmine.SpyObj<MatDialog> = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
   const eventStoreServiceMock: jasmine.SpyObj<EventStoreService> = jasmine.createSpyObj<EventStoreService>('EventStoreService', [
     'setEditorValues'
@@ -51,7 +48,8 @@ describe('EventsListComponent', () => {
         { provide: UserOwnAuthService, useValue: UserOwnAuthServiceMock },
         { provide: Store, useValue: storeMock },
         { provide: MatDialog, useValue: matDialogService },
-        { provide: EventStoreService, useValue: eventStoreServiceMock }
+        { provide: EventStoreService, useValue: eventStoreServiceMock },
+        { provide: LanguageService, LanguageService }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -98,7 +96,9 @@ describe('EventsListComponent', () => {
     const startDate = new Date('2023-10-10');
     const endDate = new Date('2023-10-20');
     spyOn(component, 'updateListOfFilters').and.callThrough();
-    spyOn((component as any).eventService, 'getEvents').and.returnValue(of({ page: [], totalElements: 0, hasNext: false }));
+    spyOn((component as any).eventService, 'getEvents')
+      .and.returnValue(of({ page: [], totalElements: 0, hasNext: false }))
+      .and.callThrough();
 
     component.dateRangeFilterForm.setValue({ from: startDate, to: endDate });
 
@@ -110,9 +110,7 @@ describe('EventsListComponent', () => {
 
   it('should change dateAdapter locale on language change', () => {
     const dateAdapter = (component as any).dateAdapter;
-    const langSubject = new BehaviorSubject<string>('en');
-    (component as any).languageService.getCurrentLangObs = () => langSubject.asObservable();
-    spyOn(dateAdapter, 'setLocale');
+    spyOn(dateAdapter, 'setLocale').and.callThrough();
 
     (component as any).languageService.changeCurrentLanguage(Language.UK);
 
@@ -121,9 +119,7 @@ describe('EventsListComponent', () => {
 
   it('should set en-US dateAdapter locale if language is undefined', () => {
     const dateAdapter = (component as any).dateAdapter;
-    const langSubject = new BehaviorSubject<string>('en');
-    (component as any).languageService.getCurrentLangObs = () => langSubject.asObservable();
-    spyOn(dateAdapter, 'setLocale');
+    spyOn(dateAdapter, 'setLocale').and.callThrough();
 
     (component as any).languageService.changeCurrentLanguage(undefined);
 

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
@@ -1,10 +1,10 @@
-import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { EventsListComponent } from './events-list.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgxPaginationModule } from 'ngx-pagination';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { UserOwnAuthService } from 'src/app/shared/services/auth/user-own-auth.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Store } from '@ngrx/store';
@@ -29,7 +29,7 @@ describe('EventsListComponent', () => {
 
   const languageServiceMock = jasmine.createSpyObj('languageService', ['getLangValue']);
   languageServiceMock.getLangValue = (valUa: string, valEn: string) => {
-    of(valEn);
+    return of(valEn);
   };
   const matDialogService: jasmine.SpyObj<MatDialog> = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
   const eventStoreServiceMock: jasmine.SpyObj<EventStoreService> = jasmine.createSpyObj<EventStoreService>('EventStoreService', [
@@ -94,48 +94,41 @@ describe('EventsListComponent', () => {
     expect(component.bookmarkSelected).toEqual(true);
   });
 
-  it('should add dateRangeFilter when date range is selected', fakeAsync(() => {
+  it('should add dateRangeFilter when date range is selected', () => {
     const startDate = new Date('2023-10-10');
     const endDate = new Date('2023-10-20');
-
+    spyOn(component, 'updateListOfFilters').and.callThrough();
     spyOn((component as any).eventService, 'getEvents').and.returnValue(of({ page: [], totalElements: 0, hasNext: false }));
 
-    component.ngOnInit();
-    tick();
-
     component.dateRangeFilterForm.setValue({ from: startDate, to: endDate });
-    tick();
 
+    expect(component.updateListOfFilters).toHaveBeenCalled();
     expect((component as any).eventService.getEvents).toHaveBeenCalledWith(
       jasmine.stringMatching(/from=2023-10-10T00:00:00.000Z&to=2023-10-20T00:00:00.000Z/)
     );
-  }));
+  });
 
-  it('should change dateAdapter locale on language change', fakeAsync(() => {
+  it('should change dateAdapter locale on language change', () => {
     const dateAdapter = (component as any).dateAdapter;
+    const langSubject = new BehaviorSubject<string>('en');
+    (component as any).languageService.getCurrentLangObs = () => langSubject.asObservable();
     spyOn(dateAdapter, 'setLocale');
-
-    component.ngOnInit();
-    tick();
 
     (component as any).languageService.changeCurrentLanguage(Language.UK);
-    tick();
 
     expect(dateAdapter.setLocale).toHaveBeenCalledWith('uk-UA');
-  }));
+  });
 
-  it('should set en-US dateAdapter locale if language is undefined', fakeAsync(() => {
+  it('should set en-US dateAdapter locale if language is undefined', () => {
     const dateAdapter = (component as any).dateAdapter;
+    const langSubject = new BehaviorSubject<string>('en');
+    (component as any).languageService.getCurrentLangObs = () => langSubject.asObservable();
     spyOn(dateAdapter, 'setLocale');
 
-    component.ngOnInit();
-    tick();
-
     (component as any).languageService.changeCurrentLanguage(undefined);
-    tick();
 
     expect(dateAdapter.setLocale).toHaveBeenCalledWith('en-US');
-  }));
+  });
 
   it('should return unique locations', () => {
     const expectedLocations: FilterItem[] = [

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
@@ -4,7 +4,7 @@ import { EventsListComponent } from './events-list.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgxPaginationModule } from 'ngx-pagination';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { from, of } from 'rxjs';
+import { of } from 'rxjs';
 import { UserOwnAuthService } from 'src/app/shared/services/auth/user-own-auth.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Store } from '@ngrx/store';
@@ -16,7 +16,6 @@ import { addressesMock, eventStateMock } from '@assets/mocks/events/mock-events'
 import { EventStoreService } from '../../services/event-store.service';
 import { MatNativeDateModule } from '@angular/material/core';
 import { Language } from 'src/app/shared/i18n/Language';
-import { emit } from 'process';
 
 describe('EventsListComponent', () => {
   let component: EventsListComponent;
@@ -98,7 +97,7 @@ describe('EventsListComponent', () => {
   it('should add dateRangeFilter when date range is selected', () => {
     const startDate = new Date('2023-10-10');
     const endDate = new Date('2023-10-20');
-    spyOn((component as any).eventService, 'getEvents');
+    spyOn((component as any).eventService, 'getEvents').and.returnValue(of({ page: [], totalElements: 0, hasNext: false }));
 
     component.dateRangeFilterForm.setValue({ from: startDate, to: endDate });
 

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { EventsListComponent } from './events-list.component';
 import { TranslateModule } from '@ngx-translate/core';
@@ -94,35 +94,48 @@ describe('EventsListComponent', () => {
     expect(component.bookmarkSelected).toEqual(true);
   });
 
-  it('should add dateRangeFilter when date range is selected', () => {
+  it('should add dateRangeFilter when date range is selected', fakeAsync(() => {
     const startDate = new Date('2023-10-10');
     const endDate = new Date('2023-10-20');
+
     spyOn((component as any).eventService, 'getEvents').and.returnValue(of({ page: [], totalElements: 0, hasNext: false }));
 
+    component.ngOnInit();
+    tick();
+
     component.dateRangeFilterForm.setValue({ from: startDate, to: endDate });
+    tick();
 
     expect((component as any).eventService.getEvents).toHaveBeenCalledWith(
       jasmine.stringMatching(/from=2023-10-10T00:00:00.000Z&to=2023-10-20T00:00:00.000Z/)
     );
-  });
+  }));
 
-  it('should change dateAdapter locale on language change', () => {
+  it('should change dateAdapter locale on language change', fakeAsync(() => {
     const dateAdapter = (component as any).dateAdapter;
     spyOn(dateAdapter, 'setLocale');
+
+    component.ngOnInit();
+    tick();
 
     (component as any).languageService.changeCurrentLanguage(Language.UK);
+    tick();
 
     expect(dateAdapter.setLocale).toHaveBeenCalledWith('uk-UA');
-  });
+  }));
 
-  it('should set en-US dateAdapter locale if language is undefined', () => {
+  it('should set en-US dateAdapter locale if language is undefined', fakeAsync(() => {
     const dateAdapter = (component as any).dateAdapter;
     spyOn(dateAdapter, 'setLocale');
 
+    component.ngOnInit();
+    tick();
+
     (component as any).languageService.changeCurrentLanguage(undefined);
+    tick();
 
     expect(dateAdapter.setLocale).toHaveBeenCalledWith('en-US');
-  });
+  }));
 
   it('should return unique locations', () => {
     const expectedLocations: FilterItem[] = [

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
@@ -4,7 +4,7 @@ import { EventsListComponent } from './events-list.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgxPaginationModule } from 'ngx-pagination';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { of } from 'rxjs';
+import { from, of } from 'rxjs';
 import { UserOwnAuthService } from 'src/app/shared/services/auth/user-own-auth.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Store } from '@ngrx/store';
@@ -14,7 +14,9 @@ import { LangValueDirective } from 'src/app/shared/directives/lang-value/lang-va
 import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component';
 import { addressesMock, eventStateMock } from '@assets/mocks/events/mock-events';
 import { EventStoreService } from '../../services/event-store.service';
-import { DateAdapter } from '@angular/material/core';
+import { MatNativeDateModule } from '@angular/material/core';
+import { Language } from 'src/app/shared/i18n/Language';
+import { emit } from 'process';
 
 describe('EventsListComponent', () => {
   let component: EventsListComponent;
@@ -38,13 +40,19 @@ describe('EventsListComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [EventsListComponent, LangValueDirective],
-      imports: [TranslateModule.forRoot(), NgxPaginationModule, HttpClientTestingModule, RouterTestingModule, MatDialogModule],
+      imports: [
+        TranslateModule.forRoot(),
+        NgxPaginationModule,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MatDialogModule,
+        MatNativeDateModule
+      ],
       providers: [
         { provide: UserOwnAuthService, useValue: UserOwnAuthServiceMock },
         { provide: Store, useValue: storeMock },
         { provide: MatDialog, useValue: matDialogService },
-        { provide: EventStoreService, useValue: eventStoreServiceMock },
-        { provide: DateAdapter, useValue: DateAdapter }
+        { provide: EventStoreService, useValue: eventStoreServiceMock }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -87,6 +95,36 @@ describe('EventsListComponent', () => {
     expect(component.bookmarkSelected).toEqual(true);
   });
 
+  it('should add dateRangeFilter when date range is selected', () => {
+    const startDate = new Date('2023-10-10');
+    const endDate = new Date('2023-10-20');
+    spyOn((component as any).eventService, 'getEvents');
+
+    component.dateRangeFilterForm.setValue({ from: startDate, to: endDate });
+
+    expect((component as any).eventService.getEvents).toHaveBeenCalledWith(
+      jasmine.stringMatching(/from=2023-10-10T00:00:00.000Z&to=2023-10-20T00:00:00.000Z/)
+    );
+  });
+
+  it('should change dateAdapter locale on language change', () => {
+    const dateAdapter = (component as any).dateAdapter;
+    spyOn(dateAdapter, 'setLocale');
+
+    (component as any).languageService.changeCurrentLanguage(Language.UK);
+
+    expect(dateAdapter.setLocale).toHaveBeenCalledWith('uk-UA');
+  });
+
+  it('should set en-US dateAdapter locale if language is undefined', () => {
+    const dateAdapter = (component as any).dateAdapter;
+    spyOn(dateAdapter, 'setLocale');
+
+    (component as any).languageService.changeCurrentLanguage(undefined);
+
+    expect(dateAdapter.setLocale).toHaveBeenCalledWith('en-US');
+  });
+
   it('should return unique locations', () => {
     const expectedLocations: FilterItem[] = [
       { type: 'location', nameEn: 'Online', nameUk: 'Онлайн' },
@@ -95,6 +133,26 @@ describe('EventsListComponent', () => {
       { type: 'location', nameEn: 'Ternopil', nameUk: 'Тернопіль' }
     ];
     expect(component.getUniqueLocations(addressesMock)).toEqual(expectedLocations);
+  });
+
+  it('should add selected filter in dateRange case if it is not exist in selectedFilters list', () => {
+    component.selectedFilters = [];
+
+    component.dateRangeFilterForm.setValue({ from: new Date('2023.10.10'), to: new Date('2023.11.10') });
+
+    expect(component.selectedFilters).toEqual([
+      { type: 'dateRange', nameEn: '10/10/2023 - 11/10/2023', nameUk: '10.10.2023 - 10.11.2023' }
+    ]);
+  });
+
+  it('should update selected filter in dateRange case if it exist in selectedFilters list', () => {
+    component.selectedFilters = [{ type: 'dateRange', nameEn: '10/10/2023 - 11/10/2023', nameUk: '10.10.2023 - 10.11.2023' }];
+
+    component.dateRangeFilterForm.setValue({ from: new Date('2023.10.10'), to: new Date('2023.12.10') });
+
+    expect(component.selectedFilters).toEqual([
+      { type: 'dateRange', nameEn: '10/10/2023 - 12/10/2023', nameUk: '10.10.2023 - 10.12.2023' }
+    ]);
   });
 
   it('should update selected filters list', () => {

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
@@ -11,10 +11,10 @@ import { Store } from '@ngrx/store';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { FilterItem } from '../../models/events.interface';
 import { LangValueDirective } from 'src/app/shared/directives/lang-value/lang-value.directive';
-import { MatSelect } from '@angular/material/select';
 import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component';
-import { addressesMock, eventStateMock, testCases } from '@assets/mocks/events/mock-events';
+import { addressesMock, eventStateMock } from '@assets/mocks/events/mock-events';
 import { EventStoreService } from '../../services/event-store.service';
+import { DateAdapter } from '@angular/material/core';
 
 describe('EventsListComponent', () => {
   let component: EventsListComponent;
@@ -43,7 +43,8 @@ describe('EventsListComponent', () => {
         { provide: UserOwnAuthService, useValue: UserOwnAuthServiceMock },
         { provide: Store, useValue: storeMock },
         { provide: MatDialog, useValue: matDialogService },
-        { provide: EventStoreService, useValue: eventStoreServiceMock }
+        { provide: EventStoreService, useValue: eventStoreServiceMock },
+        { provide: DateAdapter, useValue: DateAdapter }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.spec.ts
@@ -4,17 +4,17 @@ import { EventsListComponent } from './events-list.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgxPaginationModule } from 'ngx-pagination';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { BehaviorSubject, of } from 'rxjs';
+import { of } from 'rxjs';
 import { UserOwnAuthService } from 'src/app/shared/services/auth/user-own-auth.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Store } from '@ngrx/store';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { FilterItem } from '../../models/events.interface';
+import { EventListResponse, FilterItem } from '../../models/events.interface';
 import { LangValueDirective } from 'src/app/shared/directives/lang-value/lang-value.directive';
 import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component';
 import { addressesMock, eventStateMock } from '@assets/mocks/events/mock-events';
 import { EventStoreService } from '../../services/event-store.service';
-import { MatNativeDateModule } from '@angular/material/core';
+import { MatNativeDateModule, MatOptionSelectionChange } from '@angular/material/core';
 import { Language } from 'src/app/shared/i18n/Language';
 import { LanguageService } from 'src/app/shared/i18n/language.service';
 
@@ -96,9 +96,7 @@ describe('EventsListComponent', () => {
     const startDate = new Date('2023-10-10');
     const endDate = new Date('2023-10-20');
     spyOn(component, 'updateListOfFilters').and.callThrough();
-    spyOn((component as any).eventService, 'getEvents')
-      .and.returnValue(of({ page: [], totalElements: 0, hasNext: false }))
-      .and.callThrough();
+    spyOn((component as any).eventService, 'getEvents').and.returnValue(of({ page: [], totalElements: 0, hasNext: false }));
 
     component.dateRangeFilterForm.setValue({ from: startDate, to: endDate });
 
@@ -241,6 +239,43 @@ describe('EventsListComponent', () => {
   it('should clear selected filters for type', () => {
     component.unselectAllFiltersInType('type');
     expect(component.selectedTypeFiltersList).toEqual([]);
+  });
+
+  it('should call updateEventReaction on successful dislike', () => {
+    const event = { id: 123 } as EventListResponse;
+    const eventService = (component as any).eventService;
+    spyOn(eventService, 'dislikeEvent').and.returnValue(of({}));
+    spyOn(component as any, 'updateEventReaction');
+
+    component.dislikeEvent(event);
+
+    expect(eventService.dislikeEvent).toHaveBeenCalledWith(123);
+    expect((component as any).updateEventReaction).toHaveBeenCalledWith(event, 'dislike');
+  });
+
+  it('should return immediately if event.isUserInput is false', () => {
+    const filter = { type: 'status', nameEn: 'active' } as FilterItem;
+    const event = { isUserInput: false } as MatOptionSelectionChange;
+    spyOn(component as any, 'unselectCheckbox');
+    spyOn(component as any, 'updateSelectedFiltersList');
+
+    component.updateListOfFilters(filter, event);
+
+    expect((component as any).unselectCheckbox).not.toHaveBeenCalled();
+    expect((component as any).updateSelectedFiltersList).not.toHaveBeenCalled();
+  });
+
+  it('should reset dateRangeFilterForm when type is dateRange', () => {
+    const filter = { type: 'dateRange', nameEn: 'someDate' } as FilterItem;
+    spyOn(component.dateRangeFilterForm, 'reset');
+    spyOn(component as any, 'updateSelectedFiltersList');
+    spyOn(component, 'updateListOfFilters');
+
+    component.removeItemFromSelectedFiltersList(filter);
+
+    expect(component.dateRangeFilterForm.reset).toHaveBeenCalled();
+    expect((component as any).updateSelectedFiltersList).toHaveBeenCalled();
+    expect(component.updateListOfFilters).toHaveBeenCalled();
   });
 
   it('should reset all filter lists and unselect all checkboxes', () => {

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.ts
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { Addresses, EventListResponse, FilterItem } from '../../models/events.interface';
 import { UserOwnAuthService } from 'src/app/shared/services/auth/user-own-auth.service';
-import { first, Observable, ReplaySubject, Subscription, take, takeUntil } from 'rxjs';
+import { Observable, ReplaySubject, Subscription, take, takeUntil } from 'rxjs';
 import { LocalStorageService } from 'src/app/shared/services/localstorage/local-storage.service';
 import { Store } from '@ngrx/store';
 import { IAppState } from 'src/app/store/state/app.state';
@@ -11,7 +11,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
-import { MatSelect, MatSelectChange } from '@angular/material/select';
+import { MatSelect } from '@angular/material/select';
 import { Patterns } from 'src/assets/patterns/patterns';
 import { EventsService } from '../../services/events.service';
 import { DateAdapter, MatOption, MatOptionSelectionChange } from '@angular/material/core';

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.ts
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { Addresses, EventListResponse, FilterItem } from '../../models/events.interface';
 import { UserOwnAuthService } from 'src/app/shared/services/auth/user-own-auth.service';
-import { Observable, ReplaySubject, Subscription, take, takeUntil } from 'rxjs';
+import { first, Observable, ReplaySubject, Subscription, take, takeUntil } from 'rxjs';
 import { LocalStorageService } from 'src/app/shared/services/localstorage/local-storage.service';
 import { Store } from '@ngrx/store';
 import { IAppState } from 'src/app/store/state/app.state';
@@ -11,10 +11,10 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
-import { MatSelect } from '@angular/material/select';
+import { MatSelect, MatSelectChange } from '@angular/material/select';
 import { Patterns } from 'src/assets/patterns/patterns';
 import { EventsService } from '../../services/events.service';
-import { DateAdapter, MatOption } from '@angular/material/core';
+import { DateAdapter, MatOption, MatOptionSelectionChange } from '@angular/material/core';
 import { HttpParams } from '@angular/common/http';
 import { EventStoreService } from '../../services/event-store.service';
 import { initializeSavedState } from 'src/app/greencity/shared/components/saved-tabs/saved-section-const';
@@ -69,6 +69,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
   isSavedVisible = false;
   currentTab = 'events';
   dateRangeFilter: FilterItem = { type: 'dateRange', nameEn: '', nameUk: '' };
+  mockIsUserInput: MatOptionSelectionChange = { source: {} as MatOption, isUserInput: true };
 
   private readonly destroyed$: ReplaySubject<any> = new ReplaySubject<any>(1);
   private readonly ecoEvents$: Observable<IEcoEventsState> = this.store.select((state: IAppState): IEcoEventsState => state.ecoEventsState);
@@ -79,6 +80,14 @@ export class EventsListComponent implements OnInit, OnDestroy {
   private readonly dialogRef: MatDialogRef<unknown>;
 
   @ViewChild('cityModal') cityModal: TemplateRef<any>;
+
+  get dateRangeFromFormControl() {
+    return this.dateRangeFilterForm.get('from');
+  }
+
+  get dateRangeToFormControl() {
+    return this.dateRangeFilterForm.get('to');
+  }
 
   constructor(
     private readonly store: Store,
@@ -106,7 +115,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
       this.bookmarkSelected = isBookmark;
     });
 
-    this.ecoEvents$.subscribe((res: IEcoEventsState) => {
+    this.ecoEvents$.pipe(takeUntil(this.destroyed$)).subscribe((res: IEcoEventsState) => {
       if (res.eventState) {
         this.isLoading = false;
         this.eventsList.push(...res.eventsList.slice(this.page * this.eventsPerPage));
@@ -116,14 +125,17 @@ export class EventsListComponent implements OnInit, OnDestroy {
       }
     });
     this.getEvents();
-    this.eventService.getAddresses().subscribe((addresses) => {
-      this.locationFiltersList = this.getUniqueLocations(addresses);
-    });
+    this.eventService
+      .getAddresses()
+      .pipe(takeUntil(this.destroyed$))
+      .subscribe((addresses) => {
+        this.locationFiltersList = this.getUniqueLocations(addresses);
+      });
 
     this.initializeLocationData();
 
     this.dateRangeFilterForm.valueChanges.pipe(takeUntil(this.destroyed$)).subscribe(() => {
-      if (this.dateRangeFilterForm.get('from')?.value && this.dateRangeFilterForm.get('to')?.value) {
+      if (this.dateRangeFromFormControl?.value && this.dateRangeToFormControl?.value) {
         this.updateListOfFilters(this.dateRangeFilter);
       }
     });
@@ -243,24 +255,33 @@ export class EventsListComponent implements OnInit, OnDestroy {
   }
 
   likeEvent(event: EventListResponse): void {
-    this.eventService.likeEvent(event.id).subscribe(() => {
-      this.updateEventReaction(event, 'like');
-      this.eventService.getEventById(event.id).subscribe((updatedEvent) => {
-        //@ts-ignore
-        this.refreshEventInList(updatedEvent);
+    this.eventService
+      .likeEvent(event.id)
+      .pipe(takeUntil(this.destroyed$))
+      .subscribe(() => {
+        this.updateEventReaction(event, 'like');
+        this.eventService
+          .getEventById(event.id)
+          .pipe(takeUntil(this.destroyed$))
+          .subscribe((updatedEvent) => {
+            //@ts-ignore
+            this.refreshEventInList(updatedEvent);
+          });
       });
-    });
   }
 
   dislikeEvent(event: EventListResponse): void {
-    this.eventService.dislikeEvent(event.id).subscribe(
-      () => {
-        this.updateEventReaction(event, 'dislike');
-      },
-      (error) => {
-        console.error('Dislike API request failed:', error);
-      }
-    );
+    this.eventService
+      .dislikeEvent(event.id)
+      .pipe(takeUntil(this.destroyed$))
+      .subscribe({
+        next: () => {
+          this.updateEventReaction(event, 'dislike');
+        },
+        error: (error) => {
+          console.error('Dislike API request failed:', error);
+        }
+      });
   }
 
   private updateEventReaction(event: EventListResponse, reactionType: 'like' | 'dislike'): void {
@@ -339,7 +360,11 @@ export class EventsListComponent implements OnInit, OnDestroy {
     return uniqueLocations;
   }
 
-  updateListOfFilters(filter: FilterItem): void {
+  updateListOfFilters(filter: FilterItem, event: MatOptionSelectionChange = this.mockIsUserInput): void {
+    if (!event.isUserInput) {
+      return;
+    }
+
     switch (filter.type) {
       case 'eventTimeStatus':
         if (this.selectedEventTimeStatusFiltersList.includes(filter.nameEn)) {
@@ -394,8 +419,8 @@ export class EventsListComponent implements OnInit, OnDestroy {
         }
         break;
       case 'dateRange': {
-        const fromDate = this.dateRangeFilterForm.get('from')?.value;
-        const toDate = this.dateRangeFilterForm.get('to')?.value;
+        const fromDate = this.dateRangeFromFormControl?.value;
+        const toDate = this.dateRangeToFormControl?.value;
 
         if (fromDate && toDate) {
           filter.nameEn = fromDate.toLocaleDateString('en-US') + ' - ' + toDate.toLocaleDateString('en-US');
@@ -468,16 +493,17 @@ export class EventsListComponent implements OnInit, OnDestroy {
     this.getEvents();
   }
 
-  toggleAllOptions(filterType: string, select: MatSelect): void {
+  toggleAllOptions(filterType: string, select: MatSelect, event: MatOptionSelectionChange): void {
     const control = select.ngControl?.control;
-    if (!control) {
+
+    if (!control || !event.isUserInput) {
       return;
     }
 
     const allOptions = select.options.toArray();
     const firstOption = allOptions[0]?.value;
     const firstSelected = firstOption ? (control.value || []).includes(firstOption) : false;
-    control.setValue(firstSelected ? [] : allOptions.map((option) => option.value));
+    control.setValue(!firstSelected ? [] : allOptions.map((option) => option.value));
 
     switch (filterType) {
       case 'eventTimeStatus':
@@ -575,12 +601,15 @@ export class EventsListComponent implements OnInit, OnDestroy {
   }
 
   private getUserFavoriteEvents(): void {
-    this.eventService.getEvents(this.getEventsHttpParams()).subscribe((res) => {
-      this.isLoading = false;
-      this.eventsList.push(...res.page);
-      this.countOfEvents = res.totalElements;
-      this.hasNextPage = res.hasNext;
-    });
+    this.eventService
+      .getEvents(this.getEventsHttpParams())
+      .pipe(takeUntil(this.destroyed$))
+      .subscribe((res) => {
+        this.isLoading = false;
+        this.eventsList.push(...res.page);
+        this.countOfEvents = res.totalElements;
+        this.hasNextPage = res.hasNext;
+      });
   }
 
   private updateSelectedFiltersList(filterName: string, index?: number): void {
@@ -648,11 +677,15 @@ export class EventsListComponent implements OnInit, OnDestroy {
       ),
       this.appendIfNotEmpty(
         'from',
-        this.dateRangeFilterForm.get('from')?.value ? new Date(this.dateRangeFilterForm.get('from')?.value).toISOString() : ''
+        this.dateRangeToFormControl?.value && this.dateRangeFromFormControl?.value
+          ? new Date(this.dateRangeFromFormControl?.value).toISOString()
+          : ''
       ),
       this.appendIfNotEmpty(
         'to',
-        this.dateRangeFilterForm.get('to')?.value ? new Date(this.dateRangeFilterForm.get('to')?.value).toISOString() : ''
+        this.dateRangeToFormControl?.value && this.dateRangeFromFormControl?.value
+          ? new Date(this.dateRangeToFormControl?.value).toISOString()
+          : ''
       )
     ];
     paramsToAdd.filter((param) => param !== null).forEach((param) => (params = params.append(param.key, param.value)));
@@ -697,7 +730,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
   }
 
   private checkUserSingIn(): void {
-    this.userOwnAuthService.credentialDataSubject.subscribe((data) => {
+    this.userOwnAuthService.credentialDataSubject.pipe(takeUntil(this.destroyed$)).subscribe((data) => {
       this.isLoggedIn = !!data?.userId;
       this.userId = data.userId;
       this.statusFiltersList = this.userId ? statusFiltersData : statusFiltersData.slice(0, 2);

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.ts
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.ts
@@ -137,9 +137,12 @@ export class EventsListComponent implements OnInit, OnDestroy {
       value.trim() !== '' ? this.searchEventsByTitle() : this.getEvents();
     });
 
-    this.languageService.getCurrentLangObs().pipe(takeUntil(this.destroyed$)).subscribe((lang) => {
-      this.dateAdapter.setLocale(lang === 'uk' ? 'uk-UA' : 'en-US');
-    });
+    this.languageService
+      .getCurrentLangObs()
+      .pipe(takeUntil(this.destroyed$))
+      .subscribe((lang) => {
+        this.dateAdapter.setLocale(lang === 'uk' ? 'uk-UA' : 'en-US');
+      });
   }
 
   private initializeLocationData(): void {
@@ -393,6 +396,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
       case 'dateRange': {
         const fromDate = this.dateRangeFilterForm.get('from')?.value;
         const toDate = this.dateRangeFilterForm.get('to')?.value;
+
         if (fromDate && toDate) {
           filter.nameEn = fromDate.toLocaleDateString('en-US') + ' - ' + toDate.toLocaleDateString('en-US');
           filter.nameUk = fromDate.toLocaleDateString('uk-UA') + ' - ' + toDate.toLocaleDateString('uk-UA');
@@ -404,8 +408,6 @@ export class EventsListComponent implements OnInit, OnDestroy {
             this.selectedFilters.push(filter);
             this.dateRangeFilter = filter;
           }
-        } else {
-          this.dateRangeFilter = { type: 'dateRange', nameEn: '', nameUk: '' };
         }
         break;
       }
@@ -624,7 +626,9 @@ export class EventsListComponent implements OnInit, OnDestroy {
       this.appendIfNotEmpty('type', this.getTypeFilter()),
       this.appendIfNotEmpty(
         'cities',
-        this.selectedLocationFiltersList.filter((city) => city !== 'Online' && city !== 'Select All' && city !== 'Обрати всі')
+        this.selectedLocationFiltersList.filter(
+          (city) => city !== 'Online' && city !== 'Offline' && city !== 'Select All' && city !== 'Обрати всі'
+        )
       ),
       this.appendIfNotEmpty(
         'time',
@@ -670,11 +674,16 @@ export class EventsListComponent implements OnInit, OnDestroy {
 
   private getFilterByType(type: string): FilterItem[] {
     switch (type) {
-      case 'eventTimeStatus': return this.eventTimeStatusFiltersList;
-      case 'location': return this.locationFiltersList;
-      case 'status': return this.statusFiltersList;
-      case 'type': return this.typeFiltersList;
-      default: return [];
+      case 'eventTimeStatus':
+        return this.eventTimeStatusFiltersList;
+      case 'location':
+        return this.relevantLocationFiltersList;
+      case 'status':
+        return this.statusFiltersList;
+      case 'type':
+        return this.typeFiltersList;
+      default:
+        return [];
     }
   }
 

--- a/src/app/greencity/modules/events/components/events-list/events-list.component.ts
+++ b/src/app/greencity/modules/events/components/events-list/events-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { Addresses, EventListResponse, FilterItem } from '../../models/events.interface';
 import { UserOwnAuthService } from 'src/app/shared/services/auth/user-own-auth.service';
-import { Observable, ReplaySubject, Subscription, take } from 'rxjs';
+import { Observable, ReplaySubject, Subscription, take, takeUntil } from 'rxjs';
 import { LocalStorageService } from 'src/app/shared/services/localstorage/local-storage.service';
 import { Store } from '@ngrx/store';
 import { IAppState } from 'src/app/store/state/app.state';
@@ -14,7 +14,7 @@ import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms'
 import { MatSelect } from '@angular/material/select';
 import { Patterns } from 'src/assets/patterns/patterns';
 import { EventsService } from '../../services/events.service';
-import { MatOption } from '@angular/material/core';
+import { DateAdapter, MatOption } from '@angular/material/core';
 import { HttpParams } from '@angular/common/http';
 import { EventStoreService } from '../../services/event-store.service';
 import { initializeSavedState } from 'src/app/greencity/shared/components/saved-tabs/saved-section-const';
@@ -37,6 +37,10 @@ export class EventsListComponent implements OnInit, OnDestroy {
   statusFilterControl = new FormControl();
   typeFilterControl = new FormControl();
   searchEventControl = new FormControl('', [Validators.maxLength(30), Validators.pattern(Patterns.NameInfoPattern)]);
+  dateRangeFilterForm = this.fb.group({
+    from: [null],
+    to: [null]
+  });
 
   relevantLocationFiltersList: FilterItem[] = [];
   showAddCityInput = false;
@@ -64,6 +68,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
   isGalleryView = true;
   isSavedVisible = false;
   currentTab = 'events';
+  dateRangeFilter: FilterItem = { type: 'dateRange', nameEn: '', nameUk: '' };
 
   private readonly destroyed$: ReplaySubject<any> = new ReplaySubject<any>(1);
   private readonly ecoEvents$: Observable<IEcoEventsState> = this.store.select((state: IAppState): IEcoEventsState => state.ecoEventsState);
@@ -84,6 +89,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
     private readonly eventStoreService: EventStoreService,
     private readonly dialog: MatDialog,
     private readonly route: ActivatedRoute,
+    private readonly dateAdapter: DateAdapter<Date>,
     private readonly languageService: LanguageService,
     private fb: FormBuilder
   ) {}
@@ -116,13 +122,23 @@ export class EventsListComponent implements OnInit, OnDestroy {
 
     this.initializeLocationData();
 
-    this.searchEventControl.valueChanges.subscribe((value) => {
+    this.dateRangeFilterForm.valueChanges.pipe(takeUntil(this.destroyed$)).subscribe(() => {
+      if (this.dateRangeFilterForm.get('from')?.value && this.dateRangeFilterForm.get('to')?.value) {
+        this.updateListOfFilters(this.dateRangeFilter);
+      }
+    });
+
+    this.searchEventControl.valueChanges.pipe(takeUntil(this.destroyed$)).subscribe((value) => {
       if (this.searchResultSubscription) {
         this.searchResultSubscription.unsubscribe();
       }
       this.cleanEventList();
       this.searchQuery = value.trim();
       value.trim() !== '' ? this.searchEventsByTitle() : this.getEvents();
+    });
+
+    this.languageService.getCurrentLangObs().pipe(takeUntil(this.destroyed$)).subscribe((lang) => {
+      this.dateAdapter.setLocale(lang === 'uk' ? 'uk-UA' : 'en-US');
     });
   }
 
@@ -374,12 +390,34 @@ export class EventsListComponent implements OnInit, OnDestroy {
           this.selectedFilters.push(filter);
         }
         break;
+      case 'dateRange': {
+        const fromDate = this.dateRangeFilterForm.get('from')?.value;
+        const toDate = this.dateRangeFilterForm.get('to')?.value;
+        if (fromDate && toDate) {
+          filter.nameEn = fromDate.toLocaleDateString('en-US') + ' - ' + toDate.toLocaleDateString('en-US');
+          filter.nameUk = fromDate.toLocaleDateString('uk-UA') + ' - ' + toDate.toLocaleDateString('uk-UA');
+          const existingDateRangeFilter = this.selectedFilters.find((item) => item.type === 'dateRange');
+          if (existingDateRangeFilter) {
+            existingDateRangeFilter.nameEn = filter.nameEn;
+            existingDateRangeFilter.nameUk = filter.nameUk;
+          } else {
+            this.selectedFilters.push(filter);
+            this.dateRangeFilter = filter;
+          }
+        } else {
+          this.dateRangeFilter = { type: 'dateRange', nameEn: '', nameUk: '' };
+        }
+        break;
+      }
     }
     this.cleanEventList();
     this.getEvents();
   }
 
   removeItemFromSelectedFiltersList(filter: FilterItem, index?: number): void {
+    if (filter.type === 'dateRange') {
+      this.dateRangeFilterForm.reset();
+    }
     this.updateSelectedFiltersList(filter.nameEn, index);
     this.updateListOfFilters(filter);
   }
@@ -441,16 +479,16 @@ export class EventsListComponent implements OnInit, OnDestroy {
 
     switch (filterType) {
       case 'eventTimeStatus':
-        this.toggleAll(this.eventTimeStatusOptionList, this.selectedEventTimeStatusFiltersList);
+        this.toggleAll(this.eventTimeStatusOptionList, this.selectedEventTimeStatusFiltersList, filterType);
         break;
       case 'location':
-        this.toggleAll(this.locationOptionList, this.selectedLocationFiltersList);
+        this.toggleAll(this.locationOptionList, this.selectedLocationFiltersList, filterType);
         break;
       case 'status':
-        this.toggleAll(this.statusOptionList, this.selectedStatusFiltersList);
+        this.toggleAll(this.statusOptionList, this.selectedStatusFiltersList, filterType);
         break;
       case 'type':
-        this.toggleAll(this.typeOptionList, this.selectedTypeFiltersList);
+        this.toggleAll(this.typeOptionList, this.selectedTypeFiltersList, filterType);
         break;
     }
 
@@ -458,16 +496,23 @@ export class EventsListComponent implements OnInit, OnDestroy {
     this.getEvents();
   }
 
-  private toggleAll(select: MatSelect, selectedList: string[]): void {
+  private toggleAll(select: MatSelect, selectedList: string[], filterType: string): void {
     const control = select.ngControl?.control;
     const options = select.options.toArray();
     const currentValue = control.value || [];
+
     if (options.every((option) => currentValue.includes(option.value))) {
       control.setValue([]);
       selectedList.length = 0;
+      this.selectedFilters = this.selectedFilters.filter((filter) => filter.type !== filterType);
     } else {
       control.setValue(options.map((option) => option.value));
       selectedList.splice(0, selectedList.length, ...options.map((option) => option.value));
+      this.getFilterByType(filterType).forEach((item) => {
+        if (!this.selectedFilters.includes(item)) {
+          this.selectedFilters.push(item);
+        }
+      });
     }
   }
 
@@ -477,6 +522,7 @@ export class EventsListComponent implements OnInit, OnDestroy {
     this.selectedLocationFiltersList = [];
     this.selectedStatusFiltersList = [];
     this.selectedTypeFiltersList = [];
+    this.dateRangeFilterForm.reset();
     [this.eventTimeStatusOptionList, this.statusOptionList, this.locationOptionList, this.typeOptionList].forEach((optionList) => {
       this.unselectCheckbox(optionList);
     });
@@ -536,13 +582,11 @@ export class EventsListComponent implements OnInit, OnDestroy {
   }
 
   private updateSelectedFiltersList(filterName: string, index?: number): void {
-    if (index) {
+    if (index !== undefined) {
       this.selectedFilters.splice(index, 1);
-    } else {
-      if (this.selectedFilters.find((item) => item.nameEn === filterName)) {
-        const indexOfItem = this.selectedFilters.findIndex((item) => item.nameEn === filterName);
-        this.selectedFilters.splice(indexOfItem, 1);
-      }
+    } else if (this.selectedFilters.find((item) => item.nameEn === filterName)) {
+      const indexOfItem = this.selectedFilters.findIndex((item) => item.nameEn === filterName);
+      this.selectedFilters.splice(indexOfItem, 1);
     }
   }
 
@@ -597,9 +641,16 @@ export class EventsListComponent implements OnInit, OnDestroy {
       this.appendIfNotEmpty(
         'tags',
         this.selectedTypeFiltersList.filter((type) => type !== 'All types' && type !== 'Всі типи')
+      ),
+      this.appendIfNotEmpty(
+        'from',
+        this.dateRangeFilterForm.get('from')?.value ? new Date(this.dateRangeFilterForm.get('from')?.value).toISOString() : ''
+      ),
+      this.appendIfNotEmpty(
+        'to',
+        this.dateRangeFilterForm.get('to')?.value ? new Date(this.dateRangeFilterForm.get('to')?.value).toISOString() : ''
       )
     ];
-
     paramsToAdd.filter((param) => param !== null).forEach((param) => (params = params.append(param.key, param.value)));
     return params;
   }
@@ -614,6 +665,16 @@ export class EventsListComponent implements OnInit, OnDestroy {
       return 'ONLINE';
     } else {
       return '';
+    }
+  }
+
+  private getFilterByType(type: string): FilterItem[] {
+    switch (type) {
+      case 'eventTimeStatus': return this.eventTimeStatusFiltersList;
+      case 'location': return this.locationFiltersList;
+      case 'status': return this.statusFiltersList;
+      case 'type': return this.typeFiltersList;
+      default: return [];
     }
   }
 

--- a/src/app/greencity/shared/components/events-list-item/events-list-item.component.scss
+++ b/src/app/greencity/shared/components/events-list-item/events-list-item.component.scss
@@ -346,7 +346,7 @@
 }
 
 .event-button {
-  display: block;
+  display: flex;
   width: 100%;
   height: 40px;
 }

--- a/src/app/greencity/shared/pipes/date-localisation-pipe/date-localisation.pipe.ts
+++ b/src/app/greencity/shared/pipes/date-localisation-pipe/date-localisation.pipe.ts
@@ -17,6 +17,6 @@ export class DateLocalisationPipe implements PipeTransform {
 
   transform(date: string | Date): string {
     date = !date ? Date.now().toString() : date;
-    return formatDate(date, 'mediumDate', this.locale);
+    return formatDate(date, 'mediumDate', this.locale === 'uk' ? 'uk-UA' : 'en-US');
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -293,7 +293,8 @@
       },
       "modal-rating-title-can-evaluate": "Evaluate the event and the organizer",
       "modal-rating-title-can`t-evaluate": "You cannot add this event. First register on the site",
-      "pop-up-cancelling-event": "Are you sure that you don't want to join this event?"
+      "pop-up-cancelling-event": "Are you sure that you don't want to join this event?",
+      "date": "Date range"
     },
     "subscription": {
       "caption": "Receive interesting news",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -294,7 +294,8 @@
       },
       "modal-rating-title-can-evaluate": "Оцініть подію та організатора",
       "modal-rating-title-can`t-evaluate": "Ви не можете додати цю подію. Спочатку зареєструйтесь на сайті",
-      "pop-up-cancelling-event": "Чи впевнені ви, що не хочете приєднюватись до цієї події?"
+      "pop-up-cancelling-event": "Чи впевнені ви, що не хочете приєднюватись до цієї події?",
+      "date": "Дати"
     },
     "eco-advices": {
       "caption": "Еко поради"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a date-range filter with calendar picker, integrated into active filters and event queries.

- Accessibility
  - Improved keyboard support: Enter now opens/selects time, location, status, type filters, options, and "add city"/city modal.

- Bug Fixes
  - Consistent date localization (uk-UA / en-US) for display and requests.

- Style
  - Refined filter layout, standardized select triggers, arrow/placeholder adjustments, hidden native date input, and updated event item button layout.

- Chores
  - Added “Date range” translations (EN/UK).

- Tests
  - Added tests for date-range behavior and locale handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->