### PR TITLE
feature/3872 telegram chat edit and delete message from admin

### DIFF
--- a/src/app/chat/chat-icons.ts
+++ b/src/app/chat/chat-icons.ts
@@ -1,3 +1,4 @@
 export const CHAT_ICONS = {
-  telegram: 'assets/img/chat/telegram-logo.svg'
+  telegram: 'assets/img/chat/telegram-logo.svg',
+  edit: './assets/img/ubs-admin-employees/edit.svg'
 };

--- a/src/app/chat/chat-icons.ts
+++ b/src/app/chat/chat-icons.ts
@@ -1,5 +1,5 @@
 export const CHAT_ICONS = {
   telegram: 'assets/img/chat/telegram-logo.svg',
-  edit: './assets/img/chat/new-message.svg',
-  close: './assets/img/comments/cancel-comment-edit.png'
+  edit: 'assets/img/chat/new-message.svg',
+  close: 'assets/img/comments/cancel-comment-edit.png'
 };

--- a/src/app/chat/chat-icons.ts
+++ b/src/app/chat/chat-icons.ts
@@ -1,4 +1,5 @@
 export const CHAT_ICONS = {
   telegram: 'assets/img/chat/telegram-logo.svg',
-  edit: './assets/img/ubs-admin-employees/edit.svg'
+  edit: './assets/img/chat/new-message.svg',
+  close: './assets/img/comments/cancel-comment-edit.png'
 };

--- a/src/app/chat/component/chat-page/chat-page.component.html
+++ b/src/app/chat/component/chat-page/chat-page.component.html
@@ -31,7 +31,8 @@
 
         <app-image-modal [imageUrl]="facade.selectedImageUrl()" (closeModal)="facade.closeImageModal()"> </app-image-modal>
 
-        <app-message-input (sendText)="facade.sendMessage($event.text, $event.file)"> </app-message-input>
+        <app-message-input (sendText)="messageController($event.text, $event.file)" (editText)="facade.selectedMessage()">
+        </app-message-input>
       </div>
     </ng-container>
 

--- a/src/app/chat/component/chat-page/chat-page.component.html
+++ b/src/app/chat/component/chat-page/chat-page.component.html
@@ -31,7 +31,7 @@
 
         <app-image-modal [imageUrl]="facade.selectedImageUrl()" (closeModal)="facade.closeImageModal()"> </app-image-modal>
 
-        <app-message-input (sendText)="messageController($event.text, $event.file)" (editText)="facade.selectedMessage()">
+        <app-message-input (sendText)="messageController($event.text, $event.file)" [editText]="facade.selectedMessage()?.text">
         </app-message-input>
       </div>
     </ng-container>

--- a/src/app/chat/component/chat-page/chat-page.component.html
+++ b/src/app/chat/component/chat-page/chat-page.component.html
@@ -31,7 +31,11 @@
 
         <app-image-modal [imageUrl]="facade.selectedImageUrl()" (closeModal)="facade.closeImageModal()"> </app-image-modal>
 
-        <app-message-input (sendText)="messageController($event.text, $event.file)" [editText]="facade.selectedMessage()?.text">
+        <app-message-input
+          (sendText)="messageController($event.text, $event.file)"
+          (closeEdit)="facade.selectMessage()"
+          [editText]="facade.selectedMessage()?.text"
+        >
         </app-message-input>
       </div>
     </ng-container>

