### PR TITLE
Feature/continue existing payment

### DIFF
--- a/src/app/shared/components/dialog-pop-up/dialog-pop-up.component.ts
+++ b/src/app/shared/components/dialog-pop-up/dialog-pop-up.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { PopUpsStyles } from 'src/app/ubs/ubs-admin/components/ubs-admin-employee/ubs-admin-employee-table/employee-models.enum';
@@ -23,7 +23,7 @@ export class DialogPopUpComponent implements OnInit, OnDestroy {
   setBtnStyleGreen: boolean;
   setBtnStyleLightGreen: boolean;
   isItrefund = false;
-  іsPermissionConfirm = false;
+  isPermissionConfirm = false;
   isCancelButtonShow = false;
   isEditOrPayPopup?: boolean;
 
@@ -51,7 +51,7 @@ export class DialogPopUpComponent implements OnInit, OnDestroy {
       .subscribe(() => {
         this.userReply(this.isEditOrPayPopup ? undefined : false);
       });
-    this.isCancelButtonShow = !this.isItrefund || !this.іsPermissionConfirm;
+    this.isCancelButtonShow = !this.isItrefund || !this.isPermissionConfirm;
   }
 
   private setTitles(): void {
@@ -64,7 +64,7 @@ export class DialogPopUpComponent implements OnInit, OnDestroy {
     this.setBtnStyleRed = this.data.style === PopUpsStyles.red;
     this.setBtnStyleLightGreen = this.data.style === PopUpsStyles.lightGreen;
     this.isItrefund = this.data.isItrefund;
-    this.іsPermissionConfirm = this.data.іsPermissionConfirm;
+    this.isPermissionConfirm = this.data.isPermissionConfirm;
   }
 
   userReply(reply: boolean | undefined): void {

--- a/src/app/ubs/mocks/order-data-mock.ts
+++ b/src/app/ubs/mocks/order-data-mock.ts
@@ -1,6 +1,5 @@
 import { IUserOrderInfo } from '@ubs/ubs-user/components/ubs-user-orders-list/models/UserOrder.interface';
 import { CourierLocations, OrderDetails, PersonalData } from '@ubs/ubs/models/ubs.interface';
-import { OrderStatus } from '@ubs/ubs/order-status.enum';
 
 export const ubsOrderServiseMock = {
   orderDetails: null,
@@ -150,6 +149,7 @@ export const fakeInputOrderData: IUserOrderInfo = {
   paidAmount: 1100,
   paymentStatusUk: 'Оплачено',
   paymentStatusEn: 'Paid',
+  paymentLink: null,
   sender: {
     senderEmail: 'm.kovalushun@gmail.com',
     senderName: 'Mykola',

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/models/IOrderData.interface.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/models/IOrderData.interface.ts
@@ -5,4 +5,5 @@ export interface IOrderData {
   price: number;
   orders?: IOrderInfo[];
   bonuses: number;
+  hasLink?: boolean;
 }

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/models/UserOrder.interface.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/models/UserOrder.interface.ts
@@ -16,6 +16,7 @@ export interface IUserOrderInfo {
   paidAmount: number;
   paymentStatusUk: string;
   paymentStatusEn: string;
+  paymentLink: string;
   sender: IUserInfo;
   refundedBonuses: number;
   refundedMoney: number;

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-order-payment-pop-up/ubs-user-order-payment-pop-up.component.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-order-payment-pop-up/ubs-user-order-payment-pop-up.component.ts
@@ -15,6 +15,8 @@ import { MatRadioChange } from '@angular/material/radio';
 import { IBonusInfo } from '../models/IBonusInfo.interface';
 import { Masks, Patterns } from 'src/assets/patterns/patterns';
 import { IProcessOrderResponse } from 'src/app/ubs/ubs/models/ubs.interface';
+import { first, switchMap } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 @Component({
   selector: 'app-ubs-user-order-payment-pop-up',
@@ -265,19 +267,29 @@ export class UbsUserOrderPaymentPopUpComponent implements OnInit {
     this.localStorageService.setUserPagePayment(true);
 
     if (this.formPaymentSystem.value === 'Liqpay') {
-      this.orderService.processOrderFondyFromUserOrderList(this.orderClientDto).subscribe({
-        next: (response: ResponceOrderFondyModel) => {
-          if (response.link) {
-            this.processWayForPay(response);
-          } else {
-            this.redirectionToConfirmPage();
-            this.dialogRef.close();
+      of(this.data.hasLink)
+        .pipe(
+          switchMap((hasLink) => {
+            if (hasLink) {
+              return this.orderService.cancelExistingPayment(this.data.orderId).pipe(first());
+            }
+            return of(null);
+          }),
+          switchMap(() => this.orderService.processOrderFondyFromUserOrderList(this.orderClientDto))
+        )
+        .subscribe({
+          next: (response: ResponceOrderFondyModel) => {
+            if (response.link) {
+              this.processWayForPay(response);
+            } else {
+              this.redirectionToConfirmPage();
+              this.dialogRef.close();
+            }
+          },
+          error: () => {
+            this.dataLoadingLiqPay = false;
           }
-        },
-        error: () => {
-          this.dataLoadingLiqPay = false;
-        }
-      });
+        });
     }
   }
 

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.scss
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.scss
@@ -102,11 +102,10 @@ button {
 
 .btns-group {
   display: flex;
-  flex-direction: row;
+  flex-flow: row wrap;
   align-items: center;
   margin-left: 25px;
   gap: 16px;
-  flex-wrap: wrap;
   justify-content: flex-end;
 }
 

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.scss
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.scss
@@ -31,7 +31,7 @@
 }
 
 .mat-expansion-panel-header {
-  height: 80px;
+  min-height: 80px;
   display: flex;
   flex-direction: row-reverse;
   padding: 0 17px;
@@ -106,6 +106,8 @@ button {
   align-items: center;
   margin-left: 25px;
   gap: 16px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .mobile_list .mobile {

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.spec.ts
@@ -228,7 +228,8 @@ describe('UbsUserOrdersListComponent', () => {
         data: {
           orderId: 7,
           price: 55,
-          bonuses: 111
+          bonuses: 111,
+          hasLink: false
         },
         autoFocus: true
       });
@@ -261,6 +262,7 @@ describe('UbsUserOrdersListComponent', () => {
       const openOrderPaymentPopUpSpy = spyOn(component as any, 'openOrderPaymentPopUp');
       const editOrPayPopupSpy = spyOn(component, 'editOrPayPopup');
       spyOn(component, 'isOrderUnpaid').and.returnValue(false);
+      spyOn(component, 'isOrderHalfPaid').and.returnValue(false);
 
       component.openOrderPaymentDialog(new Event('click'), fakeInputOrderData[1] as any);
 

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.spec.ts
@@ -28,7 +28,15 @@ describe('UbsUserOrdersListComponent', () => {
   let dialogRefSpy: jasmine.SpyObj<any>;
 
   const fakeInputOrderData = [
-    { id: 3, dateForm: 55, orderStatusEn: 'Done', paymentStatusEn: 'Unpaid', orderFullPrice: 55, amountBeforePayment: 55, extend: true },
+    {
+      id: 3,
+      dateForm: 55,
+      orderStatusEn: 'Done',
+      paymentStatusEn: 'Unpaid',
+      orderFullPrice: 55,
+      amountBeforePayment: 55,
+      extend: true
+    },
     {
       id: 7,
       dateForm: 66,
@@ -435,7 +443,10 @@ describe('UbsUserOrdersListComponent', () => {
       component.editOrPayPopup(fakeInputOrderData[1] as any);
       tick();
 
-      expect(matDialogMock.open).toHaveBeenCalledWith(DialogPopUpComponent, { data: component.editOrPayDialogData, autoFocus: true });
+      expect(matDialogMock.open).toHaveBeenCalledWith(DialogPopUpComponent, {
+        data: component.editOrPayDialogData,
+        autoFocus: true
+      });
 
       expect(component.editOrPayDialogData).toBeDefined();
       expect(matDialogMock.open).toHaveBeenCalled();

--- a/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-orders-list/ubs-user-orders-list.component.ts
@@ -4,9 +4,9 @@ import { Router } from '@angular/router';
 import { LocalStorageService } from 'src/app/shared/services/localstorage/local-storage.service';
 import { forkJoin, Observable, Subject } from 'rxjs';
 import { takeUntil, tap } from 'rxjs/operators';
-import { Bag, OrderDetails, PersonalData } from '../../../ubs/models/ubs.interface';
-import { OrderService } from '../../../ubs/services/order.service';
-import { UBSOrderFormService } from '../../../ubs/services/ubs-order-form.service';
+import { Bag, OrderDetails, PersonalData } from '@ubs/ubs/models/ubs.interface';
+import { OrderService } from '@ubs/ubs/services/order.service';
+import { UBSOrderFormService } from '@ubs/ubs/services/ubs-order-form.service';
 import { IUserOrderInfo, OrderStatusEn, PaymentStatusEn } from './models/UserOrder.interface';
 import { UbsUserOrderCancelPopUpComponent } from './ubs-user-order-cancel-pop-up/ubs-user-order-cancel-pop-up.component';
 import { UbsUserOrderPaymentPopUpComponent } from './ubs-user-order-payment-pop-up/ubs-user-order-payment-pop-up.component';
@@ -111,7 +111,8 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
       data: {
         orderId: order.id,
         price: order.amountBeforePayment,
-        bonuses: this.bonuses
+        bonuses: this.bonuses,
+        hasLink: !!order.paymentLink
       },
       autoFocus: true
     });
@@ -120,7 +121,9 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
   openOrderPaymentDialog(event: Event, order: IUserOrderInfo): void {
     event.stopPropagation();
     const isOrderFormed = order.orderStatusEn === OrderStatusEn.FORMED;
-    this.isOrderUnpaid(order) && isOrderFormed ? this.editOrPayPopup(order) : this.openOrderPaymentPopUp(order);
+    (this.isOrderUnpaid(order) || this.isOrderHalfPaid(order)) && isOrderFormed
+      ? this.editOrPayPopup(order)
+      : this.openOrderPaymentPopUp(order);
     this.orderService.cleanOrderState();
   }
 
@@ -130,10 +133,18 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
       .afterClosed()
       .subscribe((res) => {
         if (res) {
-          this.openOrderPaymentPopUp(order);
+          if (order.paymentLink) {
+            window.location.href = order.paymentLink;
+          } else {
+            this.openOrderPaymentPopUp(order);
+          }
         }
         if (res === false) {
-          this.getDataForLocalStorage(order);
+          if (this.isOrderHalfPaid(order) && order.paymentLink) {
+            this.openOrderPaymentPopUp(order);
+          } else {
+            this.getDataForLocalStorage(order);
+          }
         }
       });
   }
@@ -186,8 +197,7 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
     forkJoin([orderDataRequest, personalDataRequest]).subscribe(() => {
       this.bags = orderDataResponse.bags || [];
       this.bags.forEach((item) => {
-        const bagsQuantity = this.getBagsQuantity(item.nameUk, item.capacity, order);
-        item.quantity = bagsQuantity;
+        item.quantity = this.getBagsQuantity(item.nameUk, item.capacity, order);
       });
 
       this.orderDetails = {
@@ -200,7 +210,8 @@ export class UbsUserOrdersListComponent implements OnInit, OnDestroy {
         points: this.bonuses,
         pointsSum: 0,
         pointsToUse: 0,
-        total: order.orderFullPrice
+        total: order.orderFullPrice,
+        hasPaymentLink: !!order.paymentLink
       };
 
       this.personalDetails = personalDataResponse;

--- a/src/app/ubs/ubs/components/ubs-submit-order/ubs-submit-order.component.ts
+++ b/src/app/ubs/ubs/components/ubs-submit-order/ubs-submit-order.component.ts
@@ -113,10 +113,11 @@ export class UBSSubmitOrderComponent extends FormBaseComponent implements OnInit
   }
 
   processOrder(shouldBePaid: boolean = true): void {
+    const hasLink = JSON.parse(localStorage.getItem('UBSorderData'))?.hasPaymentLink || false;
     this.isLoadingAnim = true;
     iif(
       () => this.existingOrderId >= 0,
-      this.orderService.processExistingOrder(this.getOrder(shouldBePaid), this.existingOrderId),
+      this.orderService.processExistingOrder(this.getOrder(shouldBePaid), this.existingOrderId, hasLink),
       this.orderService.processNewOrder(this.getOrder(shouldBePaid))
     )
       .pipe(

--- a/src/app/ubs/ubs/models/ubs.interface.ts
+++ b/src/app/ubs/ubs/models/ubs.interface.ts
@@ -45,6 +45,7 @@ export interface OrderDetails {
   total?: number;
   finalSum?: number;
   minAmountOfBigBags?: number;
+  hasPaymentLink?: boolean;
 }
 
 export interface IProcessOrderResponse {

--- a/src/app/ubs/ubs/services/order.service.spec.ts
+++ b/src/app/ubs/ubs/services/order.service.spec.ts
@@ -6,7 +6,7 @@ import { OrderService } from './order.service';
 import { UBSOrderFormService } from './ubs-order-form.service';
 import { OrderClientDto } from '../../ubs-user/components/ubs-user-orders-list/models/OrderClientDto';
 import { ResponceOrderFondyModel } from '../../ubs-user/components/ubs-user-orders-list/models/ResponceOrderFondyModel';
-import { DistrictsDtos, KyivNamesEnum } from '../models/ubs.interface';
+import { DistrictsDtos, KyivNamesEnum, Order } from '../models/ubs.interface';
 import { ADDRESSESMOCK } from '../../mocks/address-mock';
 import { Store, StoreModule } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
@@ -272,5 +272,19 @@ describe('OrderService', () => {
     const region = { nameUk: 'Україна', nameEn: 'Ukraine' };
     const result = service.getLocationName(location, region);
     expect(['Lviv, Ukraine', 'Львів, Україна']).toContain(result);
+  });
+
+  it('should delete existing order if it has paymentLink', () => {
+    spyOn(service, 'cancelExistingPayment').and.returnValue(of({} as any));
+    service.processExistingOrder(bagMock as unknown as Order, 123, true).subscribe();
+    expect(service.cancelExistingPayment).toHaveBeenCalledWith(123);
+  });
+
+  it('should not call cancelExistingPayment if it dont have paymentLink ', () => {
+    spyOn(service, 'cancelExistingPayment').and.returnValue(of({} as any));
+    service.processExistingOrder(bagMock as unknown as Order, 123).subscribe();
+    expect(service.cancelExistingPayment).not.toHaveBeenCalled();
+    const req = httpMock.expectOne(`${baseLink}/processOrder/123`);
+    expect(req.request.method).toBe('POST');
   });
 });

--- a/src/app/ubs/ubs/services/order.service.spec.ts
+++ b/src/app/ubs/ubs/services/order.service.spec.ts
@@ -6,7 +6,7 @@ import { OrderService } from './order.service';
 import { UBSOrderFormService } from './ubs-order-form.service';
 import { OrderClientDto } from '../../ubs-user/components/ubs-user-orders-list/models/OrderClientDto';
 import { ResponceOrderFondyModel } from '../../ubs-user/components/ubs-user-orders-list/models/ResponceOrderFondyModel';
-import { DistrictsDtos, IProcessOrderResponse, KyivNamesEnum, Order } from '../models/ubs.interface';
+import { DistrictsDtos, KyivNamesEnum, Order } from '../models/ubs.interface';
 import { ADDRESSESMOCK } from '../../mocks/address-mock';
 import { Store, StoreModule } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
@@ -286,7 +286,7 @@ describe('OrderService', () => {
     });
   });
 
-  it('should not call cancelExistingPayment if it dont have paymentLink ', (done) => {
+  it('should not call cancelExistingPayment if it doesnt have paymentLink ', (done) => {
     spyOn(service, 'cancelExistingPayment').and.returnValue(of(null));
     spyOn(service['http'], 'post').and.returnValue(of({}));
 
@@ -298,18 +298,18 @@ describe('OrderService', () => {
     });
   });
 
-  it('should post cancelPaymentAttempt', () => {
+  it('should post cancelPaymentAttempt', (done) => {
     const orderId = 123;
     const mockResponse = { success: true } as any;
 
-    let resp: IProcessOrderResponse | undefined;
-    service.cancelExistingPayment(orderId).subscribe((r) => (resp = r));
+    service.cancelExistingPayment(orderId).subscribe((resp) => {
+      expect(resp).toEqual(mockResponse);
+      done();
+    });
 
     const req = httpMock.expectOne(`${service['url']}/cancelPaymentAttempt/${orderId}`);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({});
-
     req.flush(mockResponse);
-    expect(resp).toEqual(mockResponse);
   });
 });

--- a/src/app/ubs/ubs/services/order.service.spec.ts
+++ b/src/app/ubs/ubs/services/order.service.spec.ts
@@ -1,12 +1,12 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { environment } from '@environment/environment';
-import { fakeAsync, flush, TestBed } from '@angular/core/testing';
-import { Subject, of } from 'rxjs';
+import { fakeAsync, TestBed } from '@angular/core/testing';
+import { of, Subject } from 'rxjs';
 import { OrderService } from './order.service';
 import { UBSOrderFormService } from './ubs-order-form.service';
 import { OrderClientDto } from '../../ubs-user/components/ubs-user-orders-list/models/OrderClientDto';
 import { ResponceOrderFondyModel } from '../../ubs-user/components/ubs-user-orders-list/models/ResponceOrderFondyModel';
-import { DistrictsDtos, KyivNamesEnum, Order } from '../models/ubs.interface';
+import { DistrictsDtos, IProcessOrderResponse, KyivNamesEnum, Order } from '../models/ubs.interface';
 import { ADDRESSESMOCK } from '../../mocks/address-mock';
 import { Store, StoreModule } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
@@ -274,17 +274,42 @@ describe('OrderService', () => {
     expect(['Lviv, Ukraine', 'Львів, Україна']).toContain(result);
   });
 
-  it('should delete existing order if it has paymentLink', () => {
-    spyOn(service, 'cancelExistingPayment').and.returnValue(of({} as any));
-    service.processExistingOrder(bagMock as unknown as Order, 123, true).subscribe();
-    expect(service.cancelExistingPayment).toHaveBeenCalledWith(123);
+  it('should delete existing order if it has paymentLink', (done) => {
+    spyOn(service, 'cancelExistingPayment').and.returnValue(of(null));
+    spyOn(service['http'], 'post').and.returnValue(of({}));
+
+    service.processExistingOrder(bagMock as unknown as Order, 123, true).subscribe({
+      next: () => {
+        expect(service.cancelExistingPayment).toHaveBeenCalledWith(123);
+        done();
+      }
+    });
   });
 
-  it('should not call cancelExistingPayment if it dont have paymentLink ', () => {
-    spyOn(service, 'cancelExistingPayment').and.returnValue(of({} as any));
-    service.processExistingOrder(bagMock as unknown as Order, 123).subscribe();
-    expect(service.cancelExistingPayment).not.toHaveBeenCalled();
-    const req = httpMock.expectOne(`${baseLink}/processOrder/123`);
+  it('should not call cancelExistingPayment if it dont have paymentLink ', (done) => {
+    spyOn(service, 'cancelExistingPayment').and.returnValue(of(null));
+    spyOn(service['http'], 'post').and.returnValue(of({}));
+
+    service.processExistingOrder(bagMock as unknown as Order, 123).subscribe({
+      next: () => {
+        expect(service.cancelExistingPayment).not.toHaveBeenCalled();
+        done();
+      }
+    });
+  });
+
+  it('should post cancelPaymentAttempt', () => {
+    const orderId = 123;
+    const mockResponse = { success: true } as any;
+
+    let resp: IProcessOrderResponse | undefined;
+    service.cancelExistingPayment(orderId).subscribe((r) => (resp = r));
+
+    const req = httpMock.expectOne(`${service['url']}/cancelPaymentAttempt/${orderId}`);
     expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({});
+
+    req.flush(mockResponse);
+    expect(resp).toEqual(mockResponse);
   });
 });

--- a/src/app/ubs/ubs/services/order.service.ts
+++ b/src/app/ubs/ubs/services/order.service.ts
@@ -1,23 +1,23 @@
 import { LocalStorageService } from 'src/app/shared/services/localstorage/local-storage.service';
 import {
+  ActiveCourierDto,
   Address,
   AddressData,
+  AllActiveLocationsDtosResponse,
   AllLocationsDtos,
   CourierLocations,
-  ActiveCourierDto,
   DistrictEnum,
-  ICertificateResponse,
-  OrderDetails,
   DistrictsDtos,
+  ICertificateResponse,
   IProcessOrderResponse,
+  KyivNamesEnum,
   Order,
-  AllActiveLocationsDtosResponse,
-  KyivNamesEnum
+  OrderDetails
 } from '../models/ubs.interface';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, Subject, of, throwError } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, of, Subject, throwError } from 'rxjs';
+import { first, map, switchMap } from 'rxjs/operators';
 import { environment } from '@environment/environment';
 import { UBSOrderFormService } from './ubs-order-form.service';
 import { OrderClientDto } from '@ubs/ubs-user/components/ubs-user-orders-list/models/OrderClientDto';
@@ -77,7 +77,15 @@ export class OrderService {
       : this.getLocations(courierId, false).pipe(map((allLocations) => allLocations[0].locations[0].locationId));
   }
 
-  getLocationName(location: { nameUk: string; nameEn: string } | string, region: { nameUk: string; nameEn: string } | string): string {
+  getLocationName(
+    location: { nameUk: string; nameEn: string } | string,
+    region:
+      | {
+          nameUk: string;
+          nameEn: string;
+        }
+      | string
+  ): string {
     const locationName = this.getName(location);
     const regionName = this.getName(region);
 
@@ -117,8 +125,20 @@ export class OrderService {
     return this.http.post<IProcessOrderResponse>(`${this.url}/processOrder`, order);
   }
 
-  processExistingOrder(order: Order, orderId: number): Observable<IProcessOrderResponse> {
-    return this.http.post<IProcessOrderResponse>(`${this.url}/processOrder/${orderId}`, order);
+  cancelExistingPayment(id: number): Observable<IProcessOrderResponse> {
+    return this.http.post<IProcessOrderResponse>(`${this.url}/cancelPaymentAttempt/${id}`, {});
+  }
+
+  processExistingOrder(order: Order, orderId: number, hasLink: boolean = false): Observable<IProcessOrderResponse> {
+    return of(hasLink).pipe(
+      switchMap((hasLink) => {
+        if (hasLink) {
+          return this.cancelExistingPayment(orderId).pipe(first());
+        }
+        return of(null);
+      }),
+      switchMap(() => this.http.post<IProcessOrderResponse>(`${this.url}/processOrder/${orderId}`, order))
+    );
   }
 
   processCertificate(certificate): Observable<ICertificateResponse> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Orders now include and persist external payment links; payment dialogs reflect link state and can redirect users.
  - Reprocessing an order can cancel prior payment attempts first for clean retries; payment flows use the link flag when routing.

- Bug Fixes
  - Fixed confirmation dialog permission/ cancel-button behavior.
  - Half-paid orders now follow the same edit/pay flow as unpaid.

- Style
  - Improved order list layout: taller header and wrapped, right-aligned action buttons.

- Tests
  - Added/updated tests for payment cancellation and dialog data including link flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->