### PR TITLE
Fix/8122 8127 profile page telegram sub

### DIFF
--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-switcher/ubs-switcher.component.html
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-switcher/ubs-switcher.component.html
@@ -1,4 +1,4 @@
 <label class="switch" for="user-notification-switcher">
-  <input id="user-notification-switcher" type="checkbox" [checked]="isChecked" (change)="onChange($event.target['checked'])" />
+  <input id="user-notification-switcher" type="checkbox" [checked]="displayChecked" (change)="onChange($event)" />
   <span class="slider round"></span>
 </label>

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-switcher/ubs-switcher.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-switcher/ubs-switcher.component.spec.ts
@@ -116,4 +116,42 @@ describe('UbsSwitcherComponent', () => {
       expect(component.switchChanged instanceof EventEmitter).toBe(true);
     });
   });
+
+  it('should handle null event.target gracefully', () => {
+    component.isChecked = false;
+    spyOn(component.switchChanged, 'emit');
+
+    const mockEvent = { target: null } as unknown as Event;
+
+    expect(() => component.onChange(mockEvent)).toThrow();
+  });
+
+  it('should handle undefined event.target gracefully', () => {
+    component.isChecked = false;
+    spyOn(component.switchChanged, 'emit');
+
+    const mockEvent = {} as Event;
+
+    expect(() => component.onChange(mockEvent)).toThrow();
+  });
+
+  it('should work when isChecked is undefined', () => {
+    component.isChecked = undefined;
+    spyOn(component.switchChanged, 'emit');
+
+    const mockCheckbox = { checked: true } as HTMLInputElement;
+    const mockEvent = { target: mockCheckbox } as unknown as Event;
+
+    component.onChange(mockEvent);
+
+    expect(mockCheckbox.checked).toBe(undefined);
+    expect(component.switchChanged.emit).toHaveBeenCalledWith(true);
+  });
+
+  it('should handle event with null target and undefined isChecked', () => {
+    component.isChecked = undefined;
+    const mockEvent = { target: null } as unknown as Event;
+
+    expect(() => component.onChange(mockEvent)).toThrow();
+  });
 });

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-switcher/ubs-switcher.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-switcher/ubs-switcher.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
 import { UbsSwitcherComponent } from './ubs-switcher.component';