--- a/src/app/chat/component/chat-page/chat-page.component.scss
+++ b/src/app/chat/component/chat-page/chat-page.component.scss
@@ -261,10 +261,9 @@
 }
 
 .message-icons {
-  width: 20px;
-  margin: 0 8px 2px auto;
+  width: 14px;
+  margin: 0 0 3px auto;
   display: flex;
-  gap: 5px;
 
   .icon {
     max-width: 11px;

--- a/src/app/chat/component/chat-page/chat-page.component.scss
+++ b/src/app/chat/component/chat-page/chat-page.component.scss
@@ -289,6 +289,7 @@
   p {
     margin: 0;
     font-size: 14px;
+
     &:first-of-type {
       color: var(--tertiary-light-green);
     }
@@ -296,8 +297,9 @@
 
   .icon {
     width: 16px;
-    margin: 0 15px 0 15px;
+    margin: 0 15px;
   }
+
   .close {
     margin-left: auto;
     width: 10px;
@@ -306,8 +308,9 @@
 }
 
 .edit-status {
-  margin: 0 15px 0 15px;
+  margin: 0 15px;
   font-size: 10px;
+
   .edited-icon {
     width: 13px;
   }

--- a/src/app/chat/component/chat-page/chat-page.component.scss
+++ b/src/app/chat/component/chat-page/chat-page.component.scss
@@ -260,6 +260,17 @@
   }
 }
 
+.message-icons {
+  width: 20px;
+  margin: 0 8px 2px auto;
+  display: flex;
+  gap: 5px;
+
+  .icon {
+    max-width: 11px;
+  }
+}
+
 .file-attach {
   margin-top: 6px;
   display: flex;

--- a/src/app/chat/component/chat-page/chat-page.component.scss
+++ b/src/app/chat/component/chat-page/chat-page.component.scss
@@ -145,6 +145,7 @@
 }
 
 .messages {
+  position: relative;
   flex: 1;
   overflow-y: auto;
   padding-right: 0.5rem;
@@ -195,6 +196,7 @@
 }
 
 .message-input-container {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -268,6 +270,51 @@
   .icon {
     max-width: 11px;
   }
+}
+
+.edit-text-container {
+  position: absolute;
+  bottom: 6rem;
+  width: 88%;
+  padding: 7px 10px;
+  border-radius: 7px;
+  margin-left: 5px;
+  display: flex;
+  align-self: flex-start;
+  background-color: var(--primary-white);
+  color: var(--secondary-dark-grey);
+  border: 1px solid var(--after-primary-light-grey);
+  box-shadow: -2px -1px 5px #0000001a;
+
+  p {
+    margin: 0;
+    font-size: 14px;
+    &:first-of-type {
+      color: var(--tertiary-light-green);
+    }
+  }
+
+  .icon {
+    width: 16px;
+    margin: 0 15px 0 15px;
+  }
+  .close {
+    margin-left: auto;
+    width: 10px;
+    height: 10px;
+  }
+}
+
+.edit-status {
+  margin: 0 15px 0 15px;
+  font-size: 10px;
+  .edited-icon {
+    width: 13px;
+  }
+}
+
+.menu-item {
+  font-size: 14px;
 }
 
 .file-attach {

--- a/src/app/chat/component/chat-page/chat-page.component.scss
+++ b/src/app/chat/component/chat-page/chat-page.component.scss
@@ -332,7 +332,14 @@
     margin-left: auto;
     width: 10px;
     height: 10px;
+    cursor: pointer;
   }
+}
+
+.edited-pencil {
+  height: 8px;
+  width: 8px;
+  margin-right: 3px;
 }
 
 .edit-status {

--- a/src/app/chat/component/chat-page/chat-page.component.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.ts
@@ -31,7 +31,10 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('pagingAnchor') pagingAnchor!: ElementRef<HTMLElement>;
   private io?: IntersectionObserver;
   private readonly destroy$ = new Subject<void>();
-  constructor(public facade: ChatFacade, public route: ActivatedRoute) {}
+  constructor(
+    public facade: ChatFacade,
+    public route: ActivatedRoute
+  ) {}
 
   ngOnInit(): void {
     this.facade.init(Number(this.route.snapshot.queryParams['chatId']));
@@ -71,6 +74,14 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
     );
 
     this.io.observe(this.pagingAnchor.nativeElement);
+  }
+
+  messageController(text: string, file?: File) {
+    if (!this.facade.selectedMessage) {
+      this.facade.sendMessage(text, file);
+    } else {
+      this.facade.editMessage(text);
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/chat/component/chat-page/chat-page.component.ts
+++ b/src/app/chat/component/chat-page/chat-page.component.ts
@@ -91,10 +91,10 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   messageController(text: string, file?: File) {
-    if (!this.facade.selectedMessage) {
-      this.facade.sendMessage(text, file);
-    } else {
+    if (this.facade.selectedMessage) {
       this.facade.editMessage(text);
+    } else {
+      this.facade.sendMessage(text, file);
     }
   }
 

--- a/src/app/chat/data/chat-api.service.ts
+++ b/src/app/chat/data/chat-api.service.ts
@@ -56,6 +56,18 @@ export class ChatApiService {
     return this.http.post<string>(url, form, { headers, responseType: 'text' as 'json' });
   }
 
+  editMessage(chatInternalId: number, messageId: number, newText: string) {
+    const headers = this.authHeaders();
+    if (!headers) {
+      return new Observable<string>((o) => o.complete());
+    }
+    const url = `${this.baseUrl}/message/edit`;
+    const data = new Blob([JSON.stringify({ chatId: chatInternalId, messageId: messageId, newText })], { type: 'application/json' });
+    const form = new FormData();
+    form.append('data', data);
+    return this.http.put<string>(url, form, { headers, responseType: 'text' as 'json' });
+  }
+
   getLastOrder(chatInternalId: number) {
     const headers = this.authHeaders();
     if (!headers) {

--- a/src/app/chat/data/chat-api.service.ts
+++ b/src/app/chat/data/chat-api.service.ts
@@ -63,9 +63,7 @@ export class ChatApiService {
     }
     const url = `${this.baseUrl}/message/edit`;
     const data = new Blob([JSON.stringify({ chatId: chatInternalId, messageId: messageId, newText })], { type: 'application/json' });
-    const form = new FormData();
-    form.append('data', data);
-    return this.http.put<string>(url, form, { headers, responseType: 'text' as 'json' });
+    return this.http.put<string>(url, data, { headers, responseType: 'text' as 'json' });
   }
 
   getLastOrder(chatInternalId: number) {

--- a/src/app/chat/facade/chat-facade.spec.ts
+++ b/src/app/chat/facade/chat-facade.spec.ts
@@ -103,6 +103,13 @@ describe('ChatFacade', () => {
     expect(api.getChats).not.toHaveBeenCalled();
   });
 
+  it('selectMessage should set select message', () => {
+    facade.selectedMessage.set(null);
+    const msg = { id: 1, from: 'ME', text: 'Test', time: 'Time' };
+    facade.selectMessage(msg);
+    expect(facade.selectedMessage()).toEqual(msg);
+  });
+
   it('filteredChats filters by searchId', () => {
     api.getChats.and.returnValue(
       of({ page: [sampleChat({ id: 11, chatId: '111' }), sampleChat({ id: 22, chatId: '222' })], totalPages: 1 })

--- a/src/app/chat/facade/chat.facade.ts
+++ b/src/app/chat/facade/chat.facade.ts
@@ -14,6 +14,8 @@ export class ChatFacade {
   readonly selectedChat = signal<ChatListItem | null>(null);
   readonly selectedImageUrl = signal<string | null>(null);
 
+  readonly selectedMessage = signal<ChatMessageView | null>(null);
+
   readonly clientInfoVisible = signal(false);
   readonly clientInfoData = signal<ClientInfoData>(null);
 
@@ -158,7 +160,14 @@ export class ChatFacade {
     this.location.replaceState(newPath);
   }
 
-  selectChatById(chatInternalId: number) { 
+  selectMessage(message: ChatMessageView) {
+    if (message) {
+      console.log(message);
+      this.selectedMessage.set(message);
+    }
+  }
+
+  selectChatById(chatInternalId: number) {
     const chat = this.chats().find((c) => c.chatInternalId === chatInternalId);
     if (chat) {
       this.selectChat(chat);
@@ -329,6 +338,26 @@ export class ChatFacade {
         this.selectedChat.set({ ...sel });
       },
       error: (e) => console.error('Failed to send message:', e)
+    });
+  }
+
+  editMessage(newText: string) {
+    const sel = this.selectedChat();
+    const mes = this.selectedMessage();
+    console.log(mes);
+    if (!sel || !newText.trim() || !mes) {
+      return;
+    }
+    this.api.editMessage(sel.chatInternalId, mes.id, newText.trim()).subscribe({
+      next: () => {
+        const messageIndex = sel.messages.findIndex((m) => m.id === mes.id);
+        if (messageIndex > -1) {
+          sel.messages[messageIndex].text = newText;
+        }
+        this.selectedChat.set({ ...sel });
+        console.log(mes);
+      },
+      error: (e) => console.error('Failed to edit the message:', e)
     });
   }
 

--- a/src/app/chat/facade/chat.facade.ts
+++ b/src/app/chat/facade/chat.facade.ts
@@ -160,11 +160,8 @@ export class ChatFacade {
     this.location.replaceState(newPath);
   }
 
-  selectMessage(message: ChatMessageView) {
-    if (message) {
-      console.log(message);
-      this.selectedMessage.set(message);
-    }
+  selectMessage(message?: ChatMessageView) {
+    this.selectedMessage.set(message);
   }
 
   selectChatById(chatInternalId: number) {
@@ -344,7 +341,6 @@ export class ChatFacade {
   editMessage(newText: string) {
     const sel = this.selectedChat();
     const mes = this.selectedMessage();
-    console.log(mes);
     if (!sel || !newText.trim() || !mes) {
       return;
     }
@@ -355,7 +351,7 @@ export class ChatFacade {
           sel.messages[messageIndex].text = newText;
         }
         this.selectedChat.set({ ...sel });
-        console.log(mes);
+        this.selectMessage(null);
       },
       error: (e) => console.error('Failed to edit the message:', e)
     });

--- a/src/app/chat/facade/chat.facade.ts
+++ b/src/app/chat/facade/chat.facade.ts
@@ -6,7 +6,6 @@ import { buildName, formatTimeOrDate, normalizeViewingStatus, toTime } from '../
 import { Subscription } from 'rxjs';
 import { TelegramSocketService } from '../service/chats/telegram-socket.service';
 import { Location } from '@angular/common';
-import { isUBSSelector } from 'src/app/store/selectors/auth.selectors';
 
 @Injectable({ providedIn: 'root' })
 export class ChatFacade {

--- a/src/app/chat/facade/chat.facade.ts
+++ b/src/app/chat/facade/chat.facade.ts
@@ -252,7 +252,6 @@ export class ChatFacade {
   private loadMessagesRecursive(chatInternalId: number, page: number, size: number, collected: MessageDto[]) {
     this.api.getMessages(chatInternalId, page, size).subscribe({
       next: (resp) => {
-        console.log(resp);
         const msgs = resp.page ?? [];
         collected.push(...msgs);
 

--- a/src/app/chat/facade/chat.facade.ts
+++ b/src/app/chat/facade/chat.facade.ts
@@ -6,6 +6,7 @@ import { buildName, formatTimeOrDate, normalizeViewingStatus, toTime } from '../
 import { Subscription } from 'rxjs';
 import { TelegramSocketService } from '../service/chats/telegram-socket.service';
 import { Location } from '@angular/common';
+import { isUBSSelector } from 'src/app/store/selectors/auth.selectors';
 
 @Injectable({ providedIn: 'root' })
 export class ChatFacade {
@@ -252,6 +253,7 @@ export class ChatFacade {
   private loadMessagesRecursive(chatInternalId: number, page: number, size: number, collected: MessageDto[]) {
     this.api.getMessages(chatInternalId, page, size).subscribe({
       next: (resp) => {
+        console.log(resp);
         const msgs = resp.page ?? [];
         collected.push(...msgs);
 
@@ -280,7 +282,8 @@ export class ChatFacade {
         id: msg.id,
         from: msg.fromManager ? 'Me' : sel.nickname,
         text: msg.text,
-        time: formatTimeOrDate(msg.sendAt),
+        time: formatTimeOrDate(msg.sendAt, msg.isUpdated),
+        isUpdated: msg.isUpdated,
         images: (msg.assets ?? []).filter((a) => a.type === 'IMAGE').map((a) => a.url),
         fileName: (msg.assets ?? []).find((a) => a.type === 'FILE')?.fileName,
         fileUrl: (msg.assets ?? []).find((a) => a.type === 'FILE')?.url,
@@ -319,7 +322,7 @@ export class ChatFacade {
 
     this.api.sendMessage(sel.chatInternalId, text.trim(), file).subscribe({
       next: () => {
-        const time = formatTimeOrDate(new Date().toISOString());
+        const time = formatTimeOrDate(new Date().toISOString(), false);
         const imagePreview = file?.type?.startsWith('image/') ? URL.createObjectURL(file) : null;
         const filePreview = file && !imagePreview ? URL.createObjectURL(file) : null;
 
@@ -327,6 +330,7 @@ export class ChatFacade {
           from: 'Me',
           text: text.trim(),
           time,
+          isUpdated: false,
           images: imagePreview ? [imagePreview] : [],
           fileUrl: filePreview,
           fileName: filePreview ? file.name : null,
@@ -349,10 +353,14 @@ export class ChatFacade {
     }
     this.api.editMessage(sel.chatInternalId, mes.id, newText.trim()).subscribe({
       next: () => {
+        const time = formatTimeOrDate(new Date().toISOString(), true);
         const messageIndex = sel.messages.findIndex((m) => m.id === mes.id);
         if (messageIndex > -1) {
           sel.messages[messageIndex].text = newText;
+          sel.messages[messageIndex].time = time;
+          sel.messages[messageIndex].isUpdated = true;
         }
+        sel.time = time;
         this.selectedChat.set({ ...sel });
         this.selectMessage(null);
       },

--- a/src/app/chat/model/chat-page.interface.ts
+++ b/src/app/chat/model/chat-page.interface.ts
@@ -28,6 +28,7 @@ export interface MessageDto {
   sendAt: string;
   text: string;
   fromManager: boolean;
+  isUpdated?: boolean;
   deliveryStatus: DeliveryStatus;
   assets: AssetDto[];
   messageViewingStatus?: MessageViewingStatus;
@@ -56,6 +57,7 @@ export interface ChatMessageView {
   from: string;
   text: string;
   time: string;
+  isUpdated?: boolean;
   images?: string[];
   fileUrl?: string;
   fileName?: string;

--- a/src/app/chat/ui/message-input/message-input.component.html
+++ b/src/app/chat/ui/message-input/message-input.component.html
@@ -2,6 +2,7 @@
   <div class="message-input-wrapper">
     <label class="message-input-wrapper-label">
       <input
+        #textInput
         type="text"
         id="text-input-message"
         [placeholder]="'chat.active-chat-placeholder' | translate"

--- a/src/app/chat/ui/message-input/message-input.component.html
+++ b/src/app/chat/ui/message-input/message-input.component.html
@@ -1,4 +1,12 @@
 <div class="message-input-container">
+  <div *ngIf="editText" class="edit-text-container">
+    <img class="icon" [src]="chatICons.edit" alt="edit" />
+    <div class="edited-message">
+      <p>{{ 'chat.edit-message' | translate }}</p>
+      <p>{{ editText }}</p>
+    </div>
+    <img class="close" [src]="chatICons.close" alt="close" (click)="onClose()" />
+  </div>
   <div class="message-input-wrapper">
     <label class="message-input-wrapper-label">
       <input

--- a/src/app/chat/ui/message-input/message-input.component.spec.ts
+++ b/src/app/chat/ui/message-input/message-input.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MessageInputComponent } from './message-input.component';
 import { TranslateModule } from '@ngx-translate/core';
+import { ElementRef } from '@angular/core';
 
 describe('MessageInputComponent', () => {
   let fixture: ComponentFixture<MessageInputComponent>;
@@ -148,5 +149,50 @@ describe('MessageInputComponent', () => {
 
     expect(component.file).toBeUndefined();
     expect(event.target.value).toBe('');
+  });
+
+  it('should initialize text as empty string', () => {
+    expect(component.text).toBe('');
+  });
+
+  it('should have undefined editText initially', () => {
+    expect(component.editText).toBeUndefined();
+  });
+
+  it('should set text and focus input when editText changes', () => {
+    component.textInput = new ElementRef(document.createElement('input'));
+    spyOn(component.textInput.nativeElement, 'focus');
+
+    const changes = {
+      editText: {
+        currentValue: 'Hello world',
+        previousValue: '',
+        firstChange: true,
+        isFirstChange: () => true
+      }
+    };
+
+    component.editText = 'Hello world';
+    component.ngOnChanges(changes);
+
+    expect(component.text).toBe('Hello world');
+    expect(component.textInput.nativeElement.focus).toHaveBeenCalled();
+  });
+
+  it('should not focus when editText has no currentValue', () => {
+    component.textInput = new ElementRef(document.createElement('input'));
+    spyOn(component.textInput.nativeElement, 'focus');
+
+    const changes = {
+      editText: {
+        currentValue: undefined,
+        previousValue: 'Old',
+        firstChange: false,
+        isFirstChange: () => false
+      }
+    };
+
+    component.ngOnChanges(changes);
+    expect(component.textInput.nativeElement.focus).not.toHaveBeenCalled();
   });
 });

--- a/src/app/chat/ui/message-input/message-input.component.ts
+++ b/src/app/chat/ui/message-input/message-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, ViewChild, ElementRef, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Output, ViewChild, ElementRef, Input, OnInit, OnChanges, SimpleChanges } from '@angular/core';
 import { NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -9,17 +9,20 @@ import { TranslateModule } from '@ngx-translate/core';
   imports: [FormsModule, TranslateModule],
   templateUrl: './message-input.component.html'
 })
-export class MessageInputComponent implements OnInit {
+export class MessageInputComponent implements OnChanges {
   @Output() sendText = new EventEmitter<{ text: string; file?: File }>();
   @ViewChild('fileInput', { static: false }) fileInput!: ElementRef<HTMLInputElement>;
-  @Input() editText: string;
+  @ViewChild('textInput') textInput!: ElementRef<HTMLInputElement>;
+  @Input() editText?: string;
   text = '';
   file?: File;
   private readonly MAX_FILE_MB = 5;
 
-  ngOnInit() {
-    if (this.editText) {
-      this.text = this.editText;
+  ngOnChanges(changes: SimpleChanges) {
+    console.log('message input', this.editText);
+    if (changes['editText']?.currentValue) {
+      this.text = this.editText ?? '';
+      this.textInput.nativeElement.focus();
     }
   }
 

--- a/src/app/chat/ui/message-input/message-input.component.ts
+++ b/src/app/chat/ui/message-input/message-input.component.ts
@@ -2,24 +2,26 @@ import { Component, EventEmitter, Output, ViewChild, ElementRef, Input, OnInit, 
 import { NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
+import { CHAT_ICONS } from '../../chat-icons';
 
 @Component({
   selector: 'app-message-input',
   standalone: true,
-  imports: [FormsModule, TranslateModule],
+  imports: [FormsModule, TranslateModule, NgIf],
   templateUrl: './message-input.component.html'
 })
 export class MessageInputComponent implements OnChanges {
   @Output() sendText = new EventEmitter<{ text: string; file?: File }>();
+  @Output() closeEdit = new EventEmitter();
   @ViewChild('fileInput', { static: false }) fileInput!: ElementRef<HTMLInputElement>;
   @ViewChild('textInput') textInput!: ElementRef<HTMLInputElement>;
   @Input() editText?: string;
   text = '';
   file?: File;
   private readonly MAX_FILE_MB = 5;
+  readonly chatICons = CHAT_ICONS;
 
   ngOnChanges(changes: SimpleChanges) {
-    console.log('message input', this.editText);
     if (changes['editText']?.currentValue) {
       this.text = this.editText ?? '';
       this.textInput.nativeElement.focus();
@@ -32,6 +34,7 @@ export class MessageInputComponent implements OnChanges {
     }
     this.sendText.emit({ text: this.text, file: this.file });
     this.text = '';
+    this.editText = '';
     this.file = undefined;
 
     if (this.fileInput) {
@@ -54,5 +57,11 @@ export class MessageInputComponent implements OnChanges {
       return;
     }
     this.file = file;
+  }
+
+  onClose() {
+    this.closeEdit.emit();
+    this.editText = '';
+    this.text = '';
   }
 }

--- a/src/app/chat/ui/message-input/message-input.component.ts
+++ b/src/app/chat/ui/message-input/message-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, ViewChild, ElementRef, Input, OnInit, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Output, ViewChild, ElementRef, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';

--- a/src/app/chat/ui/message-input/message-input.component.ts
+++ b/src/app/chat/ui/message-input/message-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, ViewChild, ElementRef } from '@angular/core';
+import { Component, EventEmitter, Output, ViewChild, ElementRef, Input, OnInit } from '@angular/core';
 import { NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -6,16 +6,22 @@ import { TranslateModule } from '@ngx-translate/core';
 @Component({
   selector: 'app-message-input',
   standalone: true,
-  imports: [NgIf, FormsModule, TranslateModule],
+  imports: [FormsModule, TranslateModule],
   templateUrl: './message-input.component.html'
 })
-export class MessageInputComponent {
+export class MessageInputComponent implements OnInit {
   @Output() sendText = new EventEmitter<{ text: string; file?: File }>();
   @ViewChild('fileInput', { static: false }) fileInput!: ElementRef<HTMLInputElement>;
-
+  @Input() editText: string;
   text = '';
   file?: File;
   private readonly MAX_FILE_MB = 5;
+
+  ngOnInit() {
+    if (this.editText) {
+      this.text = this.editText;
+    }
+  }
 
   send() {
     if (!this.text.trim() && !this.file) {

--- a/src/app/chat/ui/message-input/message-input.component.ts
+++ b/src/app/chat/ui/message-input/message-input.component.ts
@@ -23,7 +23,7 @@ export class MessageInputComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['editText']?.currentValue) {
-      this.text = this.editText ?? '';
+      this.text = this.editText;
       this.textInput.nativeElement.focus();
     }
   }

--- a/src/app/chat/ui/messages-list/messages-list.component.html
+++ b/src/app/chat/ui/messages-list/messages-list.component.html
@@ -1,7 +1,7 @@
 <div #scrollContainer class="messages">
   <div *ngFor="let message of messages" [ngClass]="{ message: true, sent: message.from === 'Me', received: message.from !== 'Me' }">
     <div class="message-text" *ngIf="message.text">
-      <div class="message-icons">
+      <div *ngIf="message.from === 'Me'" class="message-icons">
         <img class="icon" [src]="chatICons.edit" alt="edit" (click)="onMessageEdit(message)" />
       </div>
       {{ message.text }}

--- a/src/app/chat/ui/messages-list/messages-list.component.html
+++ b/src/app/chat/ui/messages-list/messages-list.component.html
@@ -28,6 +28,7 @@
     </div>
 
     <div class="message-footer">
+      <img *ngIf="message?.isUpdated" src="assets/img/comments/edit.png" alt="edited" class="edited-pencil" />
       <span class="message-time">{{ message.time }}</span>
       <app-status-ticks *ngIf="message.from === 'Me'" [status]="message.viewingStatus || undefined"></app-status-ticks>
     </div>
@@ -37,9 +38,9 @@
     <mat-menu #menu="matMenu" yPosition="above" (closed)="onMenuClosed()">
       <ng-template matMenuContent>
         <div>
-          <span class="edit-status"
+          <span *ngIf="selectedMessage?.isUpdated" class="edit-status"
             ><img class="edited-icon" [src]="chatICons.edit" alt="edited" />
-            {{ 'chat.status.EDITED' | translate: { editDate: '11.09.2025', editTime: '16:33' } }}</span
+            {{ 'chat.status.EDITED' | translate: { editDateTime: selectedMessage?.time } }}</span
           >
           <button mat-menu-item (click)="onMessageEdit()" class="edit-button">
             <span class="menu-item">{{ 'chat.edit-option' | translate }}</span>

--- a/src/app/chat/ui/messages-list/messages-list.component.html
+++ b/src/app/chat/ui/messages-list/messages-list.component.html
@@ -1,9 +1,19 @@
 <div #scrollContainer class="messages">
-  <div *ngFor="let message of messages" [ngClass]="{ message: true, sent: message.from === 'Me', received: message.from !== 'Me' }">
+  <div
+    *ngFor="let message of messages"
+    [ngClass]="{ message: true, sent: message.from === 'Me', received: message.from !== 'Me' }"
+    (contextmenu)="onRightClick($event, menuTrigger, message)"
+    (touchstart)="onTouchStart($event, menuTrigger, message)"
+    (touchend)="onTouchEnd($event)"
+    (touchmove)="onTouchMove($event)"
+  >
+    <div
+      style="visibility: hidden; position: fixed"
+      [style.left]="matMenuPosition.x"
+      [style.top]="matMenuPosition.y"
+      [matMenuTriggerFor]="menu"
+    ></div>
     <div class="message-text" *ngIf="message.text">
-      <div *ngIf="message.from === 'Me'" class="message-icons">
-        <img class="icon" [src]="chatICons.edit" alt="edit" (click)="onMessageEdit(message)" />
-      </div>
       {{ message.text }}
     </div>
 
@@ -21,5 +31,21 @@
       <span class="message-time">{{ message.time }}</span>
       <app-status-ticks *ngIf="message.from === 'Me'" [status]="message.viewingStatus || undefined"></app-status-ticks>
     </div>
+  </div>
+
+  <div class="mat-menu">
+    <mat-menu #menu="matMenu" yPosition="above" (closed)="onMenuClosed()">
+      <ng-template matMenuContent>
+        <div>
+          <span class="edit-status"
+            ><img class="edited-icon" [src]="chatICons.edit" alt="edited" />
+            {{ 'chat.status.EDITED' | translate: { editDate: '11.09.2025', editTime: '16:33' } }}</span
+          >
+          <button mat-menu-item (click)="onMessageEdit()" class="edit-button">
+            <span class="menu-item">{{ 'chat.edit-option' | translate }}</span>
+          </button>
+        </div>
+      </ng-template>
+    </mat-menu>
   </div>
 </div>

--- a/src/app/chat/ui/messages-list/messages-list.component.html
+++ b/src/app/chat/ui/messages-list/messages-list.component.html
@@ -1,6 +1,9 @@
 <div #scrollContainer class="messages">
   <div *ngFor="let message of messages" [ngClass]="{ message: true, sent: message.from === 'Me', received: message.from !== 'Me' }">
     <div class="message-text" *ngIf="message.text">
+      <div class="message-icons">
+        <img class="icon" [src]="chatICons.edit" alt="edit" (click)="onMessageEdit(message)" />
+      </div>
       {{ message.text }}
     </div>
 

--- a/src/app/chat/ui/messages-list/messages-list.component.spec.ts
+++ b/src/app/chat/ui/messages-list/messages-list.component.spec.ts
@@ -8,6 +8,9 @@ describe('MessagesListComponent', () => {
   let fixture: ComponentFixture<MessagesListComponent>;
   let component: MessagesListComponent;
 
+  const mockTrigger = jasmine.createSpyObj('MatMenuTrigger', ['openMenu']);
+  const event = new MouseEvent('contextmenu');
+
   const msg = (over: Partial<ChatMessageView> = {}): ChatMessageView => ({
     from: 'User',
     text: 'hello',
@@ -29,6 +32,31 @@ describe('MessagesListComponent', () => {
   it('should create', () => {
     fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it('onMenuClosed should set selectedMessage to null', () => {
+    component.selectedMessage = msg({ from: 'Me' });
+    component.onMenuClosed();
+    expect(component.selectedMessage).toBeNull();
+  });
+
+  it('should return early if message is not from "Me"', () => {
+    const message = msg({ from: 'Other' });
+    component.onRightClick(event, mockTrigger, message);
+    expect(mockTrigger.openMenu).not.toHaveBeenCalled();
+    expect(component.selectedMessage).toBeUndefined();
+  });
+
+  it('should return early if message has images', () => {
+    const message = msg({ from: 'Me', images: ['a.png'] });
+    component.onRightClick(event, mockTrigger, message);
+    expect(mockTrigger.openMenu).not.toHaveBeenCalled();
+  });
+
+  it('should return early if message has fileUrl', () => {
+    const message = msg({ from: 'Me', fileUrl: 'file.pdf' as any });
+    component.onRightClick(event, mockTrigger, message);
+    expect(mockTrigger.openMenu).not.toHaveBeenCalled();
   });
 
   it('should not scroll if message count is unchanged', () => {

--- a/src/app/chat/ui/messages-list/messages-list.component.spec.ts
+++ b/src/app/chat/ui/messages-list/messages-list.component.spec.ts
@@ -2,6 +2,7 @@ import { MessagesListComponent } from './messages-list.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ChatMessageView } from '../../model/chat-page.interface';
 import { fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('MessagesListComponent', () => {
   let fixture: ComponentFixture<MessagesListComponent>;
@@ -18,7 +19,7 @@ describe('MessagesListComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MessagesListComponent]
+      imports: [MessagesListComponent, HttpClientTestingModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(MessagesListComponent);

--- a/src/app/chat/ui/messages-list/messages-list.component.ts
+++ b/src/app/chat/ui/messages-list/messages-list.component.ts
@@ -4,11 +4,13 @@ import { ChatMessageView } from '../../model/chat-page.interface';
 import { StatusTicksComponent } from '../status-ticks/status-ticks.component';
 import { CHAT_ICONS } from '../../chat-icons';
 import { ChatFacade } from '../../facade/chat.facade';
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
+import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-messages-list',
   standalone: true,
-  imports: [NgForOf, NgIf, NgClass, StatusTicksComponent],
+  imports: [NgForOf, NgIf, NgClass, StatusTicksComponent, MatMenuModule, TranslateModule],
   templateUrl: './messages-list.component.html'
 })
 export class MessagesListComponent implements AfterViewChecked {
@@ -16,11 +18,16 @@ export class MessagesListComponent implements AfterViewChecked {
   @Output() openImage = new EventEmitter<string>();
 
   @ViewChild('scrollContainer') private readonly scrollContainer!: ElementRef<HTMLDivElement>;
+  @ViewChild(MatMenuTrigger) menuTrigger!: MatMenuTrigger;
 
   constructor(readonly facade: ChatFacade) {}
 
   readonly chatICons = CHAT_ICONS;
   private lastMsgCount = 0;
+
+  selectedMessage?: ChatMessageView;
+  pressTimer: any;
+  matMenuPosition = { x: '0px', y: '0px' };
 
   ngAfterViewChecked(): void {
     if (this.messages.length !== this.lastMsgCount) {
@@ -36,8 +43,11 @@ export class MessagesListComponent implements AfterViewChecked {
     }
   }
 
-  onMessageEdit(message: ChatMessageView) {
-    this.facade.selectMessage(message);
+  onMessageEdit() {
+    if (this.selectedMessage) {
+      this.facade.selectMessage(this.selectedMessage);
+      this.selectedMessage = null;
+    }
   }
 
   private scrollToBottom(): void {
@@ -71,5 +81,42 @@ export class MessagesListComponent implements AfterViewChecked {
         })
       );
     });
+  }
+
+  onMenuClosed() {
+    this.selectedMessage = null;
+  }
+
+  onRightClick(event: MouseEvent, trigger: MatMenuTrigger, message: ChatMessageView) {
+    if (message?.from != 'Me' || message?.images.length || message?.fileUrl) {
+      return;
+    }
+    event.preventDefault();
+    this.matMenuPosition.x = event.clientX + 'px';
+    this.matMenuPosition.y = event.clientY - 20 + 'px';
+    this.selectedMessage = message;
+    this.menuTrigger.menu.focusFirstItem('mouse');
+    trigger.openMenu();
+  }
+
+  onTouchStart(event: TouchEvent, trigger: MatMenuTrigger, message: ChatMessageView) {
+    if (message?.from != 'Me' && message?.text && !message?.images.length && !message?.fileUrl) {
+      return;
+    }
+    this.selectedMessage = message;
+    this.pressTimer = setTimeout(() => {
+      const touch = event.touches[0];
+      this.matMenuPosition.x = touch.clientX + 'px';
+      this.matMenuPosition.y = touch.clientY - 20 + 'px';
+      trigger.openMenu();
+    }, 600);
+  }
+
+  onTouchEnd(event: TouchEvent) {
+    clearTimeout(this.pressTimer);
+  }
+
+  onTouchMove(event: TouchEvent) {
+    clearTimeout(this.pressTimer);
   }
 }

--- a/src/app/chat/ui/messages-list/messages-list.component.ts
+++ b/src/app/chat/ui/messages-list/messages-list.component.ts
@@ -2,6 +2,8 @@ import { Component, EventEmitter, Input, Output, ElementRef, ViewChild, AfterVie
 import { NgForOf, NgIf, NgClass } from '@angular/common';
 import { ChatMessageView } from '../../model/chat-page.interface';
 import { StatusTicksComponent } from '../status-ticks/status-ticks.component';
+import { CHAT_ICONS } from '../../chat-icons';
+import { ChatFacade } from '../../facade/chat.facade';
 
 @Component({
   selector: 'app-messages-list',
@@ -15,6 +17,9 @@ export class MessagesListComponent implements AfterViewChecked {
 
   @ViewChild('scrollContainer') private readonly scrollContainer!: ElementRef<HTMLDivElement>;
 
+  constructor(readonly facade: ChatFacade) {}
+
+  readonly chatICons = CHAT_ICONS;
   private lastMsgCount = 0;
 
   ngAfterViewChecked(): void {
@@ -29,6 +34,10 @@ export class MessagesListComponent implements AfterViewChecked {
 
       this.lastMsgCount = this.messages.length;
     }
+  }
+
+  onMessageEdit(message: ChatMessageView) {
+    this.facade.selectMessage(message);
   }
 
   private scrollToBottom(): void {

--- a/src/app/chat/utils/chat-mappers.ts
+++ b/src/app/chat/utils/chat-mappers.ts
@@ -43,7 +43,7 @@ export function toTime(iso: string): string {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
-export function formatTimeOrDate(iso?: string | null): string {
+export function formatTimeOrDate(iso?: string | null, isEdit?: boolean): string {
   if (!iso) {
     return '';
   }
@@ -55,7 +55,7 @@ export function formatTimeOrDate(iso?: string | null): string {
   const now = new Date();
   const sameDay = d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth() && d.getDate() === now.getDate();
 
-  if (sameDay) {
+  if (sameDay && !isEdit) {
     return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   }
 

--- a/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.ts
+++ b/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.ts
@@ -154,8 +154,6 @@ export class InputGoogleAutocompleteComponent implements OnInit, OnDestroy, Cont
       };
 
       this.autocompleteService.getPlacePredictions(request, (predictions: google.maps.places.AutocompletePrediction[]) => {
-        console.log(this.autoCompRequest);
-        console.log(predictions);
         this.handlePredictions(predictions, this.requestPrefix);
       });
     });
@@ -239,12 +237,10 @@ export class InputGoogleAutocompleteComponent implements OnInit, OnDestroy, Cont
   }
 
   onInputFocus(): void {
-    console.log('focus');
     this.shouldAutocomplete = true;
   }
 
   onInputBlur(): void {
-    console.log('unfocus');
     this.markAsTouched();
     this.shouldAutocomplete = false;
   }

--- a/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.ts
+++ b/src/app/shared/components/input-google-autocomplete/input-google-autocomplete.component.ts
@@ -154,6 +154,8 @@ export class InputGoogleAutocompleteComponent implements OnInit, OnDestroy, Cont
       };
 
       this.autocompleteService.getPlacePredictions(request, (predictions: google.maps.places.AutocompletePrediction[]) => {
+        console.log(this.autoCompRequest);
+        console.log(predictions);
         this.handlePredictions(predictions, this.requestPrefix);
       });
     });
@@ -237,10 +239,12 @@ export class InputGoogleAutocompleteComponent implements OnInit, OnDestroy, Cont
   }
 
   onInputFocus(): void {
+    console.log('focus');
     this.shouldAutocomplete = true;
   }
 
   onInputBlur(): void {
+    console.log('unfocus');
     this.markAsTouched();
     this.shouldAutocomplete = false;
   }

--- a/src/app/ubs/shared/components/address-input/address-input.component.html
+++ b/src/app/ubs/shared/components/address-input/address-input.component.html
@@ -131,7 +131,7 @@
       [readonly]="isUneditableStatus"
       formControlName="addressComment"
       placeholder="{{ 'personal-info.pop-up-comment-placeholder' | translate }}"
-      (change)="onCommentChange()"
+      (input)="onCommentChange()"
       ngDefaultControl
     ></textarea>
     <div *ngIf="isErrorMessageShown(addressComment)">

--- a/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-tariffs/ubs-admin-tariffs-location-pop-up/ubs-admin-tariffs-location-pop-up.component.ts
@@ -51,13 +51,13 @@ export class UbsAdminTariffsLocationPopUpComponent implements OnInit, AfterViewC
 
   regionOptions = {
     types: ['administrative_area_level_1'],
-    componentRestrictions: { country: 'UK' },
+    componentRestrictions: { country: 'ua' },
     input: ''
   };
 
   cityOptions = {
     types: ['(cities)'],
-    componentRestrictions: { country: 'UK' },
+    componentRestrictions: { country: 'ua' },
     input: ''
   };
 

--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -656,7 +656,7 @@
     "status": {
       "READ": "Read",
       "UNREAD": "Unread",
-      "EDITED": "Edited {{editDate}} at {{editTime}}"
+      "EDITED": "Edited {{editDateTime}}"
     },
     "edit-message": "Edit message",
     "edit-option": "Edit"

--- a/src/assets/i18n/ubs-admin/en.json
+++ b/src/assets/i18n/ubs-admin/en.json
@@ -648,8 +648,11 @@
     "no-file-chosen": "No file chosen",
     "status": {
       "READ": "Read",
-      "UNREAD": "Unread"
-    }
+      "UNREAD": "Unread",
+      "EDITED": "Edited {{editDate}} at {{editTime}}"
+    },
+    "edit-message": "Edit message",
+    "edit-option": "Edit"
   },
   "ubs-employee": {
     "add-employee": "Add employee",

--- a/src/assets/i18n/ubs-admin/uk.json
+++ b/src/assets/i18n/ubs-admin/uk.json
@@ -646,8 +646,11 @@
     "no-file-chosen": "Файл не обрано",
     "status": {
       "READ": "Прочитано",
-      "UNREAD": "Не прочитано"
-    }
+      "UNREAD": "Не прочитано",
+      "EDITED": "Змінено {{editDate}} о {{editTime}}"
+    },
+    "edit-message": "Редагувати повідомлення",
+    "edit-option": "Редагувати"
   },
   "ubs-employee": {
     "add-employee": "Додати працівника",

--- a/src/assets/i18n/ubs-admin/uk.json
+++ b/src/assets/i18n/ubs-admin/uk.json
@@ -655,7 +655,7 @@
     "status": {
       "READ": "Прочитано",
       "UNREAD": "Не прочитано",
-      "EDITED": "Змінено {{editDate}} о {{editTime}}"
+      "EDITED": "Змінено {{editDateTime}}"
     },
     "edit-message": "Редагувати повідомлення",
     "edit-option": "Редагувати"


### PR DESCRIPTION
[#3872](https://github.com/ita-social-projects/GreenCityClient/issues/3872)
Added the ability to edit the admin's text messages. A drop-down with edit information and an "Edit" button is shown on the right mouse click or finger hold on the mobile version.

[#9055](https://github.com/ita-social-projects/GreenCity/issues/9055)
Fixed the button being disabled till unfocused.

Fixed the inability to add a location for the tariffs page by changing "UK" to "ua" in the country restriction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message editing: Users can now edit previously sent chat messages
  * Context menu for accessing message edit options
  * Edit preview panel displays message content before saving changes
  * Edited message indicator shows when messages have been modified

* **Bug Fixes**
  * Address comment input now updates on each keystroke instead of on blur

* **Chores**
  * Updated location autocomplete defaults to Ukraine
<!-- end of auto-generated comment: release notes by coderabbit.ai -->