### PR TITLE
bugfix/ fixed filename display and file download

### DIFF
--- a/src/app/chat/facade/chat-facade.spec.ts
+++ b/src/app/chat/facade/chat-facade.spec.ts
@@ -257,7 +257,7 @@ describe('ChatFacade', () => {
     expect(urlSpy).not.toHaveBeenCalled();
   });
 
-  it('sendMessage appends with image preview when file provided', () => {
+  it('sendMessage appends with image preview when image provided', () => {
     (facade as any).selectedChat.set({
       nickname: 'N',
       initial: 'N',
@@ -282,6 +282,60 @@ describe('ChatFacade', () => {
     expect(last.images).toEqual(['blob://preview']);
     expect(urlSpy).toHaveBeenCalled();
   });
+
+  it('sendMessage appends with file preview when file provided', () => {
+    (facade as any).selectedChat.set({
+      nickname: 'N',
+      initial: 'N',
+      chatId: '1',
+      chatInternalId: 1,
+      lastMessage: '',
+      time: '',
+      messages: []
+    });
+    api.sendMessage.and.returnValue(of('ok' as any));
+    const file = new File([new Blob(['a'])], 'a.pdf', { type: 'application/pdf' });
+    const urlSpy = spyOn(URL, 'createObjectURL').and.returnValue('blob://preview');
+
+    facade.sendMessage('with file', file);
+
+    const sel = facade.selectedChat();
+    expect(sel).toBeTruthy();
+    if (!sel) {
+      throw new Error('expected selected chat');
+    }
+    const last = sel.messages[sel.messages.length - 1];
+    expect(last.fileUrl).toEqual('blob://preview');
+    expect(last.fileName).toEqual('a.pdf');
+    expect(urlSpy).toHaveBeenCalled();
+  });
+
+  it('sendMessage does not append with preview when no image or file provided', () => {
+    (facade as any).selectedChat.set({
+      nickname: 'N',
+      initial: 'N',
+      chatId: '1',
+      chatInternalId: 1,
+      lastMessage: '',
+      time: '',
+      messages: []
+    });
+    api.sendMessage.and.returnValue(of('ok' as any));
+    const urlSpy = spyOn(URL, 'createObjectURL');
+
+    facade.sendMessage('no file');
+
+    const sel = facade.selectedChat();
+    expect(sel).toBeTruthy();
+    if (!sel) {
+      throw new Error('expected selected chat');
+    }
+    const last = sel.messages[sel.messages.length - 1];
+    expect(last.fileUrl).toBeFalsy();
+    expect(last.fileName).toBeFalsy();
+    expect(urlSpy).not.toHaveBeenCalled();
+  });
+
   describe('resolveInternalId (private)', () => {
     it('returns id when present', () => {
       const res = (facade as any).resolveInternalId({ id: 123, foo: 'bar' });

--- a/src/app/chat/facade/chat.facade.ts
+++ b/src/app/chat/facade/chat.facade.ts
@@ -314,8 +314,8 @@ export class ChatFacade {
     this.api.sendMessage(sel.chatInternalId, text.trim(), file).subscribe({
       next: () => {
         const time = formatTimeOrDate(new Date().toISOString());
-        const imagePreview = file && file.type.startsWith('image/') ? URL.createObjectURL(file) : null;
-        const filePreview = file && !file.type.startsWith('image/') ? URL.createObjectURL(file) : null;
+        const imagePreview = file && file.type?.startsWith('image/') ? URL.createObjectURL(file) : null;
+        const filePreview = file && !file.type?.startsWith('image/') ? URL.createObjectURL(file) : null;
 
         sel.messages.push({
           from: 'Me',
@@ -323,7 +323,7 @@ export class ChatFacade {
           time,
           images: imagePreview ? [imagePreview] : [],
           fileUrl: filePreview,
-          fileName: file ? file.name : null,
+          fileName: filePreview ? file.name : null,
           viewingStatus: null
         });
         sel.lastMessage = text.trim();

--- a/src/app/chat/facade/chat.facade.ts
+++ b/src/app/chat/facade/chat.facade.ts
@@ -158,7 +158,7 @@ export class ChatFacade {
     this.location.replaceState(newPath);
   }
 
-  selectChatById(chatInternalId: number) { 
+  selectChatById(chatInternalId: number) {
     const chat = this.chats().find((c) => c.chatInternalId === chatInternalId);
     if (chat) {
       this.selectChat(chat);
@@ -314,13 +314,16 @@ export class ChatFacade {
     this.api.sendMessage(sel.chatInternalId, text.trim(), file).subscribe({
       next: () => {
         const time = formatTimeOrDate(new Date().toISOString());
-        const imagePreview = file ? URL.createObjectURL(file) : null;
+        const imagePreview = file && file.type.startsWith('image/') ? URL.createObjectURL(file) : null;
+        const filePreview = file && !file.type.startsWith('image/') ? URL.createObjectURL(file) : null;
 
         sel.messages.push({
           from: 'Me',
           text: text.trim(),
           time,
           images: imagePreview ? [imagePreview] : [],
+          fileUrl: filePreview,
+          fileName: file ? file.name : null,
           viewingStatus: null
         });
         sel.lastMessage = text.trim();

--- a/src/app/chat/facade/chat.facade.ts
+++ b/src/app/chat/facade/chat.facade.ts
@@ -314,8 +314,8 @@ export class ChatFacade {
     this.api.sendMessage(sel.chatInternalId, text.trim(), file).subscribe({
       next: () => {
         const time = formatTimeOrDate(new Date().toISOString());
-        const imagePreview = file && file.type?.startsWith('image/') ? URL.createObjectURL(file) : null;
-        const filePreview = file && !file.type?.startsWith('image/') ? URL.createObjectURL(file) : null;
+        const imagePreview = file?.type?.startsWith('image/') ? URL.createObjectURL(file) : null;
+        const filePreview = file && !imagePreview ? URL.createObjectURL(file) : null;
 
         sel.messages.push({
           from: 'Me',

--- a/src/app/chat/ui/message-input/message-input.component.html
+++ b/src/app/chat/ui/message-input/message-input.component.html
@@ -38,6 +38,6 @@
       <span>{{ 'chat.attach-file' | translate }}</span>
       <input type="file" (change)="onFileSelected($event)" hidden #fileInput />
     </label>
-    <span class="file-name"> {{ 'chat.no-file-chosen' | translate }}</span>
+    <span class="file-name"> {{ file ? file.name : ('chat.no-file-chosen' | translate) }}</span>
   </div>
 </div>

--- a/src/app/chat/ui/messages-list/messages-list.component.html
+++ b/src/app/chat/ui/messages-list/messages-list.component.html
@@ -9,7 +9,7 @@
     </div>
 
     <div class="message-file" *ngIf="message.fileUrl">
-      <a [href]="message.fileUrl" target="_blank" rel="noopener noreferrer" class="file-link">
+      <a [href]="message.fileUrl" target="_blank" rel="noopener noreferrer" class="file-link" download>
         📎 {{ message.fileName || 'Download file' }}
       </a>
     </div>


### PR DESCRIPTION
[#9133](https://github.com/ita-social-projects/GreenCity/issues/9133)

<img width="1658" height="265" alt="image" src="https://github.com/user-attachments/assets/d66c2573-3790-4246-b5c9-86d89d7a8708" />
Fixed file name display near the "Attach file" button. 
Fixed file name and download link display on the message list. Now, the preview link isn't used as an image link. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-image attachments now include a file preview URL and displayed file name.
  * Message file links support direct browser downloads.

* **Bug Fixes**
  * Image previews generated only for image files; non-image files no longer show image previews.
  * Message input shows the selected file’s name instead of always showing “no file chosen.”

* **Tests**
  * Added tests covering sendMessage for image attachments, non-image attachments, and no attachment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->