+import { EventEmitter } from '@angular/core';
 
 describe('UbsSwitcherComponent', () => {
   let component: UbsSwitcherComponent;
@@ -20,5 +20,100 @@ describe('UbsSwitcherComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('displayChecked getter', () => {
+    it('should return true when isChecked is true', () => {
+      component.isChecked = true;
+      expect(component.displayChecked).toBe(true);
+    });
+
+    it('should return false when isChecked is false', () => {
+      component.isChecked = false;
+      expect(component.displayChecked).toBe(false);
+    });
+
+    it('should return undefined when isChecked is not set', () => {
+      component.isChecked = undefined;
+      expect(component.displayChecked).toBeUndefined();
+    });
+  });
+
+  describe('onChange method', () => {
+    it('should emit true when checkbox is checked', () => {
+      component.isChecked = false;
+      spyOn(component.switchChanged, 'emit');
+
+      const mockCheckbox = { checked: true } as HTMLInputElement;
+      const mockEvent = { target: mockCheckbox } as unknown as Event;
+
+      component.onChange(mockEvent);
+
+      expect(component.switchChanged.emit).toHaveBeenCalledWith(true);
+    });
+
+    it('should emit false when checkbox is unchecked', () => {
+      component.isChecked = true;
+      spyOn(component.switchChanged, 'emit');
+
+      const mockCheckbox = { checked: false } as HTMLInputElement;
+      const mockEvent = { target: mockCheckbox } as unknown as Event;
+
+      component.onChange(mockEvent);
+
+      expect(component.switchChanged.emit).toHaveBeenCalledWith(false);
+    });
+
+    it('should reset checkbox.checked to isChecked value', () => {
+      component.isChecked = true;
+
+      const mockCheckbox = { checked: false } as HTMLInputElement;
+      const mockEvent = { target: mockCheckbox } as unknown as Event;
+
+      component.onChange(mockEvent);
+
+      expect(mockCheckbox.checked).toBe(true);
+    });
+
+    it('should handle event when isChecked is false', () => {
+      component.isChecked = false;
+      spyOn(component.switchChanged, 'emit');
+
+      const mockCheckbox = { checked: true } as HTMLInputElement;
+      const mockEvent = { target: mockCheckbox } as unknown as Event;
+
+      component.onChange(mockEvent);
+
+      expect(mockCheckbox.checked).toBe(false);
+      expect(component.switchChanged.emit).toHaveBeenCalledWith(true);
+    });
+
+    it('should cast event.target to HTMLInputElement', () => {
+      component.isChecked = false;
+
+      const mockCheckbox = { checked: true } as HTMLInputElement;
+      const mockEvent = { target: mockCheckbox } as unknown as Event;
+
+      expect(() => component.onChange(mockEvent)).not.toThrow();
+    });
+  });
+
+  describe('Input properties', () => {
+    it('should accept isChecked input', () => {
+      component.isChecked = true;
+      expect(component.isChecked).toBe(true);
+    });
+
+    it('should accept isEditing input', () => {
+      component.isEditing = true;
+      expect(component.isEditing).toBe(true);
+    });
+  });
+
+  describe('Output properties', () => {
+    it('should have switchChanged EventEmitter', () => {
+      expect(component.switchChanged).toBeDefined();
+      expect(component.switchChanged instanceof EventEmitter).toBe(true);
+    });
   });
 });

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-switcher/ubs-switcher.component.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-switcher/ubs-switcher.component.ts
@@ -11,7 +11,16 @@ export class UbsSwitcherComponent {
 
   @Output() switchChanged: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-  onChange(checked: boolean) {
-    this.switchChanged.emit(checked);
+  get displayChecked(): boolean {
+    return this.isChecked;
+  }
+
+  onChange(event: Event) {
+    const checkbox = event.target as HTMLInputElement;
+    const newValue = checkbox.checked;
+
+    checkbox.checked = this.isChecked;
+
+    this.switchChanged.emit(newValue);
   }
 }

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.html
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.html
@@ -128,10 +128,10 @@
                 <app-ubs-switcher
                   class="ubs-switcher"
                   [isChecked]="isTelegramNotifyChecked()"
-                  [isEditing]="!isEditing"
+                  [isEditing]="isEditing"
                   value="id1"
                   id="telegramNotification"
-                  (switchChanged)="onSwitchChanged()"
+                  (switchChanged)="onSwitchChanged($event)"
                 ></app-ubs-switcher>
               </div>
               <div class="alert-mess">{{ 'ubs-client-profile.social-media-mess' | translate }}</div>
@@ -240,10 +240,10 @@
             </div>
           </div>
           <div class="submit-btns" *ngIf="isEditing">
-            <button class="ubs-primary-global-button s-btn" type="submit" (click)="onSubmit()" [disabled]="isSubmitBtnDisabled()">
+            <button class="ubs-primary-global-button s-btn" type="button" (click)="onSubmit()" [disabled]="isSubmitBtnDisabled()">
               {{ 'ubs-client-profile.btn.save' | translate }}
             </button>
-            <button class="ubs-secondary-global-button s-btn" type="submit" (click)="onCancel()">
+            <button class="ubs-secondary-global-button s-btn" type="button" (click)="onCancel()">
               {{ 'ubs-client-profile.btn.cancel' | translate }}
             </button>
           </div>

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
@@ -483,7 +483,8 @@ describe('UbsUserProfilePageComponent', () => {
       recipientEmail: new FormControl('some@gmail.com', [Validators.required]),
       alternateEmail: new FormControl(''),
       recipientPhone: new FormControl('1234567890'),
-      address: new FormArray([])
+      address: new FormArray([]),
+      telegramIsNotify: new FormControl(false)
     });
 
     component.userProfile = {
@@ -493,11 +494,17 @@ describe('UbsUserProfilePageComponent', () => {
       recipientPhone: '+380923473666',
       alternateEmail: '',
       addressDto: [],
-      telegramIsNotify: true,
+      telegramIsNotify: false,
       hasPassword: true
     };
 
+    component.savedTelegramIsNotify = false;
+
+    component.userForm.markAsDirty();
+
     expect(component.userForm.valid).toBeTrue();
+
+    clientProfileServiceMock.postDataClientProfile.and.returnValue(of(component.userProfile));
 
     component.onSubmit();
 
@@ -512,14 +519,29 @@ describe('UbsUserProfilePageComponent', () => {
       recipientEmail: new FormControl(null, [Validators.required]),
       alternateEmail: new FormControl(''),
       recipientPhone: new FormControl(''),
-      address: new FormArray([])
+      address: new FormArray([]),
+      telegramIsNotify: new FormControl(false)
     });
+
+    component.userProfile = {
+      recipientName: '',
+      recipientSurname: '',
+      recipientEmail: '',
+      recipientPhone: '',
+      alternateEmail: '',
+      addressDto: [],
+      telegramIsNotify: false,
+      hasPassword: true
+    };
+
+    component.savedTelegramIsNotify = false;
+    component.isEditing = false;
 
     expect(component.userForm.valid).toBeFalse();
 
     component.onSubmit();
 
-    expect(component.isEditing).toBeTruthy();
+    expect(component.userForm.get('recipientEmail').touched).toBeTrue();
   });
 
   it('on saveAddedAddresses method CreateAddress shouldnt be called if tempAddedAddressHolder is empty', () => {
@@ -837,12 +859,29 @@ describe('UbsUserProfilePageComponent', () => {
   });
 
   describe('onSwitchChanged method', () => {
-    it('should toggle telegramIsNotify and call goToTelegramUrl when id is telegramNotification', () => {
+    it('should toggle telegramIsNotify and call goToTelegramUrl when newValue is true', () => {
       const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
       spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
       spyOn(component, 'goToTelegramUrl');
-      component.userProfile.telegramIsNotify = false;
-      component.onSwitchChanged();
+
+      component.userProfile = {
+        recipientName: 'Test',
+        recipientSurname: 'User',
+        recipientEmail: 'test@example.com',
+        recipientPhone: '+380991234567',
+        alternateEmail: '',
+        addressDto: [],
+        telegramIsNotify: false,
+        hasPassword: true,
+        botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+      };
+
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.isEditing = true;
+
+      component.onSwitchChanged(true);
+
       expect(component.goToTelegramUrl).toHaveBeenCalled();
       expect(component.userProfile.telegramIsNotify).toBeTrue();
       expect(component.userForm.get('telegramIsNotify')?.value).toBeTrue();
@@ -852,11 +891,53 @@ describe('UbsUserProfilePageComponent', () => {
       const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(false) });
       spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
       spyOn(component, 'goToTelegramUrl');
-      component.userProfile.telegramIsNotify = false;
-      const ctrl = component.userForm.get('telegramIsNotify') as FormControl;
-      ctrl.setValue(false);
-      component.onSwitchChanged();
+
+      component.userProfile = {
+        recipientName: 'Test',
+        recipientSurname: 'User',
+        recipientEmail: 'test@example.com',
+        recipientPhone: '+380991234567',
+        alternateEmail: '',
+        addressDto: [],
+        telegramIsNotify: false,
+        hasPassword: true,
+        botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+      };
+
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.isEditing = true;
+
+      const initialValue = component.userProfile.telegramIsNotify;
+
+      component.onSwitchChanged(true);
+
       expect(component.goToTelegramUrl).not.toHaveBeenCalled();
+      expect(component.userProfile.telegramIsNotify).toBe(initialValue);
+      expect(component.userForm.get('telegramIsNotify')?.value).toBe(initialValue);
+    });
+
+    it('should disable telegram notifications when newValue is false', () => {
+      component.userProfile = {
+        recipientName: 'Test',
+        recipientSurname: 'User',
+        recipientEmail: 'test@example.com',
+        recipientPhone: '+380991234567',
+        alternateEmail: '',
+        addressDto: [],
+        telegramIsNotify: true,
+        hasPassword: true,
+        botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+      };
+
+      component.userInit();
+      component.savedTelegramIsNotify = true;
+      component.isEditing = false;
+
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of({ ...component.userProfile, telegramIsNotify: false }));
+
+      component.onSwitchChanged(false);
+
       expect(component.userProfile.telegramIsNotify).toBeFalse();
       expect(component.userForm.get('telegramIsNotify')?.value).toBeFalse();
     });

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
@@ -443,15 +443,19 @@ describe('UbsUserProfilePageComponent', () => {
   it('method onSubmit has to be called by clicking submit button', fakeAsync(() => {
     component.isEditing = true;
     fixture.detectChanges();
-    if (component.userForm.value.valid) {
-      const spy = spyOn(component, 'onSubmit');
-      const deleteButton = fixture.debugElement.query(By.css('.submit-btns .ubs-primary-global-button')).nativeElement;
-      deleteButton.click();
-      expect(spy).toHaveBeenCalled();
-    } else {
-      expect(component.isSubmitBtnDisabled()).toBeTrue();
-    }
+    component.recipientName.setValue('ValidName');
+    component.recipientSurname.setValue('ValidSurname');
+    component.userForm.get('recipientEmail').setValue('valid@example.com');
+    component.userForm.markAsDirty();
+    fixture.detectChanges();
+    const spy = spyOn(component, 'onSubmit');
+    const submitButton = fixture.debugElement.query(By.css('.submit-btns .ubs-primary-global-button')).nativeElement;
+    expect(submitButton.disabled).toBeFalse();
+
+    submitButton.click();
     tick(500);
+
+    expect(spy).toHaveBeenCalled();
   }));
 
   it('method onSubmit should return submitData without alternative email ', () => {
@@ -859,6 +863,550 @@ describe('UbsUserProfilePageComponent', () => {
     component.userProfile = { ...userProfileDataMock, botList: [] };
     component.setUrlToBot();
     expect(component.telegramBotURL).toBeUndefined();
+  });
+
+  it('should set savedTelegramIsNotify from response in getUserData', () => {
+    const mockProfileWithTelegram = { ...userProfileDataMock, telegramIsNotify: true };
+    clientProfileServiceMock.getDataClientProfile.and.returnValue(of(mockProfileWithTelegram));
+
+    component.savedTelegramIsNotify = false;
+    component.getUserData();
+
+    expect(component.savedTelegramIsNotify).toBe(true);
+  });
+
+  it('should set savedTelegramIsNotify to false when response has false value', () => {
+    const mockProfileWithoutTelegram = { ...userProfileDataMock, telegramIsNotify: false };
+    clientProfileServiceMock.getDataClientProfile.and.returnValue(of(mockProfileWithoutTelegram));
+
+    component.savedTelegramIsNotify = true;
+    component.getUserData();
+
+    expect(component.savedTelegramIsNotify).toBe(false);
+  });
+
+  describe('isSubmitBtnDisabled method', () => {
+    it('should return true when userForm is not initialized', () => {
+      component.userForm = null;
+
+      const result = component.isSubmitBtnDisabled();
+
+      expect(result).toBeTrue();
+    });
+
+    it('should return true when userForm is undefined', () => {
+      component.userForm = undefined;
+
+      const result = component.isSubmitBtnDisabled();
+
+      expect(result).toBeTrue();
+    });
+
+    it('should return false when telegramIsNotify switch changed from false to true', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.userForm.get('telegramIsNotify').setValue(true);
+
+      const result = component.isSubmitBtnDisabled();
+
+      expect(result).toBeFalse();
+    });
+
+    it('should return false when telegramIsNotify switch changed from true to false', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = true;
+      component.userForm.get('telegramIsNotify').setValue(false);
+
+      const result = component.isSubmitBtnDisabled();
+
+      expect(result).toBeFalse();
+    });
+
+    it('should return true when form is invalid', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.userForm.get('telegramIsNotify').setValue(false);
+      component.recipientName.setValue('');
+
+      const result = component.isSubmitBtnDisabled();
+
+      expect(result).toBeTrue();
+    });
+
+    it('should return true when form is pristine (unchanged)', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.userForm.get('telegramIsNotify').setValue(false);
+      component.userForm.markAsPristine();
+
+      const result = component.isSubmitBtnDisabled();
+
+      expect(result).toBeTrue();
+    });
+
+    it('should return false when form is valid and dirty', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.userForm.get('telegramIsNotify').setValue(false);
+      component.recipientName.setValue('ValidName');
+      component.userForm.markAsDirty();
+
+      const result = component.isSubmitBtnDisabled();
+
+      expect(result).toBeFalse();
+    });
+
+    it('should return true when switches are the same and form is pristine', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = true;
+      component.userForm.get('telegramIsNotify').setValue(true);
+      component.userForm.markAsPristine();
+
+      const result = component.isSubmitBtnDisabled();
+
+      expect(result).toBeTrue();
+    });
+
+    it('should handle undefined savedTelegramIsNotify as false', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = undefined;
+      component.userForm.get('telegramIsNotify').setValue(true);
+
+      const result = component.isSubmitBtnDisabled();
+
+      expect(result).toBeFalse();
+    });
+
+    it('should handle null telegramIsNotify form value as false', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = true;
+      component.userForm.get('telegramIsNotify').setValue(null);
+
+      const result = component.isSubmitBtnDisabled();
+
+      expect(result).toBeFalse();
+    });
+  });
+
+  describe('onSubmit method - phone value handling', () => {
+    beforeEach(() => {
+      clientProfileServiceMock.postDataClientProfile.calls.reset();
+      snackBarMock.openSnackBar.calls.reset();
+    });
+
+    it('should set phoneValue to null when recipientPhone is empty string', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+
+      component.recipientName.setValue('ValidName');
+      component.recipientSurname.setValue('ValidSurname');
+      component.userForm.get('recipientEmail').setValue('valid@example.com');
+      component.recipientPhone.setValue('');
+
+      component.userForm.markAsDirty();
+
+      const mockResponse = { ...userProfileDataMock, recipientPhone: null };
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+      component.onSubmit();
+      tick();
+
+      expect(clientProfileServiceMock.postDataClientProfile).toHaveBeenCalled();
+      const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+      expect(submittedData.recipientPhone).toBeUndefined();
+    }));
+
+    it('should set phoneValue to null when recipientPhone equals phonePrefix', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+
+      component.recipientName.setValue('ValidName');
+      component.recipientSurname.setValue('ValidSurname');
+      component.userForm.get('recipientEmail').setValue('valid@example.com');
+      component.recipientPhone.setValue('+380');
+
+      component.recipientPhone.clearValidators();
+      component.recipientPhone.updateValueAndValidity();
+
+      component.userForm.markAsDirty();
+
+      const mockResponse = { ...userProfileDataMock, recipientPhone: null };
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+      component.onSubmit();
+      tick();
+
+      expect(clientProfileServiceMock.postDataClientProfile).toHaveBeenCalled();
+      const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+      expect(submittedData.recipientPhone).toBeUndefined();
+    }));
+
+    it('should set phoneValue to null when recipientPhone is only spaces', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+
+      component.recipientName.setValue('ValidName');
+      component.recipientSurname.setValue('ValidSurname');
+      component.userForm.get('recipientEmail').setValue('valid@example.com');
+      component.recipientPhone.setValue('   ');
+
+      component.recipientPhone.clearValidators();
+      component.recipientPhone.updateValueAndValidity();
+
+      component.userForm.markAsDirty();
+
+      const mockResponse = { ...userProfileDataMock, recipientPhone: null };
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+      component.onSubmit();
+      tick();
+
+      expect(clientProfileServiceMock.postDataClientProfile).toHaveBeenCalled();
+      const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+      expect(submittedData.recipientPhone).toBeUndefined();
+    }));
+
+    it('should trim and keep phoneValue when it has valid phone number', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+
+      component.recipientName.setValue('ValidName');
+      component.recipientSurname.setValue('ValidSurname');
+      component.userForm.get('recipientEmail').setValue('valid@example.com');
+      component.recipientPhone.setValue('  +380991234567  ');
+
+      component.userForm.markAsDirty();
+
+      const expectedProfile = { ...userProfileDataMock, recipientPhone: '+380991234567' };
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(expectedProfile));
+
+      component.onSubmit();
+      tick();
+
+      expect(clientProfileServiceMock.postDataClientProfile).toHaveBeenCalled();
+      const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+      expect(submittedData.recipientPhone).toBe('+380991234567');
+    }));
+
+    it('should handle null recipientPhone value', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+
+      component.recipientName.setValue('ValidName');
+      component.recipientSurname.setValue('ValidSurname');
+      component.userForm.get('recipientEmail').setValue('valid@example.com');
+      component.recipientPhone.setValue(null);
+
+      component.recipientPhone.clearValidators();
+      component.recipientPhone.updateValueAndValidity();
+
+      component.userForm.markAsDirty();
+
+      const mockResponse = { ...userProfileDataMock, recipientPhone: null };
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+      component.onSubmit();
+      tick();
+
+      expect(clientProfileServiceMock.postDataClientProfile).toHaveBeenCalled();
+      const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+      expect(submittedData.recipientPhone).toBeUndefined();
+    }));
+
+    it('should set phoneValue to null when recipientPhone is phonePrefix with spaces', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+
+      component.recipientName.setValue('ValidName');
+      component.recipientSurname.setValue('ValidSurname');
+      component.userForm.get('recipientEmail').setValue('valid@example.com');
+      component.recipientPhone.setValue('  +380  ');
+
+      component.recipientPhone.clearValidators();
+      component.recipientPhone.updateValueAndValidity();
+
+      component.userForm.markAsDirty();
+
+      const mockResponse = { ...userProfileDataMock, recipientPhone: null };
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+      component.onSubmit();
+      tick();
+
+      expect(clientProfileServiceMock.postDataClientProfile).toHaveBeenCalled();
+      const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+      expect(submittedData.recipientPhone).toBeUndefined();
+    }));
+  });
+
+  describe('onSubmit method - form patching and error handling', () => {
+    beforeEach(() => {
+      clientProfileServiceMock.postDataClientProfile.calls.reset();
+      snackBarMock.openSnackBar.calls.reset();
+    });
+
+    it('should patch form with response data after successful submit', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.recipientName.setValue('UpdatedName');
+      component.userForm.markAsDirty();
+
+      const mockResponse: UserProfile = {
+        ...userProfileDataMock,
+        recipientEmail: 'updated@example.com',
+        alternateEmail: 'alt@example.com',
+        recipientName: 'UpdatedName',
+        recipientSurname: 'UpdatedSurname',
+        recipientPhone: '+380991234567',
+        telegramIsNotify: true
+      };
+
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+      component.onSubmit();
+      tick();
+
+      expect(component.userForm.get('recipientEmail').value).toBe('updated@example.com');
+      expect(component.userForm.get('alternateEmail').value).toBe('alt@example.com');
+      expect(component.userForm.get('recipientName').value).toBe('UpdatedName');
+      expect(component.userForm.get('recipientSurname').value).toBe('UpdatedSurname');
+      expect(component.userForm.get('recipientPhone').value).toBe('+380991234567');
+      expect(component.userForm.get('telegramIsNotify').value).toBe(true);
+    }));
+
+    it('should set alternateEmail to null when response has null alternateEmail', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.recipientName.setValue('Test');
+      component.userForm.markAsDirty();
+
+      const mockResponse: UserProfile = {
+        ...userProfileDataMock,
+        alternateEmail: null
+      };
+
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+      component.onSubmit();
+      tick();
+
+      expect(component.userForm.get('alternateEmail').value).toBeNull();
+    }));
+
+    it('should set recipientSurname to null when response has null recipientSurname', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.recipientName.setValue('Test');
+      component.userForm.markAsDirty();
+
+      const mockResponse: UserProfile = {
+        ...userProfileDataMock,
+        recipientSurname: null
+      };
+
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+      component.onSubmit();
+      tick();
+
+      expect(component.userForm.get('recipientSurname').value).toBeNull();
+    }));
+
+    it('should set recipientPhone to empty string when response has null recipientPhone', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.recipientName.setValue('Test');
+      component.userForm.markAsDirty();
+
+      const mockResponse: UserProfile = {
+        ...userProfileDataMock,
+        recipientPhone: null
+      };
+
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+      component.onSubmit();
+      tick();
+
+      expect(component.userForm.get('recipientPhone').value).toBe('');
+    }));
+
+    it('should convert telegramIsNotify to boolean with !! operator', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.recipientName.setValue('Test');
+      component.userForm.markAsDirty();
+
+      const mockResponse: UserProfile = {
+        ...userProfileDataMock,
+        telegramIsNotify: false as any
+      };
+
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+      component.onSubmit();
+      tick();
+
+      expect(component.userForm.get('telegramIsNotify').value).toBe(false);
+    }));
+
+    it('should mark form as pristine after successful submit', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.recipientName.setValue('Test');
+      component.userForm.markAsDirty();
+
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+      component.onSubmit();
+      tick();
+
+      expect(component.userForm.pristine).toBeTrue();
+    }));
+
+    it('should mark form as untouched after successful submit', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.recipientName.setValue('Test');
+      component.userForm.markAsDirty();
+      component.userForm.markAllAsTouched();
+
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+      component.onSubmit();
+      tick();
+
+      expect(component.userForm.untouched).toBeTrue();
+    }));
+
+    it('should show success snackbar after successful submit', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.recipientName.setValue('Test');
+      component.userForm.markAsDirty();
+
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+      snackBarMock.openSnackBar.calls.reset();
+
+      component.onSubmit();
+      tick();
+
+      expect(snackBarMock.openSnackBar).toHaveBeenCalledWith('savedChangesToUserProfile');
+    }));
+
+    it('should set isFetching to false on submit error', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.recipientName.setValue('Test');
+      component.userForm.markAsDirty();
+
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(throwError(() => new Error('Server error')));
+
+      component.onSubmit();
+      tick();
+
+      expect(component.isFetching).toBeFalse();
+    }));
+
+    it('should set isEditing to true on submit error', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.recipientName.setValue('Test');
+      component.userForm.markAsDirty();
+      component.isEditing = false;
+
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(throwError(() => new Error('Server error')));
+
+      component.onSubmit();
+      tick();
+
+      expect(component.isEditing).toBeTrue();
+    }));
+
+    it('should show error snackbar on submit error', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.recipientName.setValue('Test');
+      component.userForm.markAsDirty();
+
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(throwError(() => new Error('Server error')));
+      snackBarMock.openSnackBar.calls.reset();
+
+      component.onSubmit();
+      tick();
+
+      expect(snackBarMock.openSnackBar).toHaveBeenCalledWith('error');
+    }));
+
+    it('should set alternativeEmailDisplay to false after successful submit', fakeAsync(() => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.recipientName.setValue('Test');
+      component.userForm.markAsDirty();
+      component.alternativeEmailDisplay = true;
+
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+      component.onSubmit();
+      tick();
+
+      expect(component.alternativeEmailDisplay).toBeFalse();
+    }));
+
+    it('should mark all invalid controls as touched when form is invalid', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+
+      component.recipientName.setValue('');
+      component.userForm.get('recipientEmail').setValue('invalid-email');
+
+      component.onSubmit();
+
+      expect(component.recipientName.touched).toBeTrue();
+      expect(component.userForm.get('recipientEmail').touched).toBeTrue();
+    });
+
+    it('should iterate through all form controls when form is invalid', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+
+      component.recipientName.setValue('');
+      component.recipientSurname.setValue('Invalid$$$');
+      component.userForm.get('recipientEmail').setValue('invalid');
+
+      component.onSubmit();
+
+      Object.keys(component.userForm.controls).forEach((key) => {
+        const control = component.userForm.get(key);
+        if (control?.invalid) {
+          expect(control.touched).toBeTrue();
+        }
+      });
+    });
+
+    it('should not mark valid controls as touched when form is invalid', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+
+      component.recipientName.setValue('');
+      component.recipientPhone.setValue('+380991234567');
+
+      component.onSubmit();
+
+      expect(component.recipientName.touched).toBeTrue();
+      expect(component.recipientPhone.touched).toBeFalse();
+    });
+
+    it('should handle control being null or undefined in forEach loop', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+
+      component.recipientName.setValue('');
+
+      spyOn(component.userForm, 'get').and.returnValue(null);
+
+      expect(() => component.onSubmit()).not.toThrow();
+    });
   });
 
   describe('Testing controls for the form:', () => {

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
@@ -87,7 +87,8 @@ describe('UbsUserProfilePageComponent', () => {
   let fixture: ComponentFixture<UbsUserProfilePageComponent>;
   const clientProfileServiceMock: jasmine.SpyObj<ClientProfileService> = jasmine.createSpyObj('ClientProfileService', {
     getDataClientProfile: of(userProfileDataMock),
-    postDataClientProfile: of({})
+    postDataClientProfile: of({}),
+    deactivateProfile: of({})
   });
   const snackBarMock: jasmine.SpyObj<MatSnackBarService> = jasmine.createSpyObj('MatSnackBarService', ['openSnackBar']);
   const dialogMock = {
@@ -3772,4 +3773,544 @@ describe('UbsUserProfilePageComponent', () => {
       })
     );
   }));
+
+  describe('Additional Coverage Tests for 100%', () => {
+    beforeEach(() => {
+      clientProfileServiceMock.postDataClientProfile.calls.reset();
+      snackBarMock.openSnackBar.calls.reset();
+      clientProfileServiceMock.getDataClientProfile.calls.reset();
+      clientProfileServiceMock.getDataClientProfile.and.returnValue(of(userProfileDataMock));
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+    });
+
+    afterEach(() => {
+      clientProfileServiceMock.getDataClientProfile.and.returnValue(of(userProfileDataMock));
+      clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+    });
+
+    describe('onSubmit - address handling with modifications', () => {
+      it('should update address and dispatch UpdateAddress when address is modified and has id', fakeAsync(() => {
+        component.userProfile = { ...userProfileDataMock };
+        component.savedUserAddresses = [...userProfileDataMock.addressDto];
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+
+        const addressFormArray = component.userForm.get('address') as FormArray;
+        const addressControl = addressFormArray.at(0) as FormControl;
+
+        const modifiedAddress = {
+          ...addressControl.value,
+          houseNumber: '999'
+        };
+
+        addressControl.setValue(modifiedAddress);
+        component.userForm.markAsDirty();
+
+        const store = TestBed.inject(Store) as MockStore;
+        const dispatchSpy = spyOn(store, 'dispatch');
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        expect(dispatchSpy).toHaveBeenCalled();
+        const updateAddressCalls = dispatchSpy.calls.all().filter((call) => call.args[0].type === '[Order] Update Address');
+        expect(updateAddressCalls.length).toBeGreaterThan(0);
+      }));
+
+      it('should delete houseCorpus from updated address when it is empty', fakeAsync(() => {
+        component.userProfile = { ...userProfileDataMock };
+        component.savedUserAddresses = [...userProfileDataMock.addressDto];
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+
+        const addressFormArray = component.userForm.get('address') as FormArray;
+        const addressControl = addressFormArray.at(0) as FormControl;
+
+        const modifiedAddress = {
+          ...addressControl.value,
+          houseCorpus: '',
+          houseNumber: '100'
+        };
+
+        addressControl.setValue(modifiedAddress);
+        component.userForm.markAsDirty();
+
+        const store = TestBed.inject(Store) as MockStore;
+        const dispatchSpy = spyOn(store, 'dispatch');
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const updateAddressCalls = dispatchSpy.calls.all().filter((call) => call.args[0].type === '[Order] Update Address');
+
+        if (updateAddressCalls.length > 0) {
+          const updateAction = updateAddressCalls[0].args[0] as any;
+          expect(updateAction.address.houseCorpus).toBeUndefined();
+        }
+      }));
+
+      it('should delete entranceNumber from updated address when it is empty', fakeAsync(() => {
+        component.userProfile = { ...userProfileDataMock };
+        component.savedUserAddresses = [...userProfileDataMock.addressDto];
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+
+        const addressFormArray = component.userForm.get('address') as FormArray;
+        const addressControl = addressFormArray.at(0) as FormControl;
+
+        const modifiedAddress = {
+          ...addressControl.value,
+          entranceNumber: '',
+          houseNumber: '100'
+        };
+
+        addressControl.setValue(modifiedAddress);
+        component.userForm.markAsDirty();
+
+        const store = TestBed.inject(Store) as MockStore;
+        const dispatchSpy = spyOn(store, 'dispatch');
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const updateAddressCalls = dispatchSpy.calls.all().filter((call) => call.args[0].type === '[Order] Update Address');
+
+        if (updateAddressCalls.length > 0) {
+          const updateAction = updateAddressCalls[0].args[0] as any;
+          expect(updateAction.address.entranceNumber).toBeUndefined();
+        }
+      }));
+
+      it('should delete searchAddress and isHouseSelected from updated address', fakeAsync(() => {
+        component.userProfile = { ...userProfileDataMock };
+        component.savedUserAddresses = [...userProfileDataMock.addressDto];
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+
+        const addressFormArray = component.userForm.get('address') as FormArray;
+        const addressControl = addressFormArray.at(0) as FormControl;
+
+        const modifiedAddress = {
+          ...addressControl.value,
+          houseNumber: '123',
+          searchAddress: 'Some search text',
+          isHouseSelected: true
+        };
+
+        addressControl.setValue(modifiedAddress);
+        component.userForm.markAsDirty();
+
+        const store = TestBed.inject(Store) as MockStore;
+        const dispatchSpy = spyOn(store, 'dispatch');
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const updateAddressCalls = dispatchSpy.calls.all().filter((call) => call.args[0].type === '[Order] Update Address');
+
+        if (updateAddressCalls.length > 0) {
+          const updateAction = updateAddressCalls[0].args[0] as any;
+          expect(updateAction.address.searchAddress).toBeUndefined();
+          expect(updateAction.address.isHouseSelected).toBeUndefined();
+        }
+      }));
+    });
+
+    describe('onSubmit - switchChanged branch execution', () => {
+      it('should execute submit when only switchChanged is true and form is pristine', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(true);
+        component.userForm.markAsPristine();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        expect(clientProfileServiceMock.postDataClientProfile).toHaveBeenCalled();
+        expect(component.isFetching).toBeFalse();
+      }));
+
+      it('should execute submit when switchChanged is true even with invalid form', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(true);
+        component.recipientName.setValue('');
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        expect(clientProfileServiceMock.postDataClientProfile).toHaveBeenCalled();
+      }));
+    });
+
+    describe('onSwitchChanged - editing mode with savedTelegramIsNotify checks', () => {
+      it('should mark form as dirty when enabling telegram in editing mode and savedTelegramIsNotify is false', () => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+        spyOn(component, 'goToTelegramUrl');
+
+        component.userProfile = {
+          ...userProfileDataMock,
+          telegramIsNotify: false
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.isEditing = true;
+        component.userForm.markAsPristine();
+
+        component.onSwitchChanged(true);
+
+        expect(component.userForm.dirty).toBeTrue();
+      });
+
+      it('should not mark form as dirty when enabling telegram in editing mode if savedTelegramIsNotify is already true', () => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+        spyOn(component, 'goToTelegramUrl');
+
+        component.userProfile = {
+          ...userProfileDataMock,
+          telegramIsNotify: false
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.isEditing = true;
+        component.userForm.markAsPristine();
+
+        component.onSwitchChanged(true);
+
+        expect(component.userForm.dirty).toBeFalse();
+      });
+
+      it('should mark form as dirty when disabling telegram in editing mode and savedTelegramIsNotify is true', () => {
+        component.userProfile = {
+          ...userProfileDataMock,
+          telegramIsNotify: true
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.isEditing = true;
+        component.userForm.markAsPristine();
+
+        component.onSwitchChanged(false);
+
+        expect(component.userForm.dirty).toBeTrue();
+      });
+
+      it('should not mark form as dirty when disabling telegram in editing mode if savedTelegramIsNotify is already false', () => {
+        component.userProfile = {
+          ...userProfileDataMock,
+          telegramIsNotify: true
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.isEditing = true;
+        component.userForm.markAsPristine();
+
+        component.onSwitchChanged(false);
+
+        expect(component.userForm.dirty).toBeFalse();
+      });
+    });
+
+    describe('onSubmit - delete operations on submitData fields', () => {
+      it('should delete alternateEmail from submitData when it is null', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('alternateEmail').setValue(null);
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.alternateEmail).toBeUndefined();
+      }));
+
+      it('should delete recipientPhone from submitData when it is null', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientPhone.setValue(null);
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+
+      it('should delete recipientSurname from submitData when it is null', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientSurname.setValue(null);
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientSurname).toBeUndefined();
+      }));
+    });
+
+    describe('getUserData - error handling', () => {
+      it('should set isFetching to false and show error snackbar on error', fakeAsync(() => {
+        clientProfileServiceMock.getDataClientProfile.and.returnValue(throwError(() => new Error('Server error')));
+        snackBarMock.openSnackBar.calls.reset();
+
+        component.isFetching = true;
+        component.userProfile = { ...userProfileDataMock };
+        component.userInit();
+        component.getUserData();
+        tick();
+
+        expect(component.isFetching).toBeFalse();
+        expect(snackBarMock.openSnackBar).toHaveBeenCalledWith('error');
+        clientProfileServiceMock.getDataClientProfile.and.returnValue(of(userProfileDataMock));
+      }));
+    });
+
+    describe('onCancel - error handling', () => {
+      it('should handle error in getDataClientProfile and still call userInit and set isEditing to false', fakeAsync(() => {
+        component.isEditing = true;
+        component.userProfile.addressDto = [];
+
+        clientProfileServiceMock.getDataClientProfile.and.returnValue(throwError(() => new Error('Server error')));
+
+        const userInitSpy = spyOn(component, 'userInit');
+
+        component.onCancel();
+        tick();
+
+        expect(userInitSpy).toHaveBeenCalled();
+        expect(component.isEditing).toBeFalse();
+      }));
+    });
+
+    describe('setActualAddress', () => {
+      it('should call orderService.setActualAddress and mark form as dirty', fakeAsync(() => {
+        const orderServiceSpy = spyOn(component['orderService'], 'setActualAddress').and.returnValue(of({}));
+        component.userInit();
+        component.userForm.markAsPristine();
+
+        component.setActualAddress(123);
+        tick();
+
+        expect(orderServiceSpy).toHaveBeenCalledWith(123);
+        expect(component.userForm.dirty).toBeTrue();
+      }));
+    });
+
+    describe('resetValue', () => {
+      it('should reset alternateEmail value to null', () => {
+        component.userInit();
+        component.userForm.get('alternateEmail').setValue('test@example.com');
+
+        component.resetValue();
+
+        expect(component.userForm.get('alternateEmail').value).toBeNull();
+      });
+    });
+
+    describe('formatedPhoneNumber', () => {
+      it('should format valid Ukrainian phone number correctly', () => {
+        const result = component.formatedPhoneNumber('+380991234567');
+        expect(result).toBe('+380 (99) 123 45 67');
+      });
+
+      it('should return undefined for invalid phone number format', () => {
+        const result = component.formatedPhoneNumber('+123456789');
+        expect(result).toBeUndefined();
+      });
+
+      it('should return undefined for empty string', () => {
+        const result = component.formatedPhoneNumber('');
+        expect(result).toBeUndefined();
+      });
+
+      it('should return undefined for phone number without country code', () => {
+        const result = component.formatedPhoneNumber('0991234567');
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('isTelegramNotifyChecked', () => {
+      it('should return true when telegramIsNotify is true', () => {
+        component.userInit();
+        component.userForm.get('telegramIsNotify').setValue(true);
+
+        expect(component.isTelegramNotifyChecked()).toBeTrue();
+      });
+
+      it('should return false when telegramIsNotify is false', () => {
+        component.userInit();
+        component.userForm.get('telegramIsNotify').setValue(false);
+
+        expect(component.isTelegramNotifyChecked()).toBeFalse();
+      });
+
+      it('should return false when telegramIsNotify is null', () => {
+        component.userInit();
+        component.userForm.get('telegramIsNotify').setValue(null);
+
+        expect(component.isTelegramNotifyChecked()).toBeFalse();
+      });
+
+      it('should handle undefined userForm gracefully', () => {
+        component.userProfile = { ...userProfileDataMock };
+        component.userInit();
+
+        component.userForm = undefined;
+
+        const result = component.isTelegramNotifyChecked();
+        expect(result).toBeFalsy();
+      });
+    });
+
+    describe('openDeleteProfileReasonPopUp', () => {
+      beforeEach(() => {
+        clientProfileServiceMock.deactivateProfile.calls.reset();
+      });
+
+      it('should call deactivateProfile and signOut when user confirms with reason', fakeAsync(() => {
+        const dialogRefSpyObj = jasmine.createSpyObj({
+          afterClosed: of({ reason: 'test reason' })
+        });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+
+        clientProfileServiceMock.deactivateProfile.and.returnValue(of(undefined));
+        const signOutSpy = spyOn(component, 'signOut');
+
+        component.userEmail = 'test@example.com';
+        component.openDeleteProfileReasonPopUp();
+        tick();
+
+        expect(clientProfileServiceMock.deactivateProfile).toHaveBeenCalledWith('test@example.com', 'test reason');
+        expect(signOutSpy).toHaveBeenCalled();
+      }));
+
+      it('should not call deactivateProfile when dialog is cancelled', fakeAsync(() => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(null) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+
+        clientProfileServiceMock.deactivateProfile.calls.reset();
+
+        component.openDeleteProfileReasonPopUp();
+        tick();
+
+        expect(clientProfileServiceMock.deactivateProfile).not.toHaveBeenCalled();
+      }));
+    });
+
+    describe('ngOnDestroy', () => {
+      it('should call next and complete on destroy subject', () => {
+        const destroySpy = spyOn(component['destroy'], 'next');
+        const completeSpy = spyOn(component['destroy'], 'complete');
+
+        component.ngOnDestroy();
+
+        expect(destroySpy).toHaveBeenCalledWith(true);
+        expect(completeSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('onSubmit - response with addressDto handling', () => {
+      it('should update savedUserAddresses when response contains addressDto', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const newAddresses: Address[] = [
+          {
+            id: 999,
+            cityUk: 'TestCity',
+            cityEn: 'TestCity',
+            districtUk: 'TestDistrict',
+            districtEn: 'TestDistrict',
+            entranceNumber: '1',
+            houseCorpus: 'A',
+            houseNumber: '1',
+            actual: true,
+            regionUk: 'TestRegion',
+            regionEn: 'TestRegion',
+            coordinates: { latitude: 0, longitude: 0 },
+            streetUk: 'TestStreet',
+            streetEn: 'TestStreet',
+            placeId: 'test',
+            searchAddress: null,
+            isHouseSelected: true,
+            addressRegionDistrictList: null
+          }
+        ];
+
+        const mockResponse = {
+          ...userProfileDataMock,
+          addressDto: newAddresses
+        };
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.savedUserAddresses).toEqual(newAddresses);
+      }));
+
+      it('should not update savedUserAddresses when response has no addressDto', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const originalSavedAddresses = [...component.savedUserAddresses];
+
+        const mockResponse: any = {
+          recipientEmail: userProfileDataMock.recipientEmail,
+          alternateEmail: userProfileDataMock.alternateEmail,
+          recipientName: userProfileDataMock.recipientName,
+          recipientPhone: userProfileDataMock.recipientPhone,
+          recipientSurname: userProfileDataMock.recipientSurname,
+          hasPassword: userProfileDataMock.hasPassword,
+          telegramIsNotify: userProfileDataMock.telegramIsNotify,
+          botList: userProfileDataMock.botList
+        };
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.savedUserAddresses).toEqual(originalSavedAddresses);
+      }));
+    });
+  });
 });

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
@@ -1016,6 +1016,145 @@ describe('UbsUserProfilePageComponent', () => {
 
       expect(result).toBeFalse();
     });
