### PR TITLE
Bugfix/7432 buttons in order status filter displayed incorrect

### DIFF
--- a/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.html
+++ b/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.html
@@ -1,13 +1,4 @@
 <ng-container class="dropdown-menu">
-  <div class="btn-group" *ngIf="showButtons">
-    <button type="button" class="btn filter-btn" (click)="discardChanges()">
-      {{ 'ubs-tables.clear-filters' | translate }}
-    </button>
-    <button type="button" class="btn filter-btn bg-lime" [mat-dialog-close]="['apply']">
-      {{ 'ubs-tables.apply-filters' | translate }}
-    </button>
-  </div>
-
   <ng-container *ngIf="!data.isDateFilter; else date">
     <input
       *ngIf="isLocationColumn"
@@ -74,4 +65,13 @@
       </div>
     </div>
   </ng-template>
+
+  <div class="btn-group">
+    <button type="button" [disabled]="disableButtons" class="btn filter-btn" (click)="discardChanges()">
+      {{ 'ubs-tables.clear-filters' | translate }}
+    </button>
+    <button type="button" [disabled]="disableButtons" class="btn filter-btn bg-lime" [mat-dialog-close]="['apply']">
+      {{ 'ubs-tables.apply-filters' | translate }}
+    </button>
+  </div>
 </ng-container>

--- a/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.scss
+++ b/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.scss
@@ -2,6 +2,7 @@
   width: 140px;
   border: 1px solid var(--ubs-quaternary-dark-grey);
   border-radius: 4px !important;
+  background-color: var(--ubs-primary-white);
 }
 
 .search-input {
@@ -10,6 +11,10 @@
 
 .btn-group {
   gap: 7px;
+  position: sticky;
+  bottom: 0;
+  padding-bottom: 10px;
+  background-color: var(--ubs-primary-white);
 }
 
 .bg-lime {
@@ -45,4 +50,12 @@ input[type='date'] {
   border: none;
   cursor: pointer;
   margin-left: 18px;
+}
+
+::ng-deep .dropdown-menu {
+  .mat-mdc-dialog-surface {
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding-bottom: 0px;
+  }
 }

--- a/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.scss
+++ b/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.scss
@@ -54,8 +54,7 @@ input[type='date'] {
 
 ::ng-deep .dropdown-menu {
   .mat-mdc-dialog-surface {
-    overflow-x: hidden;
-    overflow-y: auto;
-    padding-bottom: 0px;
+    overflow: hidden auto;
+    padding-bottom: 0;
   }
 }

--- a/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.spec.ts
+++ b/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.spec.ts
@@ -84,14 +84,14 @@ describe('ColumnFiltersPopUpComponent', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it('should set showButtons to true and call setNewFilters on filter change', () => {
+  it('should set disableButton to false and call setNewFilters on filter change', () => {
     const checked = true;
     const currentColumn = 'testColumn';
     const option = { en: 'Option En', key: 'optionKey' };
 
     component.onFilterChange(checked, currentColumn, option);
 
-    expect(component.showButtons).toBeTrue();
+    expect(component.disableButtons).toBeFalse();
     expect(fakeAdminTableService.setNewFilters).toHaveBeenCalledWith(checked, currentColumn, option);
   });
 
@@ -120,7 +120,7 @@ describe('ColumnFiltersPopUpComponent', () => {
 
     component.onDateChange();
 
-    expect(component.showButtons).toBeTrue();
+    expect(component.disableButtons).toBeFalse();
     expect(fakeAdminTableService.swapDatesIfNeeded).toHaveBeenCalledWith(dateFrom, dateTo, component.dateChecked);
     expect(fakeAdminTableService.setDateFormat).toHaveBeenCalledWith(dateFrom);
     expect(fakeAdminTableService.setDateFormat).toHaveBeenCalledWith(dateTo);

--- a/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.ts
+++ b/src/app/ubs/ubs-admin/components/shared/components/column-filters-pop-up/column-filters-pop-up.component.ts
@@ -41,7 +41,7 @@ export class ColumnFiltersPopUpComponent implements OnInit, OnDestroy {
 
   searchTerm = '';
   isPopupOpened = false;
-  showButtons = false;
+  disableButtons = true;
   selectedFiltersCount = 0;
 
   private allFilters: IFilters;
@@ -64,7 +64,7 @@ export class ColumnFiltersPopUpComponent implements OnInit, OnDestroy {
     });
     this.setPopupPosUnderButton();
     this.initListeners();
-    this.showButtons = false;
+    this.disableButtons = true;
 
     this.isLocationColumn = columnsToFilterByName.includes(this.data.columnName);
     this.isLocationColumn ? this.getLocationsForFiltering() : this.getOptionsForFiltering();
@@ -148,7 +148,7 @@ export class ColumnFiltersPopUpComponent implements OnInit, OnDestroy {
   }
 
   onFilterChange(checked: boolean, currentColumn: string, option: IFilteredColumnValue): void {
-    this.showButtons = true;
+    this.disableButtons = false;
     this.adminTableService.setNewFilters(checked, currentColumn, option);
   }
 
@@ -158,7 +158,7 @@ export class ColumnFiltersPopUpComponent implements OnInit, OnDestroy {
   }
 
   onDateChange(): void {
-    this.showButtons = true;
+    this.disableButtons = false;
     const swappedDates = this.adminTableService.swapDatesIfNeeded(this.dateFrom, this.dateTo, this.dateChecked);
 
     this.dateFrom = swappedDates ? swappedDates.dateFrom : this.dateFrom;

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.html
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.html
@@ -28,7 +28,7 @@
           <div class="dropdown-menu-container">
             <div class="sticky-top dropdown-top-panel">
               <p class="font-weight-bold">{{ 'ubs-tables.filter' | translate }}</p>
-              <button type="button" class="reset-settings" (click)="toggleFilters()">
+              <button type="button" class="reset-settings close-btn" (click)="toggleFilters()">
                 <i class="fa fa-close" aria-hidden="true"></i>
               </button>
             </div>
@@ -190,7 +190,7 @@
                   {{ 'ubs-tables.all-elements' | translate }}
                 </mat-checkbox>
               </div>
-              <button type="button" class="reset-settings" (click)="toggleTableView()">
+              <button type="button" class="reset-settings close-btn" (click)="toggleTableView()">
                 <i class="fa fa-close" aria-hidden="true"></i>
               </button>
             </div>

--- a/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.scss
+++ b/src/app/ubs/ubs-admin/components/ubs-admin-table/ubs-admin-table.component.scss
@@ -734,3 +734,9 @@ mat-spinner {
     }
   }
 }
+
+.close-btn {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+}


### PR DESCRIPTION
https://github.com/ita-social-projects/GreenCity/issues/7432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Filter dialog buttons are now always visible and clearly indicate availability: Apply and Clear remain disabled until changes are made.
  - Improved dropdown behavior in the filter dialog with better scrolling for long content.

- Style
  - Added sticky action bar at the bottom of the filter dialog with a clean white background for consistent visibility.
  - Introduced top-right positioned close buttons in table filter and view menus for easier access.
  - Unified button styling in filter dialogs for a more polished look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->