### PR TITLE
Feature/updates for separated user status

### DIFF
--- a/src/app/main/component/auth/components/restore-password/restore-password.component.ts
+++ b/src/app/main/component/auth/components/restore-password/restore-password.component.ts
@@ -147,7 +147,7 @@ export class RestorePasswordComponent implements OnInit, OnDestroy, OnChanges {
 
   handleGoogleAuth(resp): void {
     try {
-      this.googleService.signIn(resp.credential).subscribe((signInData: UserSuccessSignIn) => {
+      this.googleService.signIn(resp.credential, this.isUbs).subscribe((signInData: UserSuccessSignIn) => {
         this.onSignInWithGoogleSuccess(signInData);
       });
     } catch (errors) {

--- a/src/app/main/component/auth/components/sign-in/sign-in.component.ts
+++ b/src/app/main/component/auth/components/sign-in/sign-in.component.ts
@@ -49,7 +49,8 @@ export class SignInComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.signInForm = new FormGroup({
       email: new FormControl('', [Validators.required, Validators.pattern(Patterns.ubsMailPattern)]),
-      password: new FormControl('', [Validators.required, Validators.minLength(8), Validators.maxLength(20)])
+      password: new FormControl('', [Validators.required, Validators.minLength(8), Validators.maxLength(20)]),
+      projectName: new FormControl(this.isUbs ? 'PICKUP' : 'GREENCITY')
     });
 
     this.initGooglePopup();

--- a/src/app/main/component/auth/components/sign-up/sign-up.component.ts
+++ b/src/app/main/component/auth/components/sign-up/sign-up.component.ts
@@ -1,8 +1,8 @@
 import { Patterns } from 'src/assets/patterns/patterns';
-import { UserSuccessSignIn, SuccessSignUpDto } from 'src/app/shared/models/singIn-singUp/user-success-sign-in';
+import { SuccessSignUpDto, UserSuccessSignIn } from 'src/app/shared/models/singIn-singUp/user-success-sign-in';
 import { UserOwnSignUp } from 'src/app/shared/models/singIn-singUp/user-own-sign-up';
 import { authImages } from 'src/app/shared/image-paths/auth-images';
-import { Component, EventEmitter, OnInit, OnDestroy, Output, OnChanges, Input } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output } from '@angular/core';
 import { AbstractControl, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -14,12 +14,11 @@ import { GoogleSignInService } from 'src/app/shared/services/auth/google-sign-in
 import { UserOwnSignInService } from 'src/app/shared/services/auth/user-own-sign-in.service';
 import { UserOwnSignUpService } from 'src/app/shared/services/auth/user-own-sign-up.service';
 import { LocalStorageService } from 'src/app/shared/services/localstorage/local-storage.service';
-import { environment } from '@environment/environment';
-import { accounts } from 'google-one-tap';
 import { googleProvider } from '@global-auth/sign-in/GoogleOAuthProvider/GoogleOAuthProvider';
 import { MatSnackBarService } from '@global-service/mat-snack-bar/mat-snack-bar.service';
 
 declare let google: any;
+
 @Component({
   selector: 'app-sign-up',
   templateUrl: './sign-up.component.html',
@@ -134,7 +133,7 @@ export class SignUpComponent implements OnInit, OnDestroy, OnChanges {
   handleGoogleAuth(resp): void {
     try {
       this.googleService
-        .signIn(resp, this.currentLanguage)
+        .signIn(resp, this.isUbs, this.currentLanguage)
         .pipe(takeUntil(this.destroy))
         .subscribe((successData) => this.signUpWithGoogleSuccess(successData));
     } catch (errorData) {

--- a/src/app/main/links.ts
+++ b/src/app/main/links.ts
@@ -22,6 +22,7 @@ export const googleSecurityLink = mainUserLink + 'googleSecurity';
 // User Controller
 export const userLink = mainUserLink + 'user';
 
+export const greenCityUserLink = mainLink + 'users';
 export const categoryLink = mainLink + 'category';
 export const placeLink = mainLink + 'place/';
 export const favoritePlaceLink = mainLink + 'favorite_place/';

--- a/src/app/shared/interceptors/interceptor.service.spec.ts
+++ b/src/app/shared/interceptors/interceptor.service.spec.ts
@@ -315,7 +315,7 @@ describe('InterceptorService', () => {
 
     service.intercept(originalReq, mockNextHandler).subscribe();
 
-    const tokenRefreshReq = httpMock.expectOne(`${updateAccessTokenLink}?refreshToken=mockRefreshToken`);
+    const tokenRefreshReq = httpMock.expectOne(`${updateAccessTokenLink}?refreshToken=mockRefreshToken&projectName=GREENCITY`);
     expect(tokenRefreshReq.request.method).toBe('GET');
 
     tokenRefreshReq.flush({ accessToken: newAccessToken, refreshToken: newRefreshToken });
@@ -342,7 +342,7 @@ describe('InterceptorService', () => {
 
     service.intercept(originalReq, mockNextHandler).subscribe();
 
-    const tokenRefreshReq = httpMock.expectOne(`${updateAccessTokenLink}?refreshToken=invalidRefreshToken`);
+    const tokenRefreshReq = httpMock.expectOne(`${updateAccessTokenLink}?refreshToken=invalidRefreshToken&projectName=PICKUP`);
     expect(tokenRefreshReq.request.method).toBe('GET');
 
     tokenRefreshReq.flush({}, { status: BAD_REQUEST, statusText: 'Bad Request' });
@@ -389,7 +389,7 @@ describe('InterceptorService', () => {
       secondRequestCompleted = true;
     });
 
-    const tokenRefreshReq = httpMock.expectOne(`${updateAccessTokenLink}?refreshToken=mockRefreshToken`);
+    const tokenRefreshReq = httpMock.expectOne(`${updateAccessTokenLink}?refreshToken=mockRefreshToken&projectName=GREENCITY`);
     expect(tokenRefreshReq.request.method).toBe('GET');
 
     tick();

--- a/src/app/shared/interceptors/interceptor.service.ts
+++ b/src/app/shared/interceptors/interceptor.service.ts
@@ -11,6 +11,8 @@ import { UBSOrderFormService } from 'src/app/ubs/ubs/services/ubs-order-form.ser
 import { MatDialog } from '@angular/material/dialog';
 import { AuthModalComponent } from '@global-auth/auth-modal/auth-modal.component';
 import { MatSnackBarService } from '@global-service/mat-snack-bar/mat-snack-bar.service';
+import { ProjectNameEnum } from '../models/auth/project-name.enum';
+import { TProjectName } from '../models/auth/project-name.type';
 
 interface NewTokenPair {
   accessToken: string;
@@ -188,8 +190,11 @@ export class InterceptorService implements HttpInterceptor {
     if (!this.isRefreshing) {
       this.isRefreshing = true;
       this.refreshTokenSubject.next(null);
-      return this.getNewTokenPair(this.localStorageService.getRefreshToken()).pipe(
-        catchError((error: HttpErrorResponse) => this.handleRefreshTokenIsNotValid(error)),
+      const currentUrl = this.router.url;
+      const isUbs = currentUrl.includes('ubs');
+      const projectName = isUbs ? ProjectNameEnum.UBS : ProjectNameEnum.GREENCITY;
+      return this.getNewTokenPair(this.localStorageService.getRefreshToken(), projectName).pipe(
+        catchError((error: HttpErrorResponse) => this.handleRefreshTokenIsNotValid(error, currentUrl, isUbs)),
         switchMap((newTokenPair: NewTokenPair) => {
           this.localStorageService.setAccessToken(newTokenPair.accessToken);
           this.localStorageService.setRefreshToken(newTokenPair.refreshToken);
@@ -213,10 +218,10 @@ export class InterceptorService implements HttpInterceptor {
    * Handles a situation when refresh token is expired.
    *
    * @param error - {@link HttpErrorResponse}
+   * @param currentUrl
+   * @param isUBS
    */
-  private handleRefreshTokenIsNotValid(error: HttpErrorResponse): Observable<HttpEvent<any>> {
-    const currentUrl = this.router.url;
-    const isUBS = currentUrl.includes('ubs');
+  private handleRefreshTokenIsNotValid(error: HttpErrorResponse, currentUrl: string, isUBS: boolean): Observable<HttpEvent<any>> {
     this.localStorageService.clear();
     this.dialog.closeAll();
     this.userOwnAuthService.isLoginUserSubject.next(false);
@@ -256,8 +261,9 @@ export class InterceptorService implements HttpInterceptor {
    * Send refresh token in order to get new access/refresh token pair.
    *
    * @param refreshToken - {@link string} refresh token.
+   * @param projectName
    */
-  private getNewTokenPair(refreshToken: string): Observable<NewTokenPair> {
-    return this.http.get<NewTokenPair>(`${updateAccessTokenLink}?refreshToken=${refreshToken}`);
+  private getNewTokenPair(refreshToken: string, projectName: TProjectName): Observable<NewTokenPair> {
+    return this.http.get<NewTokenPair>(`${updateAccessTokenLink}?refreshToken=${refreshToken}&projectName=${projectName}`);
   }
 }

--- a/src/app/shared/models/auth/project-name.enum.ts
+++ b/src/app/shared/models/auth/project-name.enum.ts
@@ -1,0 +1,4 @@
+export const enum ProjectNameEnum {
+  UBS = 'PICKUP',
+  GREENCITY = 'GREENCITY'
+}

--- a/src/app/shared/models/auth/project-name.type.ts
+++ b/src/app/shared/models/auth/project-name.type.ts
@@ -1,0 +1,3 @@
+import { ProjectNameEnum } from './project-name.enum';
+
+export type TProjectName = ProjectNameEnum.GREENCITY | ProjectNameEnum.UBS;

--- a/src/app/shared/models/auth/sign-in.interface.ts
+++ b/src/app/shared/models/auth/sign-in.interface.ts
@@ -1,4 +1,7 @@
+import { TProjectName } from './project-name.type';
+
 export interface ISignIn {
   email: string;
   password: string;
+  projectName: TProjectName;
 }

--- a/src/app/shared/services/auth/auth/auth.service.ts
+++ b/src/app/shared/services/auth/auth/auth.service.ts
@@ -6,6 +6,8 @@ import { JwtService } from 'src/app/shared/services/jwt/jwt.service';
 import { LocalStorageService } from 'src/app/shared/services/localstorage/local-storage.service';
 import { map, Observable, of } from 'rxjs';
 import { googleSecurityLink, mainUserLink } from 'src/app/main/links';
+import { TProjectName } from '../../../models/auth/project-name.type';
+import { ProjectNameEnum } from '../../../models/auth/project-name.enum';
 
 @Injectable({
   providedIn: 'root'
@@ -17,7 +19,8 @@ export class AuthService {
 
   private readonly API_ROUTES = {
     signIn: () => `${mainUserLink}ownSecurity/signIn`,
-    signInWithGoogle: (token: string, lang: string) => `${googleSecurityLink}?token=${token}&lang=${lang}`
+    signInWithGoogle: (token: string, lang: string, projectName: TProjectName) =>
+      `${googleSecurityLink}?token=${token}&lang=${lang}&projectName=${projectName}`
   };
 
   getCurrentUser(): Observable<ISignInResponse | null> {
@@ -41,9 +44,10 @@ export class AuthService {
     return this.http.post<ISignInResponse>(this.API_ROUTES.signIn(), data).pipe(map((response) => this.decodeUserRole(response)));
   }
 
-  signInWithGoogle(token: string, lang = 'uk'): Observable<ISignInResponse> {
+  signInWithGoogle(token: string, isUbs: boolean, lang = 'uk'): Observable<ISignInResponse> {
+    const projectName = isUbs ? ProjectNameEnum.UBS : ProjectNameEnum.GREENCITY;
     return this.http
-      .get<ISignInResponse>(this.API_ROUTES.signInWithGoogle(token, lang))
+      .get<ISignInResponse>(this.API_ROUTES.signInWithGoogle(token, lang, projectName))
       .pipe(map((response) => this.decodeUserRole(response)));
   }
 

--- a/src/app/shared/services/auth/google-sign-in.service.ts
+++ b/src/app/shared/services/auth/google-sign-in.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { googleSecurityLink } from '../../../main/links';
 import { Observable } from 'rxjs';
 import { UserSuccessSignIn } from '../../models/singIn-singUp/user-success-sign-in';
+import { ProjectNameEnum } from '../../models/auth/project-name.enum';
 
 @Injectable({
   providedIn: 'root'
@@ -10,7 +11,8 @@ import { UserSuccessSignIn } from '../../models/singIn-singUp/user-success-sign-
 export class GoogleSignInService {
   constructor(private http: HttpClient) {}
 
-  signIn(token: string, lang = 'en'): Observable<UserSuccessSignIn> {
-    return this.http.get<UserSuccessSignIn>(`${googleSecurityLink}?token=${token}&lang=${lang}`);
+  signIn(token: string, isUbs: boolean, lang = 'en'): Observable<UserSuccessSignIn> {
+    const projectName = isUbs ? ProjectNameEnum.UBS : ProjectNameEnum.GREENCITY;
+    return this.http.get<UserSuccessSignIn>(`${googleSecurityLink}?token=${token}&lang=${lang}&projectName=${projectName}`);
   }
 }

--- a/src/app/shared/services/user/user.service.spec.ts
+++ b/src/app/shared/services/user/user.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { UserService } from './user.service';
 import { LanguageService } from 'src/app/shared/i18n/language.service';
-import { habitStatisticLink, userLink } from '../../../main/links';
+import { greenCityUserLink, habitStatisticLink, userLink } from '../../../main/links';
 import {
   LISTOFUSERS,
   USERCHANGESTATUS,
@@ -10,7 +10,7 @@ import {
   GETUSERPAGEBLE,
   GETUPDATEUSER,
   HABITITEMS
-} from '../../../greencity/modules/user/mocks/user-service-mock';
+} from '@global-user/mocks/user-service-mock';
 
 describe('UserService', () => {
   let service: UserService;
@@ -124,7 +124,7 @@ describe('UserService', () => {
     service.countActivatedUsers().subscribe((data) => {
       expect(data).toBe(5);
     });
-    const req = httpMock.expectOne(`${userLink}/activatedUsersAmount`);
+    const req = httpMock.expectOne(`${greenCityUserLink}/activatedUsersAmount`);
     expect(req.request.method).toBe('GET');
     req.flush(5);
   });

--- a/src/app/shared/services/user/user.service.ts
+++ b/src/app/shared/services/user/user.service.ts
@@ -2,13 +2,13 @@ import { LocalStorageService } from '../localstorage/local-storage.service';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { UserRoleModel } from '../../../greencity/modules/user/models/user/user-role.model';
-import { UserStatusModel } from '../../../greencity/modules/user/models/user/user-status.model';
-import { UserPageableDtoModel } from '../../../greencity/modules/user/models/user/user-pageable-dto.model';
-import { habitStatisticLink, userLink } from '../../../main/links';
-import { RolesModel } from '../../../greencity/modules/user/models/roles.model';
-import { UserFilterDtoModel } from '../../../greencity/modules/user/models/user/userFilterDto.model';
-import { UserUpdateModel } from '../../../greencity/modules/user/models/user/user-update.model';
+import { UserRoleModel } from '@user-models/user/user-role.model';
+import { UserStatusModel } from '@user-models/user/user-status.model';
+import { UserPageableDtoModel } from '@user-models/user/user-pageable-dto.model';
+import { greenCityUserLink, habitStatisticLink, userLink } from '../../../main/links';
+import { RolesModel } from '@user-models/roles.model';
+import { UserFilterDtoModel } from '@user-models/user/userFilterDto.model';
+import { UserUpdateModel } from '@user-models/user/user-update.model';
 import moment from 'moment';
 import { HabitItemsAmountStatisticDto } from '@global-user/models/goal/HabitItemsAmountStatisticDto';
 
@@ -81,13 +81,13 @@ export class UserService {
   convertDate = (date) => moment(date).format('yyyy-MM-DDTHH:mm:ss.SSSSSS');
 
   /**
-   * Returns amount of users with activated status.
+   * Returns amount of users with activated status from GreenCity.
    * Can be used for representing total amount of users in the system.
    *
    * @returns Observable<number> that can be used for subscription to obtain amount of users.
    */
   countActivatedUsers(): Observable<number> {
-    return this.http.get(`${userLink}/activatedUsersAmount`) as Observable<number>;
+    return this.http.get(`${greenCityUserLink}/activatedUsersAmount`) as Observable<number>;
   }
 
   /**

--- a/src/app/store/effects/auth.effects.ts
+++ b/src/app/store/effects/auth.effects.ts
@@ -63,8 +63,8 @@ export class AuthEffects {
   $signInWithGoogle = createEffect(() => {
     return this.actions.pipe(
       ofType(SignInWithGoogleAction),
-      mergeMap((action: { token: string }) => {
-        return this.authService.signInWithGoogle(action.token).pipe(
+      mergeMap((action: { token: string; isUBS: boolean }) => {
+        return this.authService.signInWithGoogle(action.token, action.isUBS).pipe(
           map((response: ISignInResponse) => SignInSuccessAction({ data: response })),
           catchError((error) => of(SignInFailureAction({ error: this.BACKEND_ERRORS[error.message] || this.DEFAULT_ERROR })))
         );


### PR DESCRIPTION
update for auth according to backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Project-aware Google sign-in supporting GreenCity and UBS/PICKUP. The sign-in form now auto-sets the project, and authentication requests include project context.
- Refactor
  - Token refresh flow is now project-aware and preserves current navigation context during re-authentication.
- Chores
  - Activated users count now sourced from the GreenCity users endpoint; internal links and imports updated.
- Tests
  - Updated tests to validate project-specific token refresh requests for both GreenCity and PICKUP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->