+
+    describe('isSubmitBtnDisabled method - formSwitch coverage', () => {
+      it('should evaluate formSwitch as true when telegramIsNotify has truthy value', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(true);
+
+        const result = component.isSubmitBtnDisabled();
+
+        const formSwitch = !!component.userForm.get('telegramIsNotify')?.value;
+        expect(formSwitch).toBeTrue();
+        expect(result).toBeFalse(); // because switches are different
+      });
+
+      it('should evaluate formSwitch as false when telegramIsNotify has falsy value', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.userForm.get('telegramIsNotify').setValue(false);
+
+        const result = component.isSubmitBtnDisabled();
+
+        const formSwitch = !!component.userForm.get('telegramIsNotify')?.value;
+        expect(formSwitch).toBeFalse();
+        expect(result).toBeFalse(); // because switches are different
+      });
+
+      it('should evaluate formSwitch as false when telegramIsNotify value is null', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = true; // Different from null/false to ensure button is enabled
+        component.userForm.get('telegramIsNotify').setValue(null);
+
+        const result = component.isSubmitBtnDisabled();
+
+        const formSwitch = !!component.userForm.get('telegramIsNotify')?.value;
+        expect(formSwitch).toBeFalse();
+        expect(result).toBeFalse(); // because null becomes false, different from true savedSwitch
+      });
+
+      it('should evaluate formSwitch as false when telegramIsNotify value is undefined', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.userForm.get('telegramIsNotify').setValue(undefined);
+
+        const result = component.isSubmitBtnDisabled();
+
+        const formSwitch = !!component.userForm.get('telegramIsNotify')?.value;
+        expect(formSwitch).toBeFalse();
+        expect(result).toBeFalse(); // because switches are different
+      });
+
+      it('should evaluate formSwitch as false when telegramIsNotify value is 0', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.userForm.get('telegramIsNotify').setValue(0);
+
+        const result = component.isSubmitBtnDisabled();
+
+        const formSwitch = !!component.userForm.get('telegramIsNotify')?.value;
+        expect(formSwitch).toBeFalse();
+        expect(result).toBeFalse(); // because switches are different
+      });
+
+      it('should evaluate formSwitch as true when telegramIsNotify value is 1', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(1);
+
+        const result = component.isSubmitBtnDisabled();
+
+        const formSwitch = !!component.userForm.get('telegramIsNotify')?.value;
+        expect(formSwitch).toBeTrue();
+        expect(result).toBeFalse(); // because switches are different
+      });
+
+      it('should evaluate formSwitch as false when telegramIsNotify value is empty string', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.userForm.get('telegramIsNotify').setValue('');
+
+        const result = component.isSubmitBtnDisabled();
+
+        const formSwitch = !!component.userForm.get('telegramIsNotify')?.value;
+        expect(formSwitch).toBeFalse();
+        expect(result).toBeFalse(); // because switches are different
+      });
+
+      it('should evaluate formSwitch as true when telegramIsNotify value is non-empty string', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue('true');
+
+        const result = component.isSubmitBtnDisabled();
+
+        const formSwitch = !!component.userForm.get('telegramIsNotify')?.value;
+        expect(formSwitch).toBeTrue();
+        expect(result).toBeFalse(); // because switches are different
+      });
+
+      it('should handle optional chaining when telegramIsNotify control does not exist', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = true; // Set to true to make switches different
+        component.userForm.removeControl('telegramIsNotify');
+
+        const result = component.isSubmitBtnDisabled();
+
+        const formSwitch = !!component.userForm.get('telegramIsNotify')?.value;
+        expect(formSwitch).toBeFalse(); // undefined?.value becomes false with !!
+        expect(result).toBeFalse(); // because false !== true
+      });
+
+      it('should correctly compare formSwitch with savedTelegramIsNotify when both are true', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.userForm.get('telegramIsNotify').setValue(true);
+
+        const formSwitch = !!component.userForm.get('telegramIsNotify')?.value;
+        expect(formSwitch).toBeTrue();
+        expect(formSwitch).toBe(component.savedTelegramIsNotify);
+
+        const result = component.isSubmitBtnDisabled();
+        // Should return true because switches match and form is pristine
+        expect(result).toBeTrue();
+      });
+
+      it('should correctly compare formSwitch with savedTelegramIsNotify when both are false', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.userForm.markAsPristine();
+
+        const formSwitch = !!component.userForm.get('telegramIsNotify')?.value;
+        expect(formSwitch).toBeFalse();
+        expect(formSwitch).toBe(component.savedTelegramIsNotify);
+
+        const result = component.isSubmitBtnDisabled();
+        // Should return true because switches match and form is pristine
+        expect(result).toBeTrue();
+      });
+    });
   });
 
   describe('onSubmit method - phone value handling', () => {
@@ -1386,9 +1525,13 @@ describe('UbsUserProfilePageComponent', () => {
     it('should mark all invalid controls as touched when form is invalid', () => {
       component.userInit();
       component.savedTelegramIsNotify = false;
+      component.userForm.get('telegramIsNotify').setValue(false);
 
       component.recipientName.setValue('');
       component.userForm.get('recipientEmail').setValue('invalid-email');
+
+      component.recipientName.markAsUntouched();
+      component.userForm.get('recipientEmail').markAsUntouched();
 
       component.onSubmit();
 
@@ -1399,10 +1542,15 @@ describe('UbsUserProfilePageComponent', () => {
     it('should iterate through all form controls when form is invalid', () => {
       component.userInit();
       component.savedTelegramIsNotify = false;
+      component.userForm.get('telegramIsNotify').setValue(false);
 
       component.recipientName.setValue('');
       component.recipientSurname.setValue('Invalid$$$');
       component.userForm.get('recipientEmail').setValue('invalid');
+
+      component.recipientName.markAsUntouched();
+      component.recipientSurname.markAsUntouched();
+      component.userForm.get('recipientEmail').markAsUntouched();
 
       component.onSubmit();
 
@@ -1417,14 +1565,25 @@ describe('UbsUserProfilePageComponent', () => {
     it('should not mark valid controls as touched when form is invalid', () => {
       component.userInit();
       component.savedTelegramIsNotify = false;
+      component.userForm.get('telegramIsNotify').setValue(false);
 
       component.recipientName.setValue('');
       component.recipientPhone.setValue('+380991234567');
+      component.userForm.get('recipientEmail').setValue('valid@example.com');
+      component.recipientSurname.setValue('ValidSurname');
+
+      component.recipientName.markAsUntouched();
+      component.recipientPhone.markAsUntouched();
+      component.userForm.get('recipientEmail').markAsUntouched();
+      component.recipientSurname.markAsUntouched();
 
       component.onSubmit();
 
       expect(component.recipientName.touched).toBeTrue();
+
       expect(component.recipientPhone.touched).toBeFalse();
+      expect(component.userForm.get('recipientEmail').touched).toBeFalse();
+      expect(component.recipientSurname.touched).toBeFalse();
     });
 
     it('should handle control being null or undefined in forEach loop', () => {
@@ -1533,6 +1692,25 @@ describe('UbsUserProfilePageComponent', () => {
         expect(submittedData.recipientPhone).toBeUndefined();
       }));
 
+      it('should trim recipientPhone before checking if it equals phonePrefix', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue('  +380  ');
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+
       it('should patch recipientEmail from response', fakeAsync(() => {
         component.userInit();
         component.savedTelegramIsNotify = false;
@@ -1590,6 +1768,170 @@ describe('UbsUserProfilePageComponent', () => {
         expect(component.userForm.get('recipientPhone').value).toBe('+380501234567');
       }));
 
+      it('should use ?? operator to default recipientPhone to empty string', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = {
+          ...userProfileDataMock,
+          recipientPhone: undefined as any
+        };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('recipientPhone').value).toBe('');
+      }));
+
+      it('should execute all lines in successful submit path', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+
+        component.recipientName.setValue('ValidName');
+        component.recipientSurname.setValue('ValidSurname');
+        component.userForm.get('recipientEmail').setValue('valid@example.com');
+        component.recipientPhone.setValue('+380991234567');
+        component.alternateEmail.setValue('alt@example.com');
+        component.userForm.markAsDirty();
+        component.alternativeEmailDisplay = true;
+
+        const mockResponse: UserProfile = {
+          ...userProfileDataMock,
+          recipientEmail: 'valid@example.com',
+          alternateEmail: 'alt@example.com',
+          recipientName: 'ValidName',
+          recipientSurname: 'ValidSurname',
+          recipientPhone: '+380991234567',
+          telegramIsNotify: false
+        };
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+        snackBarMock.openSnackBar.calls.reset();
+
+        const patchValueSpy = spyOn(component.userForm, 'patchValue').and.callThrough();
+        const markAsPristineSpy = spyOn(component.userForm, 'markAsPristine').and.callThrough();
+        const markAsUntouchedSpy = spyOn(component.userForm, 'markAsUntouched').and.callThrough();
+
+        component.onSubmit();
+        tick();
+
+        expect(patchValueSpy).toHaveBeenCalledWith({
+          recipientEmail: 'valid@example.com',
+          alternateEmail: 'alt@example.com',
+          recipientName: 'ValidName',
+          recipientSurname: 'ValidSurname',
+          recipientPhone: '+380991234567',
+          telegramIsNotify: false
+        });
+
+        expect(markAsPristineSpy).toHaveBeenCalled();
+        expect(markAsUntouchedSpy).toHaveBeenCalled();
+        expect(snackBarMock.openSnackBar).toHaveBeenCalledWith('savedChangesToUserProfile');
+        expect(component.alternativeEmailDisplay).toBeFalse();
+      }));
+
+      it('should cover patchValue with null values for alternateEmail and recipientSurname', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+
+        component.recipientName.setValue('ValidName');
+        component.userForm.markAsDirty();
+
+        const mockResponse: UserProfile = {
+          ...userProfileDataMock,
+          recipientEmail: 'test@example.com',
+          alternateEmail: null,
+          recipientName: 'ValidName',
+          recipientSurname: null,
+          recipientPhone: null,
+          telegramIsNotify: false
+        };
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        const patchValueSpy = spyOn(component.userForm, 'patchValue').and.callThrough();
+
+        component.onSubmit();
+        tick();
+
+        expect(patchValueSpy).toHaveBeenCalledWith({
+          recipientEmail: 'test@example.com',
+          alternateEmail: null,
+          recipientName: 'ValidName',
+          recipientSurname: null,
+          recipientPhone: '',
+          telegramIsNotify: false
+        });
+      }));
+
+      it('should cover patchValue with undefined values using ?? operator', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+
+        component.recipientName.setValue('ValidName');
+        component.userForm.markAsDirty();
+
+        const mockResponse: UserProfile = {
+          ...userProfileDataMock,
+          recipientEmail: 'test@example.com',
+          alternateEmail: undefined,
+          recipientName: 'ValidName',
+          recipientSurname: undefined,
+          recipientPhone: undefined,
+          telegramIsNotify: false
+        } as any;
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        const patchValueSpy = spyOn(component.userForm, 'patchValue').and.callThrough();
+
+        component.onSubmit();
+        tick();
+
+        expect(patchValueSpy).toHaveBeenCalledWith({
+          recipientEmail: 'test@example.com',
+          alternateEmail: null,
+          recipientName: 'ValidName',
+          recipientSurname: null,
+          recipientPhone: '',
+          telegramIsNotify: false
+        });
+      }));
+
+      it('should cover !! operator for telegramIsNotify in patchValue', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+
+        component.recipientName.setValue('ValidName');
+        component.userForm.markAsDirty();
+
+        const mockResponse: UserProfile = {
+          ...userProfileDataMock,
+          telegramIsNotify: 1 as any
+        };
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        const patchValueSpy = spyOn(component.userForm, 'patchValue').and.callThrough();
+
+        component.onSubmit();
+        tick();
+
+        expect(patchValueSpy).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            telegramIsNotify: true
+          })
+        );
+      }));
+
       it('should show savedChangesToUserProfile snackbar on successful submit', fakeAsync(() => {
         component.userInit();
         component.savedTelegramIsNotify = false;
@@ -1605,6 +1947,27 @@ describe('UbsUserProfilePageComponent', () => {
 
         expect(snackBarMock.openSnackBar).toHaveBeenCalledWith('savedChangesToUserProfile');
         expect(snackBarMock.openSnackBar).toHaveBeenCalledTimes(1);
+      }));
+
+      it('should execute error block lines: set isFetching false, isEditing true, and show error snackBar', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+
+        component.recipientName.setValue('ValidName');
+        component.userForm.markAsDirty();
+        component.isFetching = false;
+        component.isEditing = false;
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(throwError(() => new Error('Server error')));
+        snackBarMock.openSnackBar.calls.reset();
+
+        component.onSubmit();
+        tick();
+
+        expect(component.isFetching).toBeFalse();
+        expect(component.isEditing).toBeTrue();
+        expect(snackBarMock.openSnackBar).toHaveBeenCalledWith('error');
       }));
 
       it('should iterate through all form controls and get each control when form is invalid', () => {
@@ -1687,43 +2050,73 @@ describe('UbsUserProfilePageComponent', () => {
         expect(() => component.onSubmit()).not.toThrow();
       });
 
-      it('should use ?? operator to default recipientPhone to empty string', fakeAsync(() => {
+      it('should execute else block with forEach when form is invalid', () => {
         component.userInit();
         component.savedTelegramIsNotify = false;
         component.userForm.get('telegramIsNotify').setValue(false);
-        component.recipientName.setValue('Test');
-        component.userForm.markAsDirty();
 
-        const mockResponse = {
-          ...userProfileDataMock,
-          recipientPhone: undefined as any
-        };
-        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+        component.recipientName.setValue('');
+        component.userForm.get('recipientEmail').setValue('invalid-email');
+        component.recipientSurname.setValue('');
+
+        Object.keys(component.userForm.controls).forEach((key) => {
+          component.userForm.get(key)?.markAsUntouched();
+        });
+
+        const getControlSpy = spyOn(component.userForm, 'get').and.callThrough();
 
         component.onSubmit();
-        tick();
 
-        expect(component.userForm.get('recipientPhone').value).toBe('');
-      }));
+        expect(getControlSpy).toHaveBeenCalled();
 
-      it('should trim recipientPhone before checking if it equals phonePrefix', fakeAsync(() => {
+        const allKeys = Object.keys(component.userForm.controls);
+        expect(getControlSpy.calls.count()).toBeGreaterThanOrEqual(allKeys.length);
+      });
+
+      it('should execute control.markAsTouched() inside forEach for each invalid control', () => {
         component.userInit();
         component.savedTelegramIsNotify = false;
         component.userForm.get('telegramIsNotify').setValue(false);
-        component.recipientName.setValue('Test');
-        component.recipientPhone.setValue('  +380  ');
-        component.recipientPhone.clearValidators();
-        component.recipientPhone.updateValueAndValidity();
-        component.userForm.markAsDirty();
 
-        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+        component.recipientName.setValue('');
+        component.userForm.get('recipientEmail').setValue('invalid');
+
+        component.recipientName.markAsUntouched();
+        component.userForm.get('recipientEmail').markAsUntouched();
+
+        const recipientNameSpy = spyOn(component.recipientName, 'markAsTouched').and.callThrough();
+        const recipientEmailControl = component.userForm.get('recipientEmail');
+        const recipientEmailSpy = spyOn(recipientEmailControl, 'markAsTouched').and.callThrough();
 
         component.onSubmit();
-        tick();
 
-        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
-        expect(submittedData.recipientPhone).toBeUndefined();
-      }));
+        expect(recipientNameSpy).toHaveBeenCalled();
+        expect(recipientEmailSpy).toHaveBeenCalled();
+      });
+
+      it('should handle control?.invalid check in forEach with existing controls', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+
+        component.recipientName.setValue('');
+        component.recipientName.markAsUntouched();
+
+        let controlInvalidCheckExecuted = false;
+        const originalGet = component.userForm.get.bind(component.userForm);
+
+        spyOn(component.userForm, 'get').and.callFake((key: string) => {
+          const control = originalGet(key);
+          if (control) {
+            controlInvalidCheckExecuted = true;
+          }
+          return control;
+        });
+
+        component.onSubmit();
+
+        expect(controlInvalidCheckExecuted).toBeTrue();
+      });
     });
   });
 

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
@@ -2120,6 +2120,954 @@ describe('UbsUserProfilePageComponent', () => {
     });
   });
 
+  describe('onSubmit method - Additional Coverage for Specific Lines', () => {
+    beforeEach(() => {
+      clientProfileServiceMock.postDataClientProfile.calls.reset();
+      snackBarMock.openSnackBar.calls.reset();
+    });
+
+    describe('currentSwitch evaluation with !! operator', () => {
+      it('should correctly evaluate currentSwitch as true when telegramIsNotify is truthy object', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue({ value: true } as any);
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.telegramIsNotify).toBe(true);
+      }));
+
+      it('should correctly evaluate currentSwitch as false when telegramIsNotify is NaN', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.userForm.get('telegramIsNotify').setValue(NaN);
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.telegramIsNotify).toBe(false);
+      }));
+
+      it('should handle optional chaining when telegramIsNotify control is removed', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+        component.userForm.removeControl('telegramIsNotify');
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        expect(() => {
+          component.onSubmit();
+          tick();
+        }).not.toThrow();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.telegramIsNotify).toBe(false);
+      }));
+    });
+
+    describe('phoneValue?.trim() execution', () => {
+      it('should handle recipientPhone with only whitespace characters', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue('\t\n\r  ');
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+
+      it('should handle recipientPhone with tabs and spaces around valid number', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue('\t  +380991234567  \n');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBe('+380991234567');
+      }));
+
+      it('should handle recipientPhone when value is undefined', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue(undefined);
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+
+      it('should handle recipientPhone with mixed whitespace before phonePrefix', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue(' \t +380 \n ');
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+    });
+
+    describe('phoneValue condition: !phoneValue || phoneValue === this.phonePrefix', () => {
+      it('should set phoneValue to null when it is falsy after trim (empty string)', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue('');
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+
+      it('should set phoneValue to null when phoneValue equals phonePrefix exactly', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.phonePrefix = '+380';
+        component.recipientPhone.setValue('+380');
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+
+      it('should NOT set phoneValue to null when phoneValue has more than just phonePrefix', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.phonePrefix = '+380';
+        component.recipientPhone.setValue('+380991234567');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBe('+380991234567');
+      }));
+
+      it('should test both conditions: first !phoneValue (null)', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue(null);
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+
+      it('should test second condition: phoneValue === this.phonePrefix (after first is false)', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.phonePrefix = '+380';
+        component.recipientPhone.setValue('  +380  ');
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+    });
+
+    describe('phoneValue = null assignment', () => {
+      it('should execute phoneValue = null assignment when condition is met (!phoneValue)', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue('   ');
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        let phoneValueBeforeSubmit = component.userForm.value.recipientPhone?.trim();
+        if (!phoneValueBeforeSubmit || phoneValueBeforeSubmit === component.phonePrefix) {
+          phoneValueBeforeSubmit = null;
+        }
+
+        component.onSubmit();
+        tick();
+
+        expect(phoneValueBeforeSubmit).toBeNull();
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+
+      it('should execute phoneValue = null assignment when condition is met (phonePrefix match)', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.phonePrefix = '+380';
+        component.recipientPhone.setValue('+380');
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        let phoneValueBeforeSubmit = component.userForm.value.recipientPhone?.trim();
+        if (!phoneValueBeforeSubmit || phoneValueBeforeSubmit === component.phonePrefix) {
+          phoneValueBeforeSubmit = null;
+        }
+
+        component.onSubmit();
+        tick();
+
+        expect(phoneValueBeforeSubmit).toBeNull();
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+
+      it('should NOT execute phoneValue = null when phone has valid value', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue('+380501234567');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        let phoneValueBeforeSubmit = component.userForm.value.recipientPhone?.trim();
+        if (!phoneValueBeforeSubmit || phoneValueBeforeSubmit === component.phonePrefix) {
+          phoneValueBeforeSubmit = null;
+        }
+
+        component.onSubmit();
+        tick();
+
+        expect(phoneValueBeforeSubmit).not.toBeNull();
+        expect(phoneValueBeforeSubmit).toBe('+380501234567');
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBe('+380501234567');
+      }));
+    });
+
+    describe('Complete path coverage with all branches', () => {
+      it('should cover complete onSubmit path when switchChanged is true and form is valid', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(true);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue('+380991234567');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        expect(clientProfileServiceMock.postDataClientProfile).toHaveBeenCalled();
+        expect(component.isFetching).toBeFalse();
+      }));
+
+      it('should cover onSubmit path when form is invalid and mark controls as touched', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('');
+        component.recipientName.markAsUntouched();
+
+        component.onSubmit();
+
+        expect(component.recipientName.touched).toBeTrue();
+      });
+
+      it('should handle edge case with phoneValue that becomes empty string after trim', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue('     ');
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+    });
+
+    describe('Success callback - savedTelegramIsNotify assignment', () => {
+      it('should assign res.telegramIsNotify to savedTelegramIsNotify when it is true', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, telegramIsNotify: true };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.savedTelegramIsNotify).toBe(true);
+      }));
+
+      it('should assign res.telegramIsNotify to savedTelegramIsNotify when it is false', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, telegramIsNotify: false };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.savedTelegramIsNotify).toBe(false);
+      }));
+
+      it('should assign undefined telegramIsNotify as is', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, telegramIsNotify: undefined as any };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.savedTelegramIsNotify).toBe(undefined);
+      }));
+    });
+
+    describe('Success callback - patchValue execution', () => {
+      it('should execute patchValue with all fields from response', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse: UserProfile = {
+          ...userProfileDataMock,
+          recipientEmail: 'test@example.com',
+          alternateEmail: 'alt@example.com',
+          recipientName: 'TestName',
+          recipientSurname: 'TestSurname',
+          recipientPhone: '+380991234567',
+          telegramIsNotify: true
+        };
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+        const patchValueSpy = spyOn(component.userForm, 'patchValue').and.callThrough();
+
+        component.onSubmit();
+        tick();
+
+        expect(patchValueSpy).toHaveBeenCalledWith({
+          recipientEmail: 'test@example.com',
+          alternateEmail: 'alt@example.com',
+          recipientName: 'TestName',
+          recipientSurname: 'TestSurname',
+          recipientPhone: '+380991234567',
+          telegramIsNotify: true
+        });
+      }));
+
+      it('should patch recipientEmail from response', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, recipientEmail: 'new@email.com' };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('recipientEmail').value).toBe('new@email.com');
+      }));
+
+      it('should patch alternateEmail using ?? operator when value is null', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, alternateEmail: null };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('alternateEmail').value).toBeNull();
+      }));
+
+      it('should patch alternateEmail using ?? operator when value is undefined', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, alternateEmail: undefined };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('alternateEmail').value).toBeNull();
+      }));
+
+      it('should patch alternateEmail with actual value when present', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, alternateEmail: 'alternate@test.com' };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('alternateEmail').value).toBe('alternate@test.com');
+      }));
+
+      it('should patch recipientName from response', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('OldName');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, recipientName: 'NewName' };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('recipientName').value).toBe('NewName');
+      }));
+
+      it('should patch recipientSurname using ?? operator when value is null', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, recipientSurname: null };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('recipientSurname').value).toBeNull();
+      }));
+
+      it('should patch recipientSurname using ?? operator when value is undefined', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, recipientSurname: undefined };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('recipientSurname').value).toBeNull();
+      }));
+
+      it('should patch recipientSurname with actual value when present', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, recipientSurname: 'NewSurname' };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('recipientSurname').value).toBe('NewSurname');
+      }));
+
+      it('should patch recipientPhone using ?? operator to empty string when value is null', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, recipientPhone: null };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('recipientPhone').value).toBe('');
+      }));
+
+      it('should patch recipientPhone using ?? operator to empty string when value is undefined', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, recipientPhone: undefined };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('recipientPhone').value).toBe('');
+      }));
+
+      it('should patch recipientPhone with actual value when present', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, recipientPhone: '+380501112233' };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('recipientPhone').value).toBe('+380501112233');
+      }));
+
+      it('should patch telegramIsNotify using !! operator when value is true', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, telegramIsNotify: true };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('telegramIsNotify').value).toBe(true);
+      }));
+
+      it('should patch telegramIsNotify using !! operator when value is false', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, telegramIsNotify: false };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('telegramIsNotify').value).toBe(false);
+      }));
+
+      it('should patch telegramIsNotify using !! operator to convert truthy value to true', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, telegramIsNotify: 1 as any };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('telegramIsNotify').value).toBe(true);
+      }));
+
+      it('should patch telegramIsNotify using !! operator to convert falsy value to false', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, telegramIsNotify: 0 as any };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('telegramIsNotify').value).toBe(false);
+      }));
+    });
+
+    describe('Success callback - markAsPristine and markAsUntouched', () => {
+      it('should call markAsPristine after successful submit', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+        const markAsPristineSpy = spyOn(component.userForm, 'markAsPristine').and.callThrough();
+
+        component.onSubmit();
+        tick();
+
+        expect(markAsPristineSpy).toHaveBeenCalled();
+        expect(component.userForm.pristine).toBeTrue();
+      }));
+
+      it('should call markAsUntouched after successful submit', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+        component.userForm.markAllAsTouched();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+        const markAsUntouchedSpy = spyOn(component.userForm, 'markAsUntouched').and.callThrough();
+
+        component.onSubmit();
+        tick();
+
+        expect(markAsUntouchedSpy).toHaveBeenCalled();
+        expect(component.userForm.untouched).toBeTrue();
+      }));
+
+      it('should execute both markAsPristine and markAsUntouched in sequence', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+        component.userForm.markAllAsTouched();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.pristine).toBeTrue();
+        expect(component.userForm.untouched).toBeTrue();
+      }));
+    });
+
+    describe('Success callback - snackBar.openSnackBar', () => {
+      it('should call openSnackBar with savedChangesToUserProfile message', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+        snackBarMock.openSnackBar.calls.reset();
+
+        component.onSubmit();
+        tick();
+
+        expect(snackBarMock.openSnackBar).toHaveBeenCalledWith('savedChangesToUserProfile');
+        expect(snackBarMock.openSnackBar).toHaveBeenCalledTimes(1);
+      }));
+    });
+
+    describe('Error callback - complete coverage', () => {
+      it('should execute all lines in error callback', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+        component.isFetching = true;
+        component.isEditing = false;
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(throwError(() => new Error('Server error')));
+        snackBarMock.openSnackBar.calls.reset();
+
+        component.onSubmit();
+        tick();
+
+        expect(component.isFetching).toBe(false);
+        expect(component.isEditing).toBe(true);
+        expect(snackBarMock.openSnackBar).toHaveBeenCalledWith('error');
+      }));
+
+      it('should set isFetching to false in error callback', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+        component.isFetching = true;
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(throwError(() => new Error('Error')));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.isFetching).toBe(false);
+      }));
+
+      it('should set isEditing to true in error callback', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+        component.isEditing = false;
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(throwError(() => new Error('Error')));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.isEditing).toBe(true);
+      }));
+
+      it('should call openSnackBar with error message in error callback', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(throwError(() => new Error('Error')));
+        snackBarMock.openSnackBar.calls.reset();
+
+        component.onSubmit();
+        tick();
+
+        expect(snackBarMock.openSnackBar).toHaveBeenCalledWith('error');
+      }));
+    });
+
+    describe('alternativeEmailDisplay assignment', () => {
+      it('should set alternativeEmailDisplay to false after successful submit', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+        component.alternativeEmailDisplay = true;
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.alternativeEmailDisplay).toBe(false);
+      }));
+
+      it('should set alternativeEmailDisplay to false even if it was already false', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+        component.alternativeEmailDisplay = false;
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.alternativeEmailDisplay).toBe(false);
+      }));
+    });
+
+    describe('else block - Object.keys forEach', () => {
+      it('should execute Object.keys and forEach when form is invalid', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('');
+        component.userForm.get('recipientEmail').setValue('invalid');
+
+        const objectKeysSpy = spyOn(Object, 'keys').and.callThrough();
+
+        component.onSubmit();
+
+        expect(objectKeysSpy).toHaveBeenCalledWith(component.userForm.controls);
+      });
+
+      it('should call get for each control key in forEach', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('');
+
+        const getSpy = spyOn(component.userForm, 'get').and.callThrough();
+
+        component.onSubmit();
+
+        const keys = Object.keys(component.userForm.controls);
+        expect(getSpy.calls.count()).toBeGreaterThanOrEqual(keys.length);
+      });
+
+      it('should get control for each key and check if invalid', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('');
+        component.recipientName.markAsUntouched();
+
+        component.onSubmit();
+
+        const keys = Object.keys(component.userForm.controls);
+        keys.forEach((key) => {
+          const control = component.userForm.get(key);
+          if (control && control.invalid) {
+            expect(control.touched).toBeTrue();
+          }
+        });
+      });
+
+      it('should execute control?.invalid check with optional chaining', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('');
+
+        let optionalChainingExecuted = false;
+        const originalGet = component.userForm.get.bind(component.userForm);
+        spyOn(component.userForm, 'get').and.callFake((key: string) => {
+          const control = originalGet(key);
+          if (control !== null && control !== undefined) {
+            optionalChainingExecuted = true;
+          }
+          return control;
+        });
+
+        component.onSubmit();
+
+        expect(optionalChainingExecuted).toBeTrue();
+      });
+
+      it('should call markAsTouched for invalid control inside if block', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('');
+        component.recipientName.markAsUntouched();
+
+        const markAsTouchedSpy = spyOn(component.recipientName, 'markAsTouched').and.callThrough();
+
+        component.onSubmit();
+
+        expect(markAsTouchedSpy).toHaveBeenCalled();
+      });
+
+      it('should not call markAsTouched for valid controls', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('');
+        component.recipientSurname.setValue('ValidSurname');
+        component.recipientSurname.markAsUntouched();
+
+        const markAsTouchedSpy = spyOn(component.recipientSurname, 'markAsTouched').and.callThrough();
+
+        component.onSubmit();
+
+        expect(markAsTouchedSpy).not.toHaveBeenCalled();
+        expect(component.recipientSurname.touched).toBeFalse();
+      });
+
+      it('should handle multiple invalid controls in forEach', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('');
+        component.userForm.get('recipientEmail').setValue('invalid-email');
+
+        component.recipientName.markAsUntouched();
+        component.userForm.get('recipientEmail').markAsUntouched();
+
+        component.onSubmit();
+
+        expect(component.recipientName.touched).toBeTrue();
+        expect(component.userForm.get('recipientEmail').touched).toBeTrue();
+      });
+    });
+  });
+
   describe('Testing controls for the form:', () => {
     const personalInfoControls = ['recipientName', 'recipientSurname', 'recipientEmail', 'recipientPhone'];
     const controls = ['name', 'surename', 'email', 'phone'];

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
@@ -839,6 +839,28 @@ describe('UbsUserProfilePageComponent', () => {
     expect(component.tempRemovedAddressHolder.length).toBe(0);
   });
 
+  it('should call "goToTelegramUrl" correctly', () => {
+    const windowOpenSpy = spyOn(window, 'open');
+    component.telegramBotURL = 'https://t.me/testbot';
+    component.goToTelegramUrl();
+    expect(windowOpenSpy).toHaveBeenCalledWith('https://t.me/testbot', '_blank');
+  });
+
+  it('should set telegram bot URL in setUrlToBot', () => {
+    component.userProfile = {
+      ...userProfileDataMock,
+      botList: [{ link: 'https://t.me/bot123', type: 'telegram' }]
+    };
+    component.setUrlToBot();
+    expect(component.telegramBotURL).toBe('https://t.me/bot123');
+  });
+
+  it('should handle empty botList in setUrlToBot', () => {
+    component.userProfile = { ...userProfileDataMock, botList: [] };
+    component.setUrlToBot();
+    expect(component.telegramBotURL).toBeUndefined();
+  });
+
   describe('Testing controls for the form:', () => {
     const personalInfoControls = ['recipientName', 'recipientSurname', 'recipientEmail', 'recipientPhone'];
     const controls = ['name', 'surename', 'email', 'phone'];

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
@@ -839,7 +839,7 @@ describe('UbsUserProfilePageComponent', () => {
     expect(component.tempRemovedAddressHolder.length).toBe(0);
   });
 
-  it('should call "goToTelegramUrl" correctly', () => {
+  it('should open telegram bot URL in new window', () => {
     const windowOpenSpy = spyOn(window, 'open');
     component.telegramBotURL = 'https://t.me/testbot';
     component.goToTelegramUrl();

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.spec.ts
@@ -986,6 +986,36 @@ describe('UbsUserProfilePageComponent', () => {
 
       expect(result).toBeFalse();
     });
+
+    it('should handle truthy telegramIsNotify value correctly with !! operator', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = false;
+      component.userForm.get('telegramIsNotify').setValue(1);
+
+      const result = component.isSubmitBtnDisabled();
+
+      expect(result).toBeFalse();
+    });
+
+    it('should handle falsy telegramIsNotify value correctly with !! operator', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = true;
+      component.userForm.get('telegramIsNotify').setValue(0);
+
+      const result = component.isSubmitBtnDisabled();
+
+      expect(result).toBeFalse();
+    });
+
+    it('should handle empty string as falsy with !! operator', () => {
+      component.userInit();
+      component.savedTelegramIsNotify = true;
+      component.userForm.get('telegramIsNotify').setValue('');
+
+      const result = component.isSubmitBtnDisabled();
+
+      expect(result).toBeFalse();
+    });
   });
 
   describe('onSubmit method - phone value handling', () => {
@@ -1407,6 +1437,294 @@ describe('UbsUserProfilePageComponent', () => {
 
       expect(() => component.onSubmit()).not.toThrow();
     });
+
+    describe('onSubmit method - additional coverage', () => {
+      beforeEach(() => {
+        clientProfileServiceMock.postDataClientProfile.calls.reset();
+        snackBarMock.openSnackBar.calls.reset();
+      });
+
+      it('should correctly evaluate currentSwitch with !! operator when telegramIsNotify is true', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(true);
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, telegramIsNotify: true };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.telegramIsNotify).toBe(true);
+      }));
+
+      it('should correctly evaluate currentSwitch with !! operator when telegramIsNotify is false', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = { ...userProfileDataMock, telegramIsNotify: false };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.telegramIsNotify).toBe(false);
+      }));
+
+      it('should trim phoneValue with leading and trailing spaces', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue('  +380991234567  ');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBe('+380991234567');
+      }));
+
+      it('should set phoneValue to null when it is empty after trim', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue('   ');
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+
+      it('should set phoneValue to null when it equals phonePrefix after trim', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue('+380');
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+
+      it('should patch recipientEmail from response', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = {
+          ...userProfileDataMock,
+          recipientEmail: 'newemail@example.com'
+        };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('recipientEmail').value).toBe('newemail@example.com');
+      }));
+
+      it('should patch recipientPhone to empty string when response has null', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = {
+          ...userProfileDataMock,
+          recipientPhone: null
+        };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('recipientPhone').value).toBe('');
+      }));
+
+      it('should patch recipientPhone with actual value when response has phone', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = {
+          ...userProfileDataMock,
+          recipientPhone: '+380501234567'
+        };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('recipientPhone').value).toBe('+380501234567');
+      }));
+
+      it('should show savedChangesToUserProfile snackbar on successful submit', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+        snackBarMock.openSnackBar.calls.reset();
+
+        component.onSubmit();
+        tick();
+
+        expect(snackBarMock.openSnackBar).toHaveBeenCalledWith('savedChangesToUserProfile');
+        expect(snackBarMock.openSnackBar).toHaveBeenCalledTimes(1);
+      }));
+
+      it('should iterate through all form controls and get each control when form is invalid', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+
+        component.recipientName.setValue('');
+        component.userForm.get('recipientEmail').setValue('invalid');
+
+        const getCalls: string[] = [];
+        const originalGet = component.userForm.get.bind(component.userForm);
+        spyOn(component.userForm, 'get').and.callFake((key: string) => {
+          getCalls.push(key);
+          return originalGet(key);
+        });
+
+        component.onSubmit();
+
+        const allKeys = Object.keys(component.userForm.controls);
+        allKeys.forEach((key) => {
+          expect(getCalls).toContain(key);
+        });
+      });
+
+      it('should mark invalid controls as touched in forEach loop', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+
+        component.recipientName.setValue('');
+        component.userForm.get('recipientEmail').setValue('invalid-email');
+
+        component.recipientName.markAsUntouched();
+        component.userForm.get('recipientEmail').markAsUntouched();
+
+        component.onSubmit();
+
+        expect(component.recipientName.touched).toBeTrue();
+        expect(component.userForm.get('recipientEmail').touched).toBeTrue();
+      });
+
+      it('should not mark valid controls as touched in forEach loop', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+
+        component.recipientName.setValue('');
+        component.recipientSurname.setValue('ValidSurname');
+        component.recipientPhone.setValue('+380991234567');
+
+        component.recipientName.markAsUntouched();
+        component.recipientSurname.markAsUntouched();
+        component.recipientPhone.markAsUntouched();
+
+        component.onSubmit();
+
+        expect(component.recipientName.touched).toBeTrue();
+        expect(component.recipientSurname.touched).toBeFalse();
+        expect(component.recipientPhone.touched).toBeFalse();
+      });
+
+      it('should handle control?.invalid check with null control', () => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+
+        component.recipientName.setValue('');
+
+        let callCount = 0;
+        const originalGet = component.userForm.get.bind(component.userForm);
+        spyOn(component.userForm, 'get').and.callFake((key: string) => {
+          callCount++;
+          if (callCount === 2) {
+            return null;
+          }
+          return originalGet(key);
+        });
+
+        expect(() => component.onSubmit()).not.toThrow();
+      });
+
+      it('should use ?? operator to default recipientPhone to empty string', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.userForm.markAsDirty();
+
+        const mockResponse = {
+          ...userProfileDataMock,
+          recipientPhone: undefined as any
+        };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSubmit();
+        tick();
+
+        expect(component.userForm.get('recipientPhone').value).toBe('');
+      }));
+
+      it('should trim recipientPhone before checking if it equals phonePrefix', fakeAsync(() => {
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.userForm.get('telegramIsNotify').setValue(false);
+        component.recipientName.setValue('Test');
+        component.recipientPhone.setValue('  +380  ');
+        component.recipientPhone.clearValidators();
+        component.recipientPhone.updateValueAndValidity();
+        component.userForm.markAsDirty();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(userProfileDataMock));
+
+        component.onSubmit();
+        tick();
+
+        const submittedData = clientProfileServiceMock.postDataClientProfile.calls.mostRecent().args[0];
+        expect(submittedData.recipientPhone).toBeUndefined();
+      }));
+    });
   });
 
   describe('Testing controls for the form:', () => {
@@ -1510,6 +1828,381 @@ describe('UbsUserProfilePageComponent', () => {
 
       expect(component.userProfile.telegramIsNotify).toBeFalse();
       expect(component.userForm.get('telegramIsNotify')?.value).toBeFalse();
+    });
+
+    describe('onSwitchChanged method - saveToServer function coverage', () => {
+      beforeEach(() => {
+        clientProfileServiceMock.postDataClientProfile.calls.reset();
+        snackBarMock.openSnackBar.calls.reset();
+      });
+
+      it('should call postDataClientProfile when turning on notifications in non-editing mode', fakeAsync(() => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+        spyOn(component, 'goToTelegramUrl');
+
+        component.userProfile = {
+          recipientName: 'Test',
+          recipientSurname: 'User',
+          recipientEmail: 'test@example.com',
+          recipientPhone: '+380991234567',
+          alternateEmail: '',
+          addressDto: [],
+          telegramIsNotify: false,
+          hasPassword: true,
+          botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.isEditing = false;
+        component.isFetching = false;
+
+        const mockResponse = { ...component.userProfile, telegramIsNotify: true };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSwitchChanged(true);
+        tick();
+
+        expect(clientProfileServiceMock.postDataClientProfile).toHaveBeenCalled();
+        expect(clientProfileServiceMock.postDataClientProfile).toHaveBeenCalledWith(jasmine.objectContaining({ telegramIsNotify: true }));
+      }));
+
+      it('should use pipe(take(1)) when calling postDataClientProfile', fakeAsync(() => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+        spyOn(component, 'goToTelegramUrl');
+
+        component.userProfile = {
+          recipientName: 'Test',
+          recipientSurname: 'User',
+          recipientEmail: 'test@example.com',
+          recipientPhone: '+380991234567',
+          alternateEmail: '',
+          addressDto: [],
+          telegramIsNotify: false,
+          hasPassword: true,
+          botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.isEditing = false;
+
+        const mockResponse = { ...component.userProfile, telegramIsNotify: true };
+        const observable = of(mockResponse);
+        const pipeSpy = spyOn(observable, 'pipe').and.callThrough();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(observable);
+
+        component.onSwitchChanged(true);
+        tick();
+
+        expect(pipeSpy).toHaveBeenCalled();
+      }));
+
+      it('should update userProfile.telegramIsNotify in next callback', fakeAsync(() => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+        spyOn(component, 'goToTelegramUrl');
+
+        component.userProfile = {
+          recipientName: 'Test',
+          recipientSurname: 'User',
+          recipientEmail: 'test@example.com',
+          recipientPhone: '+380991234567',
+          alternateEmail: '',
+          addressDto: [],
+          telegramIsNotify: false,
+          hasPassword: true,
+          botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.isEditing = false;
+
+        const mockResponse = { ...component.userProfile, telegramIsNotify: true };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSwitchChanged(true);
+        tick();
+
+        expect(component.userProfile.telegramIsNotify).toBe(true);
+      }));
+
+      it('should update savedTelegramIsNotify in next callback', fakeAsync(() => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+        spyOn(component, 'goToTelegramUrl');
+
+        component.userProfile = {
+          recipientName: 'Test',
+          recipientSurname: 'User',
+          recipientEmail: 'test@example.com',
+          recipientPhone: '+380991234567',
+          alternateEmail: '',
+          addressDto: [],
+          telegramIsNotify: false,
+          hasPassword: true,
+          botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.isEditing = false;
+
+        const mockResponse = { ...component.userProfile, telegramIsNotify: true };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSwitchChanged(true);
+        tick();
+
+        expect(component.savedTelegramIsNotify).toBe(true);
+      }));
+
+      it('should restore isFetching state after successful save', fakeAsync(() => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+        spyOn(component, 'goToTelegramUrl');
+
+        component.userProfile = {
+          recipientName: 'Test',
+          recipientSurname: 'User',
+          recipientEmail: 'test@example.com',
+          recipientPhone: '+380991234567',
+          alternateEmail: '',
+          addressDto: [],
+          telegramIsNotify: false,
+          hasPassword: true,
+          botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.isEditing = false;
+        component.isFetching = false;
+
+        const mockResponse = { ...component.userProfile, telegramIsNotify: true };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSwitchChanged(true);
+        tick();
+
+        expect(component.isFetching).toBe(false);
+      }));
+
+      it('should handle error in postDataClientProfile and revert switch value', fakeAsync(() => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+        spyOn(component, 'goToTelegramUrl');
+
+        component.userProfile = {
+          recipientName: 'Test',
+          recipientSurname: 'User',
+          recipientEmail: 'test@example.com',
+          recipientPhone: '+380991234567',
+          alternateEmail: '',
+          addressDto: [],
+          telegramIsNotify: false,
+          hasPassword: true,
+          botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.isEditing = false;
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(throwError(() => new Error('Server error')));
+
+        component.onSwitchChanged(true);
+        tick();
+
+        expect(component.userForm.get('telegramIsNotify')?.value).toBe(false);
+      }));
+
+      it('should revert userProfile.telegramIsNotify on error', fakeAsync(() => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+        spyOn(component, 'goToTelegramUrl');
+
+        component.userProfile = {
+          recipientName: 'Test',
+          recipientSurname: 'User',
+          recipientEmail: 'test@example.com',
+          recipientPhone: '+380991234567',
+          alternateEmail: '',
+          addressDto: [],
+          telegramIsNotify: false,
+          hasPassword: true,
+          botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.isEditing = false;
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(throwError(() => new Error('Server error')));
+
+        component.onSwitchChanged(true);
+        tick();
+
+        expect(component.userProfile.telegramIsNotify).toBe(false);
+      }));
+
+      it('should restore isFetching state on error', fakeAsync(() => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+        spyOn(component, 'goToTelegramUrl');
+
+        component.userProfile = {
+          recipientName: 'Test',
+          recipientSurname: 'User',
+          recipientEmail: 'test@example.com',
+          recipientPhone: '+380991234567',
+          alternateEmail: '',
+          addressDto: [],
+          telegramIsNotify: false,
+          hasPassword: true,
+          botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.isEditing = false;
+        component.isFetching = false;
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(throwError(() => new Error('Server error')));
+
+        component.onSwitchChanged(true);
+        tick();
+
+        expect(component.isFetching).toBe(false);
+      }));
+
+      it('should show error snackbar on postDataClientProfile error', fakeAsync(() => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+        spyOn(component, 'goToTelegramUrl');
+
+        component.userProfile = {
+          recipientName: 'Test',
+          recipientSurname: 'User',
+          recipientEmail: 'test@example.com',
+          recipientPhone: '+380991234567',
+          alternateEmail: '',
+          addressDto: [],
+          telegramIsNotify: false,
+          hasPassword: true,
+          botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.isEditing = false;
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(throwError(() => new Error('Server error')));
+        snackBarMock.openSnackBar.calls.reset();
+
+        component.onSwitchChanged(true);
+        tick();
+
+        expect(snackBarMock.openSnackBar).toHaveBeenCalledWith('error');
+      }));
+
+      it('should call saveToServer with false when turning off notifications in non-editing mode', fakeAsync(() => {
+        component.userProfile = {
+          recipientName: 'Test',
+          recipientSurname: 'User',
+          recipientEmail: 'test@example.com',
+          recipientPhone: '+380991234567',
+          alternateEmail: '',
+          addressDto: [],
+          telegramIsNotify: true,
+          hasPassword: true,
+          botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = true;
+        component.isEditing = false;
+
+        const mockResponse = { ...component.userProfile, telegramIsNotify: false };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSwitchChanged(false);
+        tick();
+
+        expect(clientProfileServiceMock.postDataClientProfile).toHaveBeenCalledWith(jasmine.objectContaining({ telegramIsNotify: false }));
+        expect(component.userProfile.telegramIsNotify).toBe(false);
+        expect(component.savedTelegramIsNotify).toBe(false);
+      }));
+
+      it('should set emitEvent to false when reverting switch on error', fakeAsync(() => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+        spyOn(component, 'goToTelegramUrl');
+
+        component.userProfile = {
+          recipientName: 'Test',
+          recipientSurname: 'User',
+          recipientEmail: 'test@example.com',
+          recipientPhone: '+380991234567',
+          alternateEmail: '',
+          addressDto: [],
+          telegramIsNotify: false,
+          hasPassword: true,
+          botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.isEditing = false;
+
+        const control = component.userForm.get('telegramIsNotify');
+        const setValueSpy = spyOn(control, 'setValue').and.callThrough();
+
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(throwError(() => new Error('Server error')));
+
+        component.onSwitchChanged(true);
+        tick();
+
+        expect(setValueSpy).toHaveBeenCalledWith(false, { emitEvent: false });
+      }));
+
+      it('should preserve isFetching state through saveToServer execution', fakeAsync(() => {
+        const dialogRefSpyObj = jasmine.createSpyObj({ afterClosed: of(true) });
+        spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj as any);
+        spyOn(component, 'goToTelegramUrl');
+
+        component.userProfile = {
+          recipientName: 'Test',
+          recipientSurname: 'User',
+          recipientEmail: 'test@example.com',
+          recipientPhone: '+380991234567',
+          alternateEmail: '',
+          addressDto: [],
+          telegramIsNotify: false,
+          hasPassword: true,
+          botList: [{ link: 'https://t.me/testbot', type: 'telegram' }]
+        };
+
+        component.userInit();
+        component.savedTelegramIsNotify = false;
+        component.isEditing = false;
+        component.isFetching = true;
+
+        const mockResponse = { ...component.userProfile, telegramIsNotify: true };
+        clientProfileServiceMock.postDataClientProfile.and.returnValue(of(mockResponse));
+
+        component.onSwitchChanged(true);
+
+        expect(component.isFetching).toBe(true);
+
+        tick();
+
+        expect(component.isFetching).toBe(true);
+      }));
     });
   });
 

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.ts
@@ -220,20 +220,17 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
     this.userProfile.telegramIsNotify = this.savedTelegramIsNotify;
     this.tempAddedAddressHolder.length = 0;
     this.tempRemovedAddressHolder.length = 0;
-    this.clientProfileService
-      .getDataClientProfile()
-      .pipe(take(1))
-      .subscribe({
-        next: (res: UserProfile) => {
-          this.userProfile.telegramIsNotify = res.telegramIsNotify;
-          this.userInit();
-          this.isEditing = false;
-        },
-        error: () => {
-          this.userInit();
-          this.isEditing = false;
-        }
-      });
+    this.clientProfileService.getDataClientProfile().subscribe({
+      next: (res: UserProfile) => {
+        this.userProfile.telegramIsNotify = res.telegramIsNotify;
+        this.userInit();
+        this.isEditing = false;
+      },
+      error: () => {
+        this.userInit();
+        this.isEditing = false;
+      }
+    });
   }
 
   onSubmit(): void {

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.ts
@@ -187,7 +187,7 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
     }
 
     const formSwitch = !!this.userForm.get('telegramIsNotify')?.value;
-    const serverSwitch = !!this.savedTelegramIsNotify;
+    const serverSwitch = this.savedTelegramIsNotify;
 
     if (formSwitch !== serverSwitch) {
       return false;
@@ -537,7 +537,7 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
             this.userForm.get('telegramIsNotify')?.setValue(true, { emitEvent: false });
 
             if (this.isEditing) {
-              if (this.savedTelegramIsNotify !== true) {
+              if (!this.savedTelegramIsNotify) {
                 this.userForm.markAsDirty();
               }
             } else {

--- a/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.ts
+++ b/src/app/ubs/ubs-user/components/ubs-user-profile-page/ubs-user-profile-page.component.ts
@@ -53,6 +53,7 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
   tempAddedAddressHolder: AddressData[] = [];
   tempRemovedAddressHolder: Address[] = [];
   savedUserAddresses: Address[];
+  savedTelegramIsNotify: boolean;
 
   private destroy: Subject<boolean> = new Subject<boolean>();
 
@@ -104,12 +105,7 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.userEmail = this.jwtService.getEmailFromAccessToken();
     this.getUserData();
-
     this.store.dispatch(GetAddresses());
-
-    this.store.pipe(select(addressesSelector)).subscribe((addresses) => {
-      this.getUserData();
-    });
   }
 
   getUserData(): void {
@@ -121,6 +117,7 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
         next: (res: UserProfile) => {
           this.userProfile = res;
           this.savedUserAddresses = [...res.addressDto];
+          this.savedTelegramIsNotify = res.telegramIsNotify;
           this.userInit();
           this.setUrlToBot();
           this.isFetching = false;
@@ -184,7 +181,18 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
     this.userForm.get('alternateEmail').setValue(null);
   }
 
-  isSubmitBtnDisabled() {
+  isSubmitBtnDisabled(): boolean {
+    if (!this.userForm) {
+      return true;
+    }
+
+    const formSwitch = !!this.userForm.get('telegramIsNotify')?.value;
+    const serverSwitch = !!this.savedTelegramIsNotify;
+
+    if (formSwitch !== serverSwitch) {
+      return false;
+    }
+
     return this.userForm.invalid || this.userForm.pristine;
   }
 
@@ -209,29 +217,58 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
 
   onCancel(): void {
     this.userProfile.addressDto = [...this.savedUserAddresses];
+    this.userProfile.telegramIsNotify = this.savedTelegramIsNotify;
     this.tempAddedAddressHolder.length = 0;
     this.tempRemovedAddressHolder.length = 0;
-    this.userInit();
-    this.isEditing = false;
+    this.clientProfileService
+      .getDataClientProfile()
+      .pipe(take(1))
+      .subscribe({
+        next: (res: UserProfile) => {
+          this.userProfile.telegramIsNotify = res.telegramIsNotify;
+          this.userInit();
+          this.isEditing = false;
+        },
+        error: () => {
+          this.userInit();
+          this.isEditing = false;
+        }
+      });
   }
 
   onSubmit(): void {
-    if (this.userForm.valid) {
+    const currentSwitch = !!this.userForm.get('telegramIsNotify')?.value;
+    const savedSwitch = !!this.savedTelegramIsNotify;
+    const switchChanged = currentSwitch !== savedSwitch;
+
+    if (switchChanged || (this.userForm.valid && this.userForm.dirty)) {
       this.isFetching = true;
       this.isEditing = false;
+
+      let phoneValue = this.userForm.value.recipientPhone?.trim();
+      if (!phoneValue || phoneValue === this.phonePrefix) {
+        phoneValue = null;
+      }
+
       const submitData: UserProfile = {
         addressDto: [],
-        recipientEmail: this.userForm.value.recipientEmail,
-        alternateEmail: this.userForm.value.alternateEmail,
-        recipientName: this.userForm.value.recipientName,
-        recipientPhone: this.userForm.value.recipientPhone,
-        recipientSurname: this.userForm.value.recipientSurname,
-        telegramIsNotify: this.userProfile.telegramIsNotify,
+        recipientEmail: this.userForm.value.recipientEmail?.trim(),
+        alternateEmail: this.userForm.value.alternateEmail?.trim() || null,
+        recipientName: this.userForm.value.recipientName?.trim(),
+        recipientPhone: phoneValue,
+        recipientSurname: this.userForm.value.recipientSurname?.trim() || null,
+        telegramIsNotify: currentSwitch,
         hasPassword: this.userProfile.hasPassword
       };
 
-      if (!submitData.alternateEmail?.length) {
+      if (!submitData.alternateEmail) {
         delete submitData.alternateEmail;
+      }
+      if (!submitData.recipientPhone) {
+        delete submitData.recipientPhone;
+      }
+      if (!submitData.recipientSurname) {
+        delete submitData.recipientSurname;
       }
 
       this.userProfile.addressDto.forEach((address, i) => {
@@ -279,19 +316,37 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
             if (res.addressDto) {
               this.savedUserAddresses = [...res.addressDto];
             }
-            this.userProfile.recipientEmail = this.userForm.value.recipientEmail;
-            this.userProfile.alternateEmail = this.userForm.value.alternateEmail;
+
+            this.savedTelegramIsNotify = res.telegramIsNotify;
+
+            this.userForm.patchValue({
+              recipientEmail: res.recipientEmail,
+              alternateEmail: res.alternateEmail ?? null,
+              recipientName: res.recipientName,
+              recipientSurname: res.recipientSurname ?? null,
+              recipientPhone: res.recipientPhone ?? '',
+              telegramIsNotify: !!res.telegramIsNotify
+            });
+
+            this.userForm.markAsPristine();
+            this.userForm.markAsUntouched();
+            this.snackBar.openSnackBar('savedChangesToUserProfile');
           },
-          error: (err: Error) => {
+          error: () => {
             this.isFetching = false;
+            this.isEditing = true;
             this.snackBar.openSnackBar('error');
           }
         });
       this.alternativeEmailDisplay = false;
     } else {
-      this.isEditing = true;
+      Object.keys(this.userForm.controls).forEach((key) => {
+        const control = this.userForm.get(key);
+        if (control?.invalid) {
+          control.markAsTouched();
+        }
+      });
     }
-    this.snackBar.openSnackBar('savedChangesToUserProfile');
   }
 
   saveAddedAddresses() {
@@ -442,32 +497,72 @@ export class UbsUserProfilePageComponent implements OnInit, OnDestroy {
     this.alternativeEmailDisplay ? this.userForm.addControl('alternateEmail', control) : this.userForm.removeControl('alternateEmail');
   }
 
-  onSwitchChanged(): void {
-    const currentValue = this.userProfile.telegramIsNotify;
-    const newValue = !currentValue;
+  onSwitchChanged(newValue: boolean): void {
+    const saveToServer = (status: boolean) => {
+      const wasFetching = this.isFetching;
+      this.isFetching = true;
+
+      const submitData: UserProfile = {
+        ...this.userProfile,
+        telegramIsNotify: status
+      };
+
+      this.clientProfileService
+        .postDataClientProfile(submitData)
+        .pipe(take(1))
+        .subscribe({
+          next: (res: UserProfile) => {
+            this.userProfile.telegramIsNotify = res.telegramIsNotify;
+            this.savedTelegramIsNotify = res.telegramIsNotify;
+            this.isFetching = wasFetching;
+          },
+          error: () => {
+            this.userForm.get('telegramIsNotify')?.setValue(!status, { emitEvent: false });
+            this.userProfile.telegramIsNotify = !status;
+            this.isFetching = wasFetching;
+            this.snackBar.openSnackBar('error');
+          }
+        });
+    };
 
     if (newValue) {
       const matDialogRef = this.dialog.open(ConfirmationDialogComponent, {
         data: this.dataTelegramSubscription,
         hasBackdrop: true
       });
+
       matDialogRef
         .afterClosed()
         .pipe(take(1))
         .subscribe((confirmed) => {
           if (confirmed) {
             this.userProfile.telegramIsNotify = true;
-            this.userForm.markAsDirty();
-            this.userForm.get('telegramIsNotify')?.setValue(true);
+            this.userForm.get('telegramIsNotify')?.setValue(true, { emitEvent: false });
+
+            if (this.isEditing) {
+              if (this.savedTelegramIsNotify !== true) {
+                this.userForm.markAsDirty();
+              }
+            } else {
+              saveToServer(true);
+            }
+
             this.goToTelegramUrl();
           } else {
-            this.userForm.get('telegramIsNotify')?.setValue(false);
+            this.userForm.get('telegramIsNotify')?.setValue(this.userProfile.telegramIsNotify, { emitEvent: false });
           }
         });
     } else {
       this.userProfile.telegramIsNotify = false;
-      this.userForm.markAsDirty();
-      this.userForm.get('telegramIsNotify')?.setValue(false);
+      this.userForm.get('telegramIsNotify')?.setValue(false, { emitEvent: false });
+
+      if (this.isEditing) {
+        if (this.savedTelegramIsNotify !== false) {
+          this.userForm.markAsDirty();
+        }
+      } else {
+        saveToServer(false);
+      }
     }
   }
 


### PR DESCRIPTION
Changed the logic of the switcher
Added the logic of comparing the switcher status with the saved status
Added tests
Fixed the 404 error
Added the selection confirmation window
Edited the page logic for the correct operation of the notification subscription functionality
Edited the logic of the Save changes button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telegram notification switch now uses event-driven toggles with optimistic save, rollback on error, and persisted saved-state syncing. Confirmation flow added for navigating away when changing this setting.

* **Bug Fixes**
  * Save/Cancel buttons no longer submit forms; Cancel restores server state. Submit enabling tightened; form dirty/pristine handling, phone/email normalization, and post-save UI/state sync improved.

* **Tests**
  * Expanded coverage for switch behavior, telegram flows, bot URL handling, submission/cancellation, and numerous edